### PR TITLE
[Issue 234] Extend CLI check spec to validate OpenAPI 3.1 specs

### DIFF
--- a/.changeset/cuddly-socks-call.md
+++ b/.changeset/cuddly-socks-call.md
@@ -1,0 +1,5 @@
+---
+"@common-grants/cli": patch
+---
+
+Extend check spec to support OpenAPI v3.1

--- a/lib/cli/src/__tests__/commands/check/check-service.test.ts
+++ b/lib/cli/src/__tests__/commands/check/check-service.test.ts
@@ -2,6 +2,8 @@ import { OpenAPIV3 } from "openapi-types";
 import { DefaultCheckService } from "../../../commands/check/check-service";
 import SwaggerParser from "@apidevtools/swagger-parser";
 import { compileTypeSpec } from "../../../utils/typespec";
+import * as fs from "fs";
+import * as yaml from "js-yaml";
 
 // Mock dependencies
 jest.mock("@apidevtools/swagger-parser", () => ({
@@ -12,6 +14,15 @@ jest.mock("../../../utils/typespec", () => ({
   compileTypeSpec: jest.fn(),
 }));
 
+jest.mock("fs", () => ({
+  readFileSync: jest.fn(),
+  existsSync: jest.fn(),
+}));
+
+jest.mock("js-yaml", () => ({
+  load: jest.fn(),
+}));
+
 describe("ValidationService", () => {
   let service: DefaultCheckService;
   const mockConsoleLog = jest.spyOn(console, "log").mockImplementation(() => {});
@@ -19,6 +30,9 @@ describe("ValidationService", () => {
   beforeEach(() => {
     service = new DefaultCheckService();
     jest.clearAllMocks();
+    
+    // Mock fs.existsSync to return true for base spec path
+    (fs.existsSync as jest.Mock).mockReturnValue(true);
   });
 
   afterAll(() => {
@@ -103,6 +117,10 @@ describe("ValidationService", () => {
         paths: {},
       };
 
+      // Mock file system operations
+      (fs.readFileSync as jest.Mock).mockReturnValue("mock yaml content");
+      (yaml.load as jest.Mock).mockReturnValue(implDoc);
+
       (SwaggerParser.dereference as jest.Mock)
         .mockResolvedValueOnce(implDoc) // First call for impl spec
         .mockResolvedValueOnce(baseDoc); // Second call for TypeSpec-generated base spec
@@ -121,6 +139,10 @@ describe("ValidationService", () => {
       };
 
       const implDoc = { ...baseDoc, info: { title: "Impl", version: "1.0.0" } };
+
+      // Mock file system operations
+      (fs.readFileSync as jest.Mock).mockReturnValue("mock yaml content");
+      (yaml.load as jest.Mock).mockReturnValue(implDoc);
 
       (SwaggerParser.dereference as jest.Mock)
         .mockResolvedValueOnce(implDoc)
@@ -162,6 +184,10 @@ describe("ValidationService", () => {
         info: { title: "Implementation", version: "1.0.0" },
         paths: {},
       };
+
+      // Mock file system operations
+      (fs.readFileSync as jest.Mock).mockReturnValue("mock yaml content");
+      (yaml.load as jest.Mock).mockReturnValue(implDoc);
 
       (SwaggerParser.dereference as jest.Mock)
         .mockResolvedValueOnce(implDoc) // First call for impl spec
@@ -238,6 +264,10 @@ describe("ValidationService", () => {
         },
       };
 
+      // Mock file system operations
+      (fs.readFileSync as jest.Mock).mockReturnValue("mock yaml content");
+      (yaml.load as jest.Mock).mockReturnValue(implDoc);
+
       (SwaggerParser.dereference as jest.Mock)
         .mockResolvedValueOnce(implDoc)
         .mockResolvedValueOnce(baseDoc);
@@ -272,6 +302,10 @@ describe("ValidationService", () => {
       };
 
       const implDoc = { ...baseDoc, info: { title: "Impl", version: "1.0.0" } };
+
+      // Mock file system operations
+      (fs.readFileSync as jest.Mock).mockReturnValue("mock yaml content");
+      (yaml.load as jest.Mock).mockReturnValue(implDoc);
 
       (SwaggerParser.dereference as jest.Mock)
         .mockResolvedValueOnce(implDoc)

--- a/lib/cli/src/commands/check/check-service.ts
+++ b/lib/cli/src/commands/check/check-service.ts
@@ -5,8 +5,10 @@ import { checkMissingRequiredRoutes } from "./utils/check-missing-routes";
 import { Document } from "./utils/types";
 import { CheckApiCommandOptions, CheckSpecCommandOptions } from "./check-args";
 import { ErrorCollection, ErrorFormatter } from "./utils/error-utils";
+import { convertOpenApiToV3 } from "./utils/convert-openapi-v3";
 import * as path from "path";
 import * as fs from "fs";
+import * as yaml from "js-yaml";
 
 export class DefaultCheckService {
   /** Check that an API implementation matches its spec. */
@@ -24,8 +26,15 @@ export class DefaultCheckService {
    *   4) Checking that matching routes are compatible
    */
   async checkSpec(specPath: string, options: CheckSpecCommandOptions): Promise<void> {
-    // Parse and dereference the spec
-    const doc = (await SwaggerParser.dereference(specPath)) as Document;
+    // Read the spec file as raw YAML/JSON first
+    const specContent = fs.readFileSync(specPath, 'utf8');
+    const rawSpec = yaml.load(specContent) as any;
+
+    // Convert OpenAPI v3.1 to v3.0 if needed
+    const convertedSpec = convertOpenApiToV3(rawSpec);
+
+    // Now parse and dereference the converted spec
+    const doc = (await SwaggerParser.dereference(convertedSpec)) as Document;
 
     // If no base spec provided, compile from TypeSpec
     const baseSpecPath = options.base || getBaseSpecPath();

--- a/lib/cli/src/commands/check/utils/convert-openapi-v3.ts
+++ b/lib/cli/src/commands/check/utils/convert-openapi-v3.ts
@@ -1,0 +1,129 @@
+import { OpenAPIV3 } from "openapi-types";
+
+/**
+ * Script to transform OpenAPI specifications.
+ * 
+ * This module provides functionality to transform OpenAPI specifications from one
+ * version to another, e.g. v3.1 to v3.0
+ */
+
+// OpenAPI version constants
+const OPENAPI_V3 = "3.0.0";
+
+export type OpenAPISchema = OpenAPIV3.Document & {
+  definitions?: Record<string, any>;
+};
+
+/**
+ * Convert OpenAPI schema v3.1 to 3.0.
+ * 
+ * @param schema - The base OpenAPI schema from FastAPI
+ * @returns The schema converted to OpenAPI 3.0 format
+ */
+export function convertOpenApiToV3(schema: OpenAPISchema): OpenAPISchema {
+  // Set OpenAPI version
+  schema.openapi = OPENAPI_V3;
+
+  // Move schemas from components to definitions
+  moveSchemasToDefinitions(schema);
+
+  // Convert all schema references
+  return convertRefs(schema) as OpenAPISchema;
+}
+
+/**
+ * Move schemas from components to definitions for OpenAPI 3.0.0 compatibility.
+ * 
+ * @param schema - The OpenAPI schema to modify
+ */
+function moveSchemasToDefinitions(schema: OpenAPISchema): void {
+  // Initialize definitions if it doesn't exist
+  if (!schema.definitions) {
+    schema.definitions = {};
+  }
+
+  // Move schemas from components to definitions
+  if (schema.components && schema.components.schemas) {
+    schema.definitions = { ...schema.definitions, ...schema.components.schemas };
+    // Keep the components section but remove schemas
+    if (Object.keys(schema.components).length === 1) { // Only had schemas
+      delete schema.components;
+    } else {
+      delete schema.components.schemas;
+    }
+  }
+
+  // Move $defs to definitions
+  moveDefsToDefinitions(schema);
+}
+
+/**
+ * Move $defs sections to definitions for OpenAPI 3.0.0 compatibility.
+ * 
+ * @param obj - The object to process
+ */
+function moveDefsToDefinitions(obj: any): void {
+  if (typeof obj === "object" && obj !== null) {
+    if (Array.isArray(obj)) {
+      obj.forEach(item => moveDefsToDefinitions(item));
+    } else {
+      // Check if this object has $defs
+      if (obj.$defs && typeof obj.$defs === "object") {
+        // Move $defs to the root definitions
+        if (!obj.definitions) {
+          obj.definitions = {};
+        }
+        obj.definitions = { ...obj.definitions, ...obj.$defs };
+        delete obj.$defs;
+      }
+      
+      // Recursively process all properties
+      for (const value of Object.values(obj)) {
+        moveDefsToDefinitions(value);
+      }
+    }
+  }
+}
+
+/**
+ * Convert a schema reference to OpenAPI 3.0.0 format.
+ * 
+ * @param ref - The reference string to convert
+ * @returns The converted reference
+ */
+function convertRef(ref: string): string {
+  if (ref.includes("#/components/schemas/")) {
+    return ref.replace("#/components/schemas/", "#/definitions/");
+  }
+  if (ref.includes("#/$defs/")) {
+    return ref.replace("#/$defs/", "#/definitions/");
+  }
+  return ref;
+}
+
+/**
+ * Convert all schema references from components to definitions.
+ * 
+ * @param obj - The object to convert references in
+ * @returns The object with converted references
+ */
+function convertRefs(
+  obj: any
+): any {
+  if (typeof obj === "object" && obj !== null) {
+    if (Array.isArray(obj)) {
+      return obj.map(item => convertRefs(item));
+    } else {
+      const result: Record<string, any> = {};
+      for (const [k, v] of Object.entries(obj)) {
+        if (k === "$ref") {
+          result[k] = convertRef(v as string);
+        } else {
+          result[k] = convertRefs(v);
+        }
+      }
+      return result;
+    }
+  }
+  return obj;
+} 

--- a/templates/fast-api/Makefile
+++ b/templates/fast-api/Makefile
@@ -30,7 +30,7 @@ check-lint:
 	$(RUNTIME_PREFIX) ruff check $(PYTHON_DIRS) --fix --exit-non-zero-on-fix
 
 check-spec:
-	$(RUNTIME_PREFIX) python src/common_grants/scripts/generate_openapi.py --version 3.0.0 > openapi-v3.yaml && cg check spec openapi-v3.yaml
+	$(RUNTIME_PREFIX) python src/common_grants/scripts/generate_openapi.py > openapi.yaml && cg check spec openapi.yaml
 
 check-types:
 	$(RUNTIME_PREFIX) pyright $(PYTHON_DIRS)
@@ -39,7 +39,3 @@ checks: check-format check-lint check-types
 
 gen-openapi:
 	$(RUNTIME_PREFIX) python src/common_grants/scripts/generate_openapi.py > openapi.yaml
-
-gen-openapi-v3:
-	$(RUNTIME_PREFIX) python src/common_grants/scripts/generate_openapi.py --version 3.0.0 > openapi-v3.yaml
-

--- a/templates/fast-api/src/common_grants/scripts/generate_openapi.py
+++ b/templates/fast-api/src/common_grants/scripts/generate_openapi.py
@@ -13,6 +13,7 @@ from fastapi.openapi.utils import get_openapi
 
 from common_grants.routes import opportunity_router
 
+
 def get_openapi_schema() -> dict[str, Any]:
     """
     Generate OpenAPI schema.

--- a/templates/fast-api/src/common_grants/scripts/generate_openapi.py
+++ b/templates/fast-api/src/common_grants/scripts/generate_openapi.py
@@ -3,109 +3,19 @@
 """
 Script to generate OpenAPI specifications for the CommonGrants API.
 
-This module provides functionality to generate OpenAPI specifications in different versions,
-with support for converting between OpenAPI 3.0.0 and FastAPI's default format.
+This module provides functionality to generate OpenAPI specifications.
 """
 
-import argparse
-from typing import Any, Union, cast
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 
 from common_grants.routes import opportunity_router
 
-# OpenAPI version constants
-OPENAPI_V3 = "3.0.0"
-DEFAULT_VERSION = "default"
-
-
-def move_schemas_to_definitions(schema: dict[str, Any]) -> None:
+def get_openapi_schema() -> dict[str, Any]:
     """
-    Move schemas from components to definitions for OpenAPI 3.0.0 compatibility.
-
-    Args:
-        schema: The OpenAPI schema to modify
-
-    """
-    if "components" in schema and "schemas" in schema["components"]:
-        schema["definitions"] = schema["components"]["schemas"]
-        # Keep the components section but remove schemas
-        if len(schema["components"]) == 1:  # Only had schemas
-            del schema["components"]
-        else:
-            del schema["components"]["schemas"]
-
-
-def convert_ref(ref: str) -> str:
-    """
-    Convert a schema reference to OpenAPI 3.0.0 format.
-
-    Args:
-        ref: The reference string to convert
-
-    Returns:
-        str: The converted reference
-
-    """
-    if "#/components/schemas/" in ref:
-        return ref.replace("#/components/schemas/", "#/definitions/")
-    if "#/$defs/" in ref:
-        return ref.replace("#/$defs/", "#/definitions/")
-    return ref
-
-
-def convert_refs(
-    obj: Union[dict[str, Any], list[Any], str, float, bool, None],
-) -> Union[dict[str, Any], list[Any], str, int, float, bool, None]:
-    """
-    Convert all schema references from components to definitions.
-
-    Args:
-        obj: The object to convert references in
-
-    Returns:
-        The object with converted references
-
-    """
-    if isinstance(obj, dict):
-        return {
-            k: convert_refs(v) if k != "$ref" else convert_ref(cast(str, v))
-            for k, v in obj.items()
-        }
-    if isinstance(obj, list):
-        return [convert_refs(item) for item in obj]
-    return obj
-
-
-def convert_to_openapi_v3(schema: dict[str, Any]) -> dict[str, Any]:
-    """
-    Convert a FastAPI OpenAPI schema to OpenAPI 3.0.0 format.
-
-    Args:
-        schema: The base OpenAPI schema from FastAPI
-
-    Returns:
-        dict: The schema converted to OpenAPI 3.0.0 format
-
-    """
-    # Set OpenAPI version
-    schema["openapi"] = OPENAPI_V3
-
-    # Move schemas from components to definitions
-    move_schemas_to_definitions(schema)
-
-    # Convert all schema references
-    return cast(dict[str, Any], convert_refs(schema))
-
-
-def get_openapi_schema(version: str = DEFAULT_VERSION) -> dict[str, Any]:
-    """
-    Generate OpenAPI schema for the specified version.
-
-    Args:
-        version: Either DEFAULT_VERSION for FastAPI's default version
-                 or OPENAPI_V3 for OpenAPI 3.0.0
+    Generate OpenAPI schema.
 
     Returns:
         dict: The OpenAPI schema
@@ -116,24 +26,14 @@ def get_openapi_schema(version: str = DEFAULT_VERSION) -> dict[str, Any]:
         return app.openapi_schema
 
     # Generate base schema using FastAPI's built-in generator
-    openapi_schema = get_openapi(
+    app.openapi_schema = get_openapi(
         title=app.title,
         version=app.version,
         description=app.description,
         routes=app.routes,
     )
 
-    # Cache and return the schema as-is for default version
-    if version == DEFAULT_VERSION:
-        app.openapi_schema = openapi_schema
-        return openapi_schema
-
-    # Special case: Apply OpenAPI 3.0.0 specific transformations
-    if version == OPENAPI_V3:
-        openapi_schema = convert_to_openapi_v3(openapi_schema)
-
-    app.openapi_schema = openapi_schema
-    return openapi_schema
+    return app.openapi_schema
 
 
 app = FastAPI(
@@ -146,13 +46,4 @@ app.include_router(opportunity_router)
 if __name__ == "__main__":
     import yaml
 
-    parser = argparse.ArgumentParser(description="Generate OpenAPI specification")
-    parser.add_argument(
-        "--version",
-        choices=[DEFAULT_VERSION, OPENAPI_V3],
-        default=DEFAULT_VERSION,
-        help=f"OpenAPI version to generate (default: {DEFAULT_VERSION})",
-    )
-    args = parser.parse_args()
-
-    print(yaml.dump(get_openapi_schema(args.version), sort_keys=False))  # noqa: T201
+    print(yaml.dump(get_openapi_schema(), sort_keys=False))  # noqa: T201


### PR DESCRIPTION
### Summary

- Fixes #234 
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

The existing `check spec` command in the CLI lib could validate OpenAPI 3.0 spec files but could _not_ validate OpenAPI 3.1 spec files. This PR adds that capability. Also, this PR removes from FastAPI template the now-obsolete code to convert spec files, because the conversion logic has been moved to CLI `check spec`.  

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
