### PR TITLE
[Issue 253] Fix bug in `-V` command

### DIFF
--- a/.changeset/icy-weeks-swim.md
+++ b/.changeset/icy-weeks-swim.md
@@ -1,0 +1,5 @@
+---
+"@common-grants/cli": patch
+---
+
+Fix bug in version command

--- a/lib/cli/src/index.ts
+++ b/lib/cli/src/index.ts
@@ -6,7 +6,8 @@ import { previewCommand } from "./commands/preview/preview";
 import { checkCommand } from "./commands/check/check";
 import { compileCommand } from "./commands/compile/compile";
 
-program.name("cg").description("CommonGrants CLI tools").version("0.1.0");
+const packageJson = require("../package.json");
+program.name("cg").description("CommonGrants CLI tools").version(packageJson.version);
 
 // Register commands
 initCommand(program);


### PR DESCRIPTION
### Summary

- Fixes #253 
- Time to review: 1 minute

### Changes proposed
> What was added, updated, or removed in this PR.

This PR fixes a bug in the `-V` command which was always returning a hard-coded version number. 

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
