### PR TITLE
[Issue #175] Add Cabin analytics

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -10,6 +10,16 @@ export default defineConfig({
   site: "https://commongrants.org",
   integrations: [
     starlight({
+      head: [
+        // Adds Cabin analytics to the page.
+        {
+          tag: "script",
+          attrs: {
+            async: true,
+            src: "https://scripts.withcabin.com/hello.js",
+          },
+        },
+      ],
       favicon: "/favicon.ico",
       customCss: ["./src/styles/custom.css"],
       plugins: [


### PR DESCRIPTION
### Summary

Adds Cabin analytics to track site traffic and usage. Cabin is a low-carbon alternative to Google Analytics that doesn't require cookies or collect IP addresses.

- Related to #175 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

Adds Cabin script to header in `astro.config.js` for the website

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This is hard to test until we deploy it.