### PR TITLE
Update CLI check-spec logic for optional properties

### DIFF
--- a/.changeset/neat-regions-dress.md
+++ b/.changeset/neat-regions-dress.md
@@ -1,0 +1,5 @@
+---
+"common-grants-sdk": minor
+---
+
+Update fields and opportunity models to support core v0.1.0

--- a/lib/cli/src/commands/check/utils/check-schema-compatibility.ts
+++ b/lib/cli/src/commands/check/utils/check-schema-compatibility.ts
@@ -132,11 +132,15 @@ function checkObjectCompatibility(
     errors.addErrors(propErrors.getAllErrors());
   }
 
-  // Step 3: Handle missing props
+  // Step 3: Handle missing props - only flag as errors if they are required
+  const requiredProps = baseSchema.required || [];
   for (const propName of propsByStatus.missing) {
-    const propLoc = `${location}.${propName}`;
-    const error = missingFieldError(propLoc, propName, { ...ctx, baseSchema });
-    errors.addError(error);
+    // Only flag as missing if the property is actually required
+    if (requiredProps.includes(propName)) {
+      const propLoc = `${location}.${propName}`;
+      const error = missingFieldError(propLoc, propName, { ...ctx, baseSchema });
+      errors.addError(error);
+    }
   }
 
   // Step 4: Handle extra props

--- a/lib/python-sdk/common_grants_sdk/schemas/models/opp_base.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/models/opp_base.py
@@ -22,9 +22,12 @@ class OpportunityBase(SystemMetadata, CommonGrantsBaseModel):
         ...,
         description="Description of the opportunity's purpose and scope",
     )
-    funding: OppFunding = Field(..., description="Details about the funding available")
-    key_dates: OppTimeline = Field(
-        ...,
+    funding: Optional[OppFunding] = Field(
+        default=None,
+        description="Details about the funding available",
+    )
+    key_dates: Optional[OppTimeline] = Field(
+        default=None,
         alias="keyDates",
         description="Key dates for the opportunity, such as when the application opens and closes",
     )

--- a/lib/python-sdk/common_grants_sdk/schemas/models/opp_funding.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/models/opp_funding.py
@@ -11,18 +11,22 @@ from common_grants_sdk.schemas.fields import Money
 class OppFunding(CommonGrantsBaseModel):
     """Details about the funding available for an opportunity."""
 
-    total_amount_available: Money = Field(
-        ...,
+    details: Optional[str] = Field(
+        default=None,
+        description="Details about the funding available for this opportunity that don't fit other fields",
+    )
+    total_amount_available: Optional[Money] = Field(
+        default=None,
         alias="totalAmountAvailable",
         description="Total amount of funding available for this opportunity",
     )
-    min_award_amount: Money = Field(
-        ...,
+    min_award_amount: Optional[Money] = Field(
+        default=None,
         alias="minAwardAmount",
         description="Minimum amount of funding granted per award",
     )
-    max_award_amount: Money = Field(
-        ...,
+    max_award_amount: Optional[Money] = Field(
+        default=None,
         alias="maxAwardAmount",
         description="Maximum amount of funding granted per award",
     )

--- a/lib/python-sdk/common_grants_sdk/schemas/models/opp_status.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/models/opp_status.py
@@ -39,8 +39,7 @@ class OppStatus(CommonGrantsBaseModel):
         alias="customValue",
         description="A custom status value",
     )
-    description: str = Field(
-        ...,
+    description: Optional[str] = Field(
+        default=None,
         description="A human-readable description of the status",
-        min_length=1,
     )

--- a/lib/python-sdk/common_grants_sdk/schemas/models/opp_timeline.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/models/opp_timeline.py
@@ -1,10 +1,8 @@
 """Encapsulates key dates in the opportunity timeline."""
 
-import warnings
-
 from typing import Optional
 
-from pydantic import Field, model_validator
+from pydantic import Field
 
 from common_grants_sdk.schemas.base import CommonGrantsBaseModel
 from common_grants_sdk.schemas.fields import Event
@@ -13,27 +11,18 @@ from common_grants_sdk.schemas.fields import Event
 class OppTimeline(CommonGrantsBaseModel):
     """Key dates and events in the lifecycle of an opportunity."""
 
-    app_opens: Event = Field(
-        ...,
-        alias="appOpens",
-        description="The date (and time) at which the opportunity begins accepting applications",
+    post_date: Optional[Event] = Field(
+        default=None,
+        alias="postDate",
+        description="The date (and time) at which the opportunity is posted",
     )
-    app_deadline: Event = Field(
-        ...,
-        alias="appDeadline",
-        description="The final deadline for submitting applications",
+    close_date: Optional[Event] = Field(
+        default=None,
+        alias="closeDate",
+        description="The date (and time) at which the opportunity closes",
     )
     other_dates: Optional[dict[str, Event]] = Field(
         default=None,
         alias="otherDates",
-        description="An optional map of other key dates in the opportunity timeline",
+        description="An optional map of other key dates or events in the opportunity timeline",
     )
-
-    @model_validator(mode="after")
-    def validate_dates(self) -> "OppTimeline":
-        """Validate that the application deadline is after the opening date."""
-        if self.app_opens.date > self.app_deadline.date:
-            e = f"Application deadline ({self.app_deadline.date}) "
-            e = e + f"preceeds opening date ({self.app_opens.date})"
-            warnings.warn(e, RuntimeWarning)
-        return self

--- a/lib/python-sdk/tests/schemas/test_opportunity.py
+++ b/lib/python-sdk/tests/schemas/test_opportunity.py
@@ -4,7 +4,7 @@ import pytest
 from datetime import datetime, date, UTC
 from uuid import uuid4
 
-from common_grants_sdk.schemas.fields import Money, Event
+from common_grants_sdk.schemas.fields import Money, EventType, SingleDateEvent
 from common_grants_sdk.schemas.models.opp_base import OpportunityBase
 from common_grants_sdk.schemas.models.opp_funding import OppFunding
 from common_grants_sdk.schemas.models.opp_status import OppStatus, OppStatusOptions
@@ -32,13 +32,15 @@ def sample_opportunity():
                 "estimatedAwardCount": 5,
             },
             "keyDates": {
-                "appOpens": {
-                    "name": "Application Opens",
+                "postDate": {
+                    "name": "Application Posted",
+                    "eventType": "singleDate",
                     "date": date(2024, 1, 1),
-                    "description": "Applications open",
+                    "description": "Applications posted",
                 },
-                "appDeadline": {
+                "closeDate": {
                     "name": "Application Deadline",
+                    "eventType": "singleDate",
                     "date": date(2024, 3, 31),
                     "description": "Applications close",
                 },
@@ -47,50 +49,137 @@ def sample_opportunity():
     )
 
 
+@pytest.fixture
+def minimal_opportunity():
+    """Create a minimal opportunity with only required fields."""
+    return OpportunityBase.model_validate(
+        {
+            "id": uuid4(),
+            "title": "Minimal Research Grant",
+            "description": "Funding for innovative research projects",
+            "status": {
+                "value": OppStatusOptions.OPEN,
+            },
+            "createdAt": datetime.now(UTC),
+            "lastModifiedAt": datetime.now(UTC),
+        }
+    )
+
+
 def test_opportunity_timeline_validation(sample_opportunity):
     """Test opportunity timeline validation."""
-    # Test that app_opens date is before app_deadline
+    # Test that post_date is before close_date
     assert (
-        sample_opportunity.key_dates.app_opens.date
-        < sample_opportunity.key_dates.app_deadline.date
+        sample_opportunity.key_dates.post_date.date
+        < sample_opportunity.key_dates.close_date.date
     )
 
     # Test that dates are valid
-    assert isinstance(sample_opportunity.key_dates.app_opens.date, date)
-    assert isinstance(sample_opportunity.key_dates.app_deadline.date, date)
+    assert isinstance(sample_opportunity.key_dates.post_date.date, date)
+    assert isinstance(sample_opportunity.key_dates.close_date.date, date)
 
     # Test that event names are not empty
-    assert sample_opportunity.key_dates.app_opens.name
-    assert sample_opportunity.key_dates.app_deadline.name
+    assert sample_opportunity.key_dates.post_date.name
+    assert sample_opportunity.key_dates.close_date.name
+
+    # Test that event types are correct
+    assert sample_opportunity.key_dates.post_date.event_type == EventType.SINGLE_DATE
+    assert sample_opportunity.key_dates.close_date.event_type == EventType.SINGLE_DATE
 
 
-def test_invalid_timeline_scenarios():
-    """Test invalid timeline scenarios."""
-    # Test opportunity with invalid dates (deadline before opens)
-    with pytest.raises(ValueError):
-        OpportunityBase(
-            id=uuid4(),
-            title="Invalid Timeline Opportunity",
-            description="Testing invalid timeline",
-            status=OppStatus(value=OppStatusOptions.OPEN, description="Testing"),
-            created_at=datetime.now(UTC),
-            last_modified_at=datetime.now(UTC),
-            funding=OppFunding(
-                total_amount_available=Money(amount="100000.00", currency="USD"),
-                min_award_amount=Money(amount="10000.00", currency="USD"),
-                max_award_amount=Money(amount="50000.00", currency="USD"),
-                estimated_award_count=5,
-            ),
-            key_dates=OppTimeline(
-                app_opens=Event(
-                    name="Application Opens",
-                    date=date(2024, 3, 31),
-                    description="Applications open",
-                ),
-                app_deadline=Event(
-                    name="Application Deadline",
-                    date=date(2024, 1, 1),
-                    description="Applications close",
-                ),
-            ),
+def test_minimal_opportunity_validation(minimal_opportunity):
+    """Test that minimal opportunity with only required fields works."""
+    assert minimal_opportunity.id is not None
+    assert minimal_opportunity.title == "Minimal Research Grant"
+    assert minimal_opportunity.description == "Funding for innovative research projects"
+    assert minimal_opportunity.status.value == OppStatusOptions.OPEN
+    assert minimal_opportunity.funding is None
+    assert minimal_opportunity.key_dates is None
+    assert minimal_opportunity.source is None
+    assert minimal_opportunity.custom_fields is None
+
+
+def test_optional_funding_fields():
+    """Test that funding fields are optional."""
+    funding = OppFunding(
+        totalAmountAvailable=Money(amount="100000.00", currency="USD"),
+        details="Additional funding information",
+    )
+    assert funding.total_amount_available is not None
+    assert funding.details == "Additional funding information"
+    assert funding.min_award_amount is None
+    assert funding.max_award_amount is None
+    assert funding.min_award_count is None
+    assert funding.max_award_count is None
+    assert funding.estimated_award_count is None
+
+
+def test_optional_status_description():
+    """Test that status description is optional."""
+    status = OppStatus(value=OppStatusOptions.OPEN)
+    assert status.value == OppStatusOptions.OPEN
+    assert status.description is None
+    assert status.custom_value is None
+
+    status_with_desc = OppStatus(
+        value=OppStatusOptions.OPEN,
+        description="This opportunity is currently accepting applications",
+    )
+    assert (
+        status_with_desc.description
+        == "This opportunity is currently accepting applications"
+    )
+
+
+def test_optional_timeline_fields():
+    """Test that timeline fields are optional."""
+    timeline = OppTimeline()
+    assert timeline.post_date is None
+    assert timeline.close_date is None
+    assert timeline.other_dates is None
+
+    timeline_with_post = OppTimeline(
+        postDate=SingleDateEvent(
+            name="Application Posted",
+            event_type=EventType.SINGLE_DATE,
+            date=date(2024, 1, 1),
         )
+    )
+    assert timeline_with_post.post_date is not None
+    assert timeline_with_post.close_date is None
+    assert timeline_with_post.other_dates is None
+
+
+def test_opportunity_with_custom_fields():
+    """Test opportunity with custom fields."""
+    from common_grants_sdk.schemas.fields import CustomFieldType
+
+    opportunity = OpportunityBase.model_validate(
+        {
+            "id": uuid4(),
+            "title": "Custom Field Test",
+            "description": "Testing custom fields",
+            "status": {
+                "value": OppStatusOptions.OPEN,
+            },
+            "createdAt": datetime.now(UTC),
+            "lastModifiedAt": datetime.now(UTC),
+            "customFields": {
+                "programArea": {
+                    "name": "programArea",
+                    "fieldType": CustomFieldType.STRING,
+                    "value": "Healthcare Innovation",
+                    "description": "Primary focus area of the grant program",
+                    "schema": "https://example.com/schema",
+                }
+            },
+        }
+    )
+
+    assert opportunity.custom_fields is not None
+    assert "programArea" in opportunity.custom_fields
+    custom_field = opportunity.custom_fields["programArea"]
+    assert custom_field.name == "programArea"
+    assert custom_field.field_type == CustomFieldType.STRING
+    assert custom_field.value == "Healthcare Innovation"
+    assert str(custom_field.schema_url) == "https://example.com/schema"


### PR DESCRIPTION
### Summary

- Fixes #[issue number]
- Time to review: 1 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

The `check-spec` command currently throws an error if optional fields are missing. I assume this is a bug! This PR changes the CLI `check-spec` command behavior to NOT throw errors if optional properties are missing. 

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
