### PR TITLE
[Issue #6] Publish website to GitHub pages

### DIFF
--- a/.github/workflows/cd-website.yml
+++ b/.github/workflows/cd-website.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  # Trigger the workflow every time we push to the `main` branch
+  # if it includes changes to the website/ directory
+  push:
+    branches: [main]
+    paths:
+      - "website/**"
+  # Allows us to run this workflow manually from the Actions tab on GitHub.
+  workflow_dispatch:
+
+# Allow this job to clone the repo and create a page deployment
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+      - name: Install, build, and upload your site
+        uses: withastro/action@v3
+        with:
+          path: ./website # Path to the root of our Astro project
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -4,6 +4,8 @@ import starlight from "@astrojs/starlight";
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://hhs.github.io",
+  base: "simpler-grants-protocol",
   integrations: [
     starlight({
       title: "Simpler Grant Protocol",

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Integrating data across the grants ecosystem.
   actions:
     - text: Example Guide
-      link: /guides/example/
+      link: guides/example/
       icon: right-arrow
     - text: Visit our GitHub repo
       link: https://github.com/HHS/simpler-grants-protocol


### PR DESCRIPTION
### Summary

Set up a CD pipeline to deploy the website to GitHub pages each time changes to the `website/` sub-directory are pushed to main.

- Fixes #6 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Updated `website/astro.config.mjs` to work with GitHub pages
- Adds `.github/workflows/cd-website.yml` to set up automatic deploys

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Checkout the PR
2. Run `npm run dev`
3. Go to http://localhost:4321/simpler-grants-protocol/ **Note:** the trailing `/` is important because it enables relative links to work correctly

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
