### PR TITLE
Update CLI check-spec logic for optional properties

### DIFF
--- a/lib/cli/src/commands/check/utils/check-schema-compatibility.ts
+++ b/lib/cli/src/commands/check/utils/check-schema-compatibility.ts
@@ -132,11 +132,15 @@ function checkObjectCompatibility(
     errors.addErrors(propErrors.getAllErrors());
   }
 
-  // Step 3: Handle missing props
+  // Step 3: Handle missing props - only flag as errors if they are required
+  const requiredProps = baseSchema.required || [];
   for (const propName of propsByStatus.missing) {
-    const propLoc = `${location}.${propName}`;
-    const error = missingFieldError(propLoc, propName, { ...ctx, baseSchema });
-    errors.addError(error);
+    // Only flag as missing if the property is actually required
+    if (requiredProps.includes(propName)) {
+      const propLoc = `${location}.${propName}`;
+      const error = missingFieldError(propLoc, propName, { ...ctx, baseSchema });
+      errors.addError(error);
+    }
   }
 
   // Step 4: Handle extra props


### PR DESCRIPTION
### Summary

- Fixes #[issue number]
- Time to review: 1 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

The `check-spec` command currently throws an error if optional fields are missing. I assume this is a bug! This PR changes the CLI `check-spec` command behavior to NOT throw errors if optional properties are missing. 

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
