### PR TITLE
[Issue #63] TypeSpec templates

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,23 @@
+# CommonGrants TypeSpec Templates
+
+This directory contains templates defining CommonGrants-compatible APIs using TypeSpec.
+
+## Usage
+
+To initialize a new TypeSpec project with a CommonGrants template, run the following command:
+
+```bash
+tsp init https://raw.githubusercontent.com/HHS/simpler-grants-protocol/refs/heads/main/templates/template.json
+```
+
+This will walk you through a series of prompts to initialize the your project.
+
+> [!NOTE]
+> We're working to simplify the init process using the [CommonGrants CLI](../cli).
+
+## Templates
+
+| Template Name | Description                                                                      |
+| ------------- | -------------------------------------------------------------------------------- |
+| Default API   | Define a CommonGrants API spec with default routes from the CommonGrants library |
+| Custom API    | Extend the default CommonGrants API spec with custom fields and routes           |

--- a/templates/custom-api/main.tsp
+++ b/templates/custom-api/main.tsp
@@ -1,0 +1,12 @@
+// main.tsp
+
+import "@typespec/http";
+import "./routes.tsp";
+
+using TypeSpec.Http;
+
+/** API description here */
+@service({
+  title: "{{parameters.apiName}}",
+})
+namespace {{parameters.namespace}};

--- a/templates/custom-api/models.tsp
+++ b/templates/custom-api/models.tsp
@@ -1,0 +1,27 @@
+// models.tsp
+
+import "@common-grants/core";
+
+// Allows us to use models defined in the specification library
+// without prefixing each model with `CommonGrants.Models.`
+using CommonGrants.Models;
+
+@TypeSpec.JsonSchema.jsonSchema
+namespace {{parameters.namespace}}.Models;
+
+// Define a custom field
+model {{parameters.fieldNamePascal}} extends CustomField {
+  name: "{{parameters.fieldNameDisplay}}";
+  type: CustomFieldType.{{parameters.fieldTypeJSON}};
+  value: {{parameters.fieldTypeTSP}};
+  description: "{{parameters.fieldDescription}}";
+}
+
+// Create a custom Opportunity type using the template
+model CustomOpportunity extends Opportunity.OpportunityBase {
+
+  // Add an example of the new customFields object using `@example()`
+  customFields: {
+    {{parameters.fieldNamePascal}}: {{parameters.fieldNamePascal}};
+  };
+}

--- a/templates/custom-api/routes.tsp
+++ b/templates/custom-api/routes.tsp
@@ -1,0 +1,19 @@
+// routes.tsp
+
+import "@common-grants/core";
+import "./models.tsp";
+
+// Allows us to use models defined in the specification library
+// without prefixing each model with `CommonGrants.Routes.`
+using CommonGrants.Routes;
+using TypeSpec.Http;
+
+@tag("Search")
+@route("/opportunities")
+namespace {{parameters.namespace}}.Routes {
+  alias OpportunitiesRouter = Opportunities;
+
+  // Use the default model for list but custom model for read
+  op list is OpportunitiesRouter.list<Models.CustomOpportunity>;
+  op read is OpportunitiesRouter.read<Models.CustomOpportunity>;
+}

--- a/templates/custom-api/tspconfig.yaml
+++ b/templates/custom-api/tspconfig.yaml
@@ -1,0 +1,3 @@
+emit:
+  - "@typespec/openapi3"
+  - "@typespec/json-schema"

--- a/templates/default-api/main.tsp
+++ b/templates/default-api/main.tsp
@@ -1,0 +1,22 @@
+// main.tsp
+
+import "@typespec/http";
+import "@common-grants/core";
+
+using TypeSpec.Http;
+
+@service({
+  title: "{{parameters.apiName}}",
+})
+namespace {{parameters.namespace}};
+
+
+@tag("Opportunities")
+@route("/opportunities")
+namespace Routes {
+  alias OpportunitiesRouter = CommonGrants.Routes.Opportunities;
+
+  // Use the default model for list but custom model for read
+  op list is OpportunitiesRouter.list;
+  op read is OpportunitiesRouter.read;
+}

--- a/templates/default-api/tspconfig.yaml
+++ b/templates/default-api/tspconfig.yaml
@@ -1,0 +1,3 @@
+emit:
+  - "@typespec/openapi3"
+  - "@typespec/json-schema"

--- a/templates/template.json
+++ b/templates/template.json
@@ -1,7 +1,7 @@
 {
   "default-api": {
-    "title": "CommonGrants API spec",
-    "description": "Define a Custom API spec with default routes from the CommonGrants library",
+    "title": "Default CommonGrants API",
+    "description": "Define an API spec with default routes from the CommonGrants library",
     "compilerVersion": "0.63.0",
     "libraries": ["@common-grants/core"],
     "config": {},
@@ -24,8 +24,8 @@
     }
   },
   "custom-api": {
-    "title": "CommonGrants API spec with custom fields",
-    "description": "Define a CommonGrants API spec with custom fields",
+    "title": "Custom CommonGrants API",
+    "description": "Extend the default CommonGrants API spec with custom fields and routes",
     "compilerVersion": "0.63.0",
     "libraries": ["@common-grants/core"],
     "config": {},

--- a/templates/template.json
+++ b/templates/template.json
@@ -1,0 +1,81 @@
+{
+  "default-api": {
+    "title": "CommonGrants API spec",
+    "description": "Define a Custom API spec with default routes from the CommonGrants library",
+    "compilerVersion": "0.63.0",
+    "libraries": ["@common-grants/core"],
+    "config": {},
+    "files": [
+      {
+        "path": "./default-api/tspconfig.yaml",
+        "destination": "tspconfig.yaml"
+      },
+      { "path": "./default-api/main.tsp", "destination": "main.tsp" }
+    ],
+    "inputs": {
+      "apiName": {
+        "type": "text",
+        "description": "Name of the API"
+      },
+      "namespace": {
+        "type": "text",
+        "description": "Namespace for the API in PascalCase"
+      }
+    }
+  },
+  "custom-api": {
+    "title": "CommonGrants API spec with custom fields",
+    "description": "Define a CommonGrants API spec with custom fields",
+    "compilerVersion": "0.63.0",
+    "libraries": ["@common-grants/core"],
+    "config": {},
+    "files": [
+      {
+        "path": "./custom-api/tspconfig.yaml",
+        "destination": "tspconfig.yaml"
+      },
+      {
+        "path": "./custom-api/main.tsp",
+        "destination": "main.tsp"
+      },
+      {
+        "path": "./custom-api/routes.tsp",
+        "destination": "routes.tsp"
+      },
+      {
+        "path": "./custom-api/models.tsp",
+        "destination": "models.tsp"
+      }
+    ],
+    "inputs": {
+      "apiName": {
+        "type": "text",
+        "description": "Name of the API"
+      },
+      "namespace": {
+        "type": "text",
+        "description": "Namespace for the API in PascalCase"
+      },
+      "fieldNameDisplay": {
+        "type": "text",
+        "description": "Human readable display name for the custom field"
+      },
+      "fieldNamePascal": {
+        "type": "text",
+        "description": "Name of the custom field in PascalCase"
+      },
+      "fieldTypeJSON": {
+        "type": "text",
+        "description": "Type of the custom field in JSON (e.g. string, number, boolean, object, array)"
+      },
+      "fieldTypeTSP": {
+        "type": "text",
+        "description": "Type of the custom field in TypeSpec"
+      },
+      "fieldDescription": {
+        "type": "text",
+        "description": "Description of the custom field"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Adds a series of TypeSpec templates that we can use for the `cg init` function.

- Supports #63 
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

Creates a `templates/` directory with scaffolding for the following templates:
- Default CommonGrants API
- CommonGrants API with custom fields

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. With `@typespec/compiler` installed globally, open a new directory and run the following command:
    ```
    tsp init https://raw.githubusercontent.com/HHS/simpler-grants-protocol/9c829a2afe9a8a561d42967e8089656cb2459844/templates/template.json
    ```
2. Follow the prompts to set up your project
3. After the `init` wizard finishes, run `tsp install` then `tsp compile .` 

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1155" alt="Screenshot 2025-02-07 at 10 49 43 AM" src="https://github.com/user-attachments/assets/826200f1-83c3-4960-b8bf-1d1d263dec23" />
