### PR TITLE
[Issue #202] Add interest form link to sidebar

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -53,6 +53,10 @@ export default defineConfig({
       },
       sidebar: [
         {
+          label: "Get in touch with us →",
+          link: "https://forms.gle/XUJuEnNtaZkdc1MQ6",
+        },
+        {
           label: "Welcome",
           items: [
             { label: "Getting started", link: "getting-started" },


### PR DESCRIPTION
### Summary

Also adds interest form link to the sidebar so it will display in mobile.

- Fixes #202 
- Time to review: 1 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We might want to seek a more robust solution in the future like adding a responsive button, but it was hard to get that to work correctly without overriding a ton of the default layouts.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="416" alt="Screenshot 2025-05-30 at 11 31 48 AM" src="https://github.com/user-attachments/assets/228f3dd7-2fa0-4651-9f07-dfe266c9d2c9" />
