### PR TITLE
[Issue 87] Bump `@common-grants/core` prerelease version

### DIFF
--- a/.github/workflows/ci-specs-npm.yml
+++ b/.github/workflows/ci-specs-npm.yml
@@ -23,6 +23,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Checks that the version is not already published and
+      # that there are no uncommitted changes
+      - name: Run prepublish checks
+        run: npm run prepublishOnly
+
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:

--- a/specs/README.md
+++ b/specs/README.md
@@ -76,13 +76,14 @@ using CommonGrants.Routes;
 using TypeSpec.Http;
 
 @tag("Search")
-@route("/opportunities")
+@route("/common-grants/opportunities")
 namespace CustomAPI.CustomRoutes {
   alias OpportunitiesRouter = Opportunities;
 
-  // Use the default model for list but custom model for read
+  // Use the default model for list but custom model for read and search
   op list is OpportunitiesRouter.list;
   op read is OpportunitiesRouter.read<CustomModels.CustomOpportunity>;
+  op search is OpportunitiesRouter.search<CustomModels.CustomOpportunity>;
 }
 ```
 

--- a/specs/package-lock.json
+++ b/specs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@common-grants/core",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@common-grants/core",
-      "version": "0.1.0-alpha.9",
+      "version": "0.1.0-alpha.10",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "^20.10.6",

--- a/specs/package.json
+++ b/specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@common-grants/core",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
   "description": "TypeSpec library for defining grant opportunity data models and APIs",
   "type": "module",
   "main": "dist/src/index.js",

--- a/specs/package.json
+++ b/specs/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/HHS/simpler-grants-protocol/tree/main/specs#readme",
   "scripts": {
+    "prepublishOnly": "bash scripts/prepublish-checks.sh",
     "clean": "rimraf dist tsp-output",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",

--- a/specs/scripts/prepublish-checks.sh
+++ b/specs/scripts/prepublish-checks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e  # Exit on error
+
+PACKAGE_VERSION=$(node -p "require('./package.json').version")
+PUBLISHED_VERSION=$(npm info . version || echo "0.0.0")
+
+if [ "$PACKAGE_VERSION" == "$PUBLISHED_VERSION" ]; then
+  echo "❌ Version $PACKAGE_VERSION is already published. Please bump the version."
+  exit 1
+fi
+
+if ! git diff --quiet; then
+  echo "❌ Uncommitted changes detected. Please commit before publishing."
+  exit 1
+fi
+
+echo "✅ Prepublish checks passed!"

--- a/templates/custom-api/routes.tsp
+++ b/templates/custom-api/routes.tsp
@@ -7,11 +7,12 @@ using CommonGrants.Routes;
 using TypeSpec.Http;
 
 @tag("Opportunities")
-@route("/opportunities")
+@route("/common-grants/opportunities")
 namespace Custom.Routes {
   alias OpportunitiesRouter = Opportunities;
 
   // Use custom model for list and read
   op list is OpportunitiesRouter.list<Models.CustomOpportunity>;
   op read is OpportunitiesRouter.read<Models.CustomOpportunity>;
+  op search is OpportunitiesRouter.search<Models.CustomOpportunity>;
 }

--- a/templates/default-api/main.tsp
+++ b/templates/default-api/main.tsp
@@ -9,11 +9,12 @@ using TypeSpec.Http;
 namespace Default;
 
 @tag("Opportunities")
-@route("/opportunities")
+@route("/common-grants/opportunities")
 namespace Routes {
   alias OpportunitiesRouter = CommonGrants.Routes.Opportunities;
 
   // Use the default model for list but custom model for read
   op list is OpportunitiesRouter.list;
   op read is OpportunitiesRouter.read;
+  op search is OpportunitiesRouter.search;
 }

--- a/templates/quickstart/routes.tsp
+++ b/templates/quickstart/routes.tsp
@@ -3,10 +3,11 @@ import "@common-grants/core";
 using TypeSpec.Http;
 
 @tag("Opportunities")
-@route("/opportunities")
+@route("/common-grants/opportunities")
 namespace Quickstart.Routes {
   alias OpportunitiesRouter = CommonGrants.Routes.Opportunities;
 
   op list is OpportunitiesRouter.list;
   op read is OpportunitiesRouter.read;
+  op search is OpportunitiesRouter.search;
 }

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -172,7 +172,7 @@ There's a lot happening here, so let's break it down section by section.
    using CommonGrants.Models;
    ```
 
-   Without this, you would have to prefix each model `CommonGrants.Models` and each field `CommonGrants.Fields`. For example `CommonGrants.Fields.CustomField`.
+   Without this, you would have to prefix each model with `CommonGrants.Models` and each field with `CommonGrants.Fields`. For example `CommonGrants.Fields.CustomField`.
 
 3. Declare a namespace for the current file.
    ```tsp
@@ -228,7 +228,7 @@ Update the `routes.tsp` file and make the following changes:
 - Import the `models.tsp` file to expose the `CustomOpportunity` model.
 - Update the routes to use the `CustomOpportunity` model.
 
-```tsp title=routes.tsp ins={2,13,14} del={11,12}
+```tsp title=routes.tsp ins={2,14-16} del={11-13}
 import "@common-grants/core";
 import "./models.tsp";
 
@@ -241,8 +241,10 @@ namespace Quickstart.Routes {
 
   op list is OpportunitiesRouter.list;
   op read is OpportunitiesRouter.read;
+  op search is OpportunitiesRouter.search;
   op list is OpportunitiesRouter.list<Models.CustomOpportunity>;
   op read is OpportunitiesRouter.read<Models.CustomOpportunity>;
+  op search is OpportunitiesRouter.search<Models.CustomOpportunity>;
 }
 ```
 
@@ -271,7 +273,7 @@ There's also a lot happening here, so let's break it down section by section.
 
 3. Update the default routes to use the `CustomOpportunity` model.
 
-   ```tsp {6,7}
+   ```tsp {6-8}
    @tag("Opportunities")
    @route("/opportunities")
    namespace Quickstart.Routes {
@@ -279,6 +281,7 @@ There's also a lot happening here, so let's break it down section by section.
 
      op list is OpportunitiesRouter.list<Models.CustomOpportunity>;
      op read is OpportunitiesRouter.read<Models.CustomOpportunity>;
+     op search is OpportunitiesRouter.search<Models.CustomOpportunity>;
    }
    ```
 
@@ -301,6 +304,7 @@ namespace Quickstart.Routes {
 
   op list is OpportunitiesRouter.list<Models.CustomOpportunity>;
   op read is OpportunitiesRouter.read<Models.CustomOpportunity>;
+  op search is OpportunitiesRouter.search<Models.CustomOpportunity>;
 }
 ```
 


### PR DESCRIPTION
### Summary

Updates templates and bumps the `@common-grants/core` prerelease version

- Relates to #87 
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds a `prepublishOnly` check that fails if the current version matches the published version
- Adds the `POST /common-grants/opportunities/search` route to each of the templates
- Adds the `POST /common-grants/opportunities/search` route to the README and quickstart guide

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1436" alt="Screenshot 2025-02-27 at 5 41 53 PM" src="https://github.com/user-attachments/assets/9e057d03-b35d-401d-8ad4-5d8544f1aa43" />

<img width="1093" alt="Screenshot 2025-02-27 at 5 42 48 PM" src="https://github.com/user-attachments/assets/c10fca00-0757-4ab5-bae3-37419d03f782" />
