### PR TITLE
[Issue #50]: Publish spec to npm via GitHub action

### DIFF
--- a/.github/workflows/cd-specs-npm.yml
+++ b/.github/workflows/cd-specs-npm.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run checks
         run: npm run checks
 
-      - name: Dry run publish
+      - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --tag alpha --access public

--- a/.github/workflows/cd-specs-npm.yml
+++ b/.github/workflows/cd-specs-npm.yml
@@ -1,7 +1,7 @@
-name: CI - Publish @common-grants/core (dry run)
+name: CD - Publish @common-grants/core
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
@@ -23,7 +23,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run checks
+        run: npm run checks
+
       - name: Dry run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --tag alpha --access public --dry-run
+        run: npm publish --tag alpha --access public

--- a/.github/workflows/cd-specs-npm.yml
+++ b/.github/workflows/cd-specs-npm.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Run checks
         run: npm run checks
 

--- a/.github/workflows/cd-specs-npm.yml
+++ b/.github/workflows/cd-specs-npm.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "specs/**" # Trigger only if files in the `specs/` directory are changed
-      - ".github/workflows/ci-specs-npm.yml"
+      - ".github/workflows/cd-specs-npm.yml"
 
 defaults:
   run:

--- a/.github/workflows/ci-specs-npm.yml
+++ b/.github/workflows/ci-specs-npm.yml
@@ -23,6 +23,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+
       - name: Dry run publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci-specs-npm.yml
+++ b/.github/workflows/ci-specs-npm.yml
@@ -1,0 +1,28 @@
+name: CI - Publish @common-grants/core (dry run)
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "specs/**" # Trigger only if files in the `specs/` directory are changed
+
+defaults:
+  run:
+    working-directory: ./specs
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Dry run publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --dry-run

--- a/.github/workflows/ci-specs-npm.yml
+++ b/.github/workflows/ci-specs-npm.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "specs/**" # Trigger only if files in the `specs/` directory are changed
+      - ".github/workflows/ci-specs-npm.yml"
 
 defaults:
   run:

--- a/specs/README.md
+++ b/specs/README.md
@@ -26,7 +26,6 @@ A basic project structure that uses the library might look like this:
 └── tspconfig.yaml  # Manages TypeSpec configuration, including emitters
 ```
 
-
 ### Define a custom field
 
 Define custom fields on an existing model by extending the `CustomField` model from the `@common-grants/core` library.
@@ -131,7 +130,6 @@ Both strategies will generate an OpenAPI specification in the `tsp-output/` dire
 
 - See the [TypeSpec documentation](https://typespec.org/docs/getting-started/overview) for more information on how to use TypeSpec.
 - See the [CommonGrants docs](https://hhs.github.io/simpler-grants-protocol/) to learn more about the CommonGrants protocol.
-
 
 ## 💻 Contributing to the library
 

--- a/specs/package-lock.json
+++ b/specs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@common-grants/core",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@common-grants/core",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0-alpha.5",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "^20.10.6",

--- a/specs/package.json
+++ b/specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@common-grants/core",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0-alpha.5",
   "description": "TypeSpec library for defining grant opportunity data models and APIs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/specs/package.json
+++ b/specs/package.json
@@ -30,7 +30,8 @@
     "lint": "eslint . --fix",
     "format": "prettier --write . && tsp format lib",
     "check:lint": "eslint",
-    "check:format": "prettier --check . && tsp format lib --check"
+    "check:format": "prettier --check . && tsp format lib --check",
+    "checks": "npm run check:lint && npm run check:format"
   },
   "keywords": [
     "typespec",


### PR DESCRIPTION
### Summary

Creates a GitHub action to publish the `@common-grants/core` package to NPM via GitHub actions.

- Fixes #50
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds GitHub actions to publish the package to npm
- Updates the package README

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Here's the [dry run of the publish](https://github.com/HHS/simpler-grants-protocol/actions/runs/12958709407/job/36149626793?pr=52).

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1403" alt="Screenshot 2025-01-24 at 5 33 30 PM" src="https://github.com/user-attachments/assets/ee0bf5d0-a22e-4d44-a7d7-2b396fea9a54" />
