### PR TITLE
[Issue #249] Fix versioning decorators in core library

### DIFF
--- a/.changeset/khaki-years-sort.md
+++ b/.changeset/khaki-years-sort.md
@@ -1,0 +1,7 @@
+---
+"@common-grants/core": patch
+---
+
+Fix version decorators for OpenAPI spec.
+
+Decorates the routes, schemas, and properties that were added in v0.2.0 with the `@Versioning.added()` decorator. This ensures that those items are omitted from the v0.1.0 OpenAPI spec when it is generated from the TypeSpec project.

--- a/lib/core/lib/api.tsp
+++ b/lib/core/lib/api.tsp
@@ -77,6 +77,7 @@ namespace Opportunities {
 namespace Competitions {
   alias Router = Routes.Competitions;
 
+  @added(Versions.v0_2)
   op read is Router.read;
 }
 
@@ -124,13 +125,14 @@ namespace Applications {
 // #########################################################
 
 @tag("Forms")
+@tag("experimental")
 @route("/forms")
 namespace Forms {
   alias Router = Routes.Forms;
 
-  @tag("optional")
+  @added(Versions.v0_2)
   op list is Router.list;
 
-  @tag("optional")
+  @added(Versions.v0_2)
   op read is Router.read;
 }

--- a/lib/core/lib/api.tsp
+++ b/lib/core/lib/api.tsp
@@ -61,6 +61,10 @@ namespace Opportunities {
   op list is Router.list;
 
   @tag("required")
+  @returnTypeChangedFrom(
+    CommonGrants.Versions.v0_2,
+    Responses.Ok<Models.OpportunityBase> | Responses.NotFound
+  )
   op read is Router.read;
 
   @tag("optional")

--- a/lib/core/lib/core/fields/address.tsp
+++ b/lib/core/lib/core/fields/address.tsp
@@ -2,6 +2,7 @@ namespace CommonGrants.Fields;
 
 /** A mailing address. */
 @example(Examples.Address.apartment)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model Address {
   /** The primary street address line. */
   street1: string;
@@ -34,6 +35,7 @@ model Address {
 /** A collection of addresses. */
 @example(Examples.Address.personalCollection)
 @example(Examples.Address.orgCollection)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model AddressCollection {
   /** The primary address for a person or organization. */
   primary: Address;

--- a/lib/core/lib/core/fields/email.tsp
+++ b/lib/core/lib/core/fields/email.tsp
@@ -7,6 +7,7 @@ alias Email = Types.email; // Exposes Email from CommonGrants.Fields
 
 /** A collection of email addresses. */
 @example(Examples.Email.personalCollection)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model EmailCollection {
   /** The primary email address for a person or organization. */
   primary: Types.email;

--- a/lib/core/lib/core/fields/file.tsp
+++ b/lib/core/lib/core/fields/file.tsp
@@ -3,6 +3,7 @@ namespace CommonGrants.Fields;
 /** A field representing a downloadable file. */
 @example(Examples.File.imageFile, #{ title: "An image file" })
 @example(Examples.File.pdfFile, #{ title: "A PDF file" })
+@Versioning.added(CommonGrants.Versions.v0_2)
 model File {
   /** The file's download URL. */
   downloadUrl: url;

--- a/lib/core/lib/core/fields/name.tsp
+++ b/lib/core/lib/core/fields/name.tsp
@@ -2,6 +2,7 @@ namespace CommonGrants.Fields;
 
 /** A person's name. */
 @example(Examples.Name.janeDoe)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model Name {
   /** Honorific prefix (e.g., Mr., Mrs., Dr., Prof.). */
   prefix?: string;

--- a/lib/core/lib/core/fields/pcs.tsp
+++ b/lib/core/lib/core/fields/pcs.tsp
@@ -13,6 +13,7 @@ namespace CommonGrants.Fields;
  * See https://taxonomy.candid.org/ for more information.
  */
 @example(Examples.PCS.orgTypeTerm)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PCSTerm {
   /** The plain language PCS term. */
   term: string;
@@ -34,6 +35,7 @@ model PCSTerm {
 // #########################################################
 
 /** The class to which the PCS term belongs. */
+@Versioning.added(CommonGrants.Versions.v0_2)
 enum PCSClass {
   orgTypes: "Organization types",
   subjects: "Subjects",
@@ -50,6 +52,7 @@ enum PCSClass {
  *
  * See https://taxonomy.candid.org/organization-type for more information.
  */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PCSOrgType extends PCSTerm {
   /** The PCS term for the organization type. */
   class: PCSClass.orgTypes;
@@ -59,6 +62,7 @@ model PCSOrgType extends PCSTerm {
  *
  * See https://taxonomy.candid.org/subjects for more information.
  */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PCSSubject extends PCSTerm {
   /** The PCS term for the subject. */
   class: PCSClass.subjects;
@@ -68,6 +72,7 @@ model PCSSubject extends PCSTerm {
  *
  * See https://taxonomy.candid.org/populations for more information.
  */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PCSPopulation extends PCSTerm {
   /** The PCS term for the population. */
   class: PCSClass.populationGroups;
@@ -77,6 +82,7 @@ model PCSPopulation extends PCSTerm {
  *
  * See https://taxonomy.candid.org/support-strategies for more information.
  */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PCSSupportStrategy extends PCSTerm {
   /** The PCS term for the support strategy. */
   class: PCSClass.supportStrategies;
@@ -86,6 +92,7 @@ model PCSSupportStrategy extends PCSTerm {
  *
  * See https://taxonomy.candid.org/transaction-types for more information.
  */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PCSTransactionType extends PCSTerm {
   /** The PCS term for the transaction type. */
   class: PCSClass.transactionTypes;

--- a/lib/core/lib/core/models/applicant-type.tsp
+++ b/lib/core/lib/core/models/applicant-type.tsp
@@ -7,6 +7,7 @@ namespace CommonGrants.Models;
 /** The type of applicant eligible to apply for funding */
 @example(Examples.ApplicantType.organization)
 @example(Examples.ApplicantType.individual)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ApplicantType {
   /** The type of applicant */
   value: ApplicantTypeOptions;
@@ -23,6 +24,7 @@ model ApplicantType {
 // #########################################################
 
 /** The set of possible applicant types */
+@Versioning.added(CommonGrants.Versions.v0_2)
 enum ApplicantTypeOptions {
   /** The applicant is an individual */
   individual,

--- a/lib/core/lib/core/models/application.tsp
+++ b/lib/core/lib/core/models/application.tsp
@@ -2,6 +2,7 @@ namespace CommonGrants.Models;
 
 /** The base model for an application to a competition for a funding opportunity */
 @example(Examples.Application.applicationBase)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ApplicationBase {
   /** The unique identifier for the application */
   id: Types.uuid;
@@ -37,6 +38,7 @@ model ApplicationBase {
 
 /** The status of the application */
 @example(Examples.Application.submittedStatus)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model AppStatus {
   /** The status of the application, from a predefined set of options */
   value: AppStatusOptions;
@@ -73,6 +75,7 @@ enum AppStatusOptions {
 
 /** The model for a form response included in an application */
 @example(Examples.Application.formResponse)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model AppFormResponse {
   /** The unique identifier for the application */
   applicationId: Types.uuid;

--- a/lib/core/lib/core/models/competition.tsp
+++ b/lib/core/lib/core/models/competition.tsp
@@ -7,6 +7,7 @@ namespace CommonGrants.Models;
  * distinct application period and set of application forms.
  */
 @example(Examples.Competition.competition)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model CompetitionBase {
   /** Globally unique id for the competition */
   id: Types.uuid;

--- a/lib/core/lib/core/models/form-response.tsp
+++ b/lib/core/lib/core/models/form-response.tsp
@@ -2,6 +2,7 @@ namespace CommonGrants.Models;
 
 /** The base model for a form response */
 @example(Examples.FormResponse.formResponse)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model FormResponseBase {
   /** The unique identifier for the form response */
   id: Types.uuid;
@@ -31,6 +32,7 @@ model FormResponseBase {
 
 /** The status of the form response */
 @example(Examples.FormResponse.inProgressStatus)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model FormResponseStatus {
   /** The status of the form response, from a predefined set of options */
   value: FormResponseStatusOptions;
@@ -52,6 +54,7 @@ model FormResponseStatus {
  * - `complete`: The form response is complete, meaning all required fields have been filled out and there are no validation errors
  * - `custom`: A custom status
  */
+@Versioning.added(CommonGrants.Versions.v0_2)
 enum FormResponseStatusOptions {
   notStarted,
   inProgress,

--- a/lib/core/lib/core/models/form.tsp
+++ b/lib/core/lib/core/models/form.tsp
@@ -8,6 +8,7 @@ namespace CommonGrants.Models;
 
 /** A form for collecting data from a user. */
 @example(Examples.Form.form)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model Form {
   /** The form's unique identifier. */
   id: Types.uuid;
@@ -43,6 +44,7 @@ model Form {
 
 /** A JSON schema used to validate form responses. */
 @example(Examples.Form.formSchema)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model FormJsonSchema {
   ...Record<unknown>;
 }
@@ -53,6 +55,7 @@ model FormJsonSchema {
 
 /** A UI schema used to render the form in the browser. */
 @example(Examples.Form.uiSchema)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model FormUISchema {
   ...Record<unknown>;
 }

--- a/lib/core/lib/core/models/mapping.tsp
+++ b/lib/core/lib/core/models/mapping.tsp
@@ -52,6 +52,7 @@ namespace CommonGrants.Models;
 @example(Examples.Mapping.simpleSwitch)
 @example(Examples.Mapping.nestedSwitch)
 @example(Examples.Mapping.withLiteralValues)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model MappingSchema {
   ...Record<MappingFunction | MappingSchema>;
 }
@@ -64,6 +65,7 @@ model MappingSchema {
 @example(Examples.Mapping.constId)
 @example(Examples.Mapping.amountField)
 @example(Examples.Mapping.statusSwitch)
+@Versioning.added(CommonGrants.Versions.v0_2)
 union MappingFunction {
   `const`: MappingConstantFunction,
   field: MappingFieldFunction,
@@ -76,6 +78,7 @@ union MappingFunction {
 
 /** Returns a constant value. */
 @example(Examples.Mapping.constId)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model MappingConstantFunction {
   `const`: unknown;
 }
@@ -86,6 +89,7 @@ model MappingConstantFunction {
 
 /** Returns the value of a field in the source data. */
 @example(Examples.Mapping.amountField)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model MappingFieldFunction {
   field: string;
 }
@@ -96,6 +100,7 @@ model MappingFieldFunction {
 
 /** Returns a new value based on the value of a field in the source data using a switch statement. */
 @example(Examples.Mapping.statusSwitch)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model MappingSwitchFunction {
   switch: {
     /** The field in the source data to switch on. */

--- a/lib/core/lib/core/models/opportunity/base.tsp
+++ b/lib/core/lib/core/models/opportunity/base.tsp
@@ -8,7 +8,6 @@ namespace CommonGrants.Models;
 
 using Fields;
 using Types;
-using Versioning;
 
 // ########################################
 // Model definition
@@ -64,7 +63,7 @@ model OpportunityBase {
   keyDates?: OppTimeline;
 
   /** The type of applicant for the opportunity */
-  @added(CommonGrants.Versions.v0_2)
+  @Versioning.added(CommonGrants.Versions.v0_2)
   acceptedApplicantTypes?: ApplicantType[];
 
   /** URL for the original source of the opportunity */
@@ -82,8 +81,8 @@ model OpportunityBase {
 // ########################################
 
 /** A funding opportunity with additional details, like available competitions. */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model OpportunityDetails extends OpportunityBase {
   /** The competitions associated with the opportunity */
-  @added(CommonGrants.Versions.v0_2)
   competitions?: CompetitionBase[];
 }

--- a/lib/core/lib/core/models/opportunity/base.tsp
+++ b/lib/core/lib/core/models/opportunity/base.tsp
@@ -8,6 +8,7 @@ namespace CommonGrants.Models;
 
 using Fields;
 using Types;
+using Versioning;
 
 // ########################################
 // Model definition
@@ -63,6 +64,7 @@ model OpportunityBase {
   keyDates?: OppTimeline;
 
   /** The type of applicant for the opportunity */
+  @added(CommonGrants.Versions.v0_2)
   acceptedApplicantTypes?: ApplicantType[];
 
   /** URL for the original source of the opportunity */
@@ -82,5 +84,6 @@ model OpportunityBase {
 /** A funding opportunity with additional details, like available competitions. */
 model OpportunityDetails extends OpportunityBase {
   /** The competitions associated with the opportunity */
+  @added(CommonGrants.Versions.v0_2)
   competitions?: CompetitionBase[];
 }

--- a/lib/core/lib/core/models/organization.tsp
+++ b/lib/core/lib/core/models/organization.tsp
@@ -4,6 +4,7 @@ namespace CommonGrants.Models;
 
 /** An organization that can apply for grants. */
 @example(Examples.Organization.exampleOrg)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model OrganizationBase {
   /** The organization's unique identifier. */
   id: Types.uuid;
@@ -51,6 +52,7 @@ model OrganizationBase {
 
 /** A collection of social media and web presence links for an organization. */
 @example(Examples.Organization.exampleSocials)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model OrgSocialLinks {
   /** The organization's primary website URL. */
   website?: url;

--- a/lib/core/lib/core/models/person.tsp
+++ b/lib/core/lib/core/models/person.tsp
@@ -5,6 +5,7 @@ namespace CommonGrants.Models;
 
 /** A person affiliated with an organization or grant application. */
 @example(Examples.Person.examplePerson)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model PersonBase {
   /** The person's full name, including all relevant components (first, middle, last, etc.). */
   name: Fields.Name;

--- a/lib/core/lib/core/models/proposal.tsp
+++ b/lib/core/lib/core/models/proposal.tsp
@@ -6,6 +6,7 @@ namespace CommonGrants.Models;
 
 /** A proposal for funding. */
 @example(Examples.Proposal.exampleProposal)
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ProposalBase {
   /** The title of the proposal and/or the project requesting funding. */
   title?: string;
@@ -37,6 +38,7 @@ model ProposalBase {
 // #########################################################
 
 /** The opportunity to which this proposal is related */
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ProposalOpportunity {
   /** The opportunity's unique identifier. */
   id: Types.uuid;
@@ -52,6 +54,7 @@ model ProposalOpportunity {
 // ProjectTimeline
 // #########################################################
 
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ProjectTimeline {
   /** The start date of the period for which the funding is requested. */
   startDate?: Fields.Event;
@@ -70,6 +73,7 @@ model ProjectTimeline {
 // ProjectContacts
 // #########################################################
 
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ProposalContacts {
   /** The primary point of contact for the proposal. */
   primary: PersonBase;
@@ -82,6 +86,7 @@ model ProposalContacts {
 // ProposalOrgs
 // #########################################################
 
+@Versioning.added(CommonGrants.Versions.v0_2)
 model ProposalOrgs {
   /** The primary organization that is requesting funding. */
   primary: OrganizationBase;

--- a/lib/core/lib/core/responses/error.tsp
+++ b/lib/core/lib/core/responses/error.tsp
@@ -1,7 +1,5 @@
 import "@typespec/http";
 
-using Versioning;
-
 namespace CommonGrants.Responses;
 
 /** A standard error response schema, used to create custom error responses
@@ -36,7 +34,7 @@ alias NotFound = Error & Http.NotFoundResponse;
   message: "Application submission failed due to validation errors",
   errors: #[#{ field: "formA.name", message: "Name is required" }],
 })
-@added(CommonGrants.Versions.v0_2)
+@Versioning.added(CommonGrants.Versions.v0_2)
 @doc("A failure to submit an application due to validation errors")
 model ApplicationSubmissionError extends Error {
   @example(400)

--- a/lib/core/lib/core/responses/error.tsp
+++ b/lib/core/lib/core/responses/error.tsp
@@ -1,5 +1,7 @@
 import "@typespec/http";
 
+using Versioning;
+
 namespace CommonGrants.Responses;
 
 /** A standard error response schema, used to create custom error responses
@@ -34,6 +36,7 @@ alias NotFound = Error & Http.NotFoundResponse;
   message: "Application submission failed due to validation errors",
   errors: #[#{ field: "formA.name", message: "Name is required" }],
 })
+@added(CommonGrants.Versions.v0_2)
 @doc("A failure to submit an application due to validation errors")
 model ApplicationSubmissionError extends Error {
   @example(400)

--- a/lib/core/lib/core/types.tsp
+++ b/lib/core/lib/core/types.tsp
@@ -33,6 +33,7 @@ scalar uuid extends string;
 /** An email address */
 @example("test@example.com")
 @format("email")
+@Versioning.added(CommonGrants.Versions.v0_2)
 scalar email extends string;
 
 /** An Employer Identification Number (EIN) issued by the IRS */

--- a/lib/core/lib/core/types.tsp
+++ b/lib/core/lib/core/types.tsp
@@ -38,17 +38,20 @@ scalar email extends string;
 /** An Employer Identification Number (EIN) issued by the IRS */
 @example("12-3456789")
 @pattern("^[0-9]{2}-[0-9]{7}$")
+@Versioning.added(CommonGrants.Versions.v0_2)
 scalar employerTaxId extends string;
 
 /** A Unique Entity Identifier (UEI) issued by SAM.gov */
 @example("12ABC34DEF56")
 @pattern("^[A-z0-9]{12}$")
+@Versioning.added(CommonGrants.Versions.v0_2)
 scalar samUEI extends string;
 
 /** A Data Universal Numbering System (DUNS) number */
 @example("123456789")
 @example("12-345-6789")
 @example("123456789-1234")
+@Versioning.added(CommonGrants.Versions.v0_2)
 scalar duns extends string;
 
 // ########################################
@@ -80,4 +83,5 @@ scalar isoDate extends plainDate;
 /** A calendar year */
 @example("2025")
 @pattern("^[0-9]{4}$")
+@Versioning.added(CommonGrants.Versions.v0_2)
 scalar calendarYear extends string;

--- a/lib/core/tspconfig.yaml
+++ b/lib/core/tspconfig.yaml
@@ -3,4 +3,4 @@ emit:
   - "@typespec/openapi3"
 options:
   "@typespec/openapi3":
-    "omit-unreachable-types": false
+    "omit-unreachable-types": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
     },
     "lib/cli": {
       "name": "@common-grants/cli",
-      "version": "0.1.2",
+      "version": "0.1.4",
       "license": "CC0-1.0",
       "dependencies": {
-        "@common-grants/core": "0.1.1",
+        "@common-grants/core": "0.2.0",
         "@typespec/compiler": "^1.1.0",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
@@ -814,7 +814,7 @@
     },
     "lib/core": {
       "name": "@common-grants/core",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "CC0-1.0",
       "devDependencies": {
         "@types/node": "^20.10.6",


### PR DESCRIPTION
### Summary

Adds missing version decorators to routes, schemas, and properties introduced in v0.2.0 so that they are omitted from the v0.1.0 OpenAPI spec.

- Fixes #249 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds `Versioning.added(CommonGrants.Versions.v0_2)` to all new routes, models, and fields
- Updates `tspconfig.yaml` to omit unreachable types
- Adds a PATCH changeset

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

1. Checkout the PR locally
2. Change directory to `lib/core`: `cd lib/core`
3. Run `npm run typespec` to generate the OpenAPI specs
4. Run `diff tsp-output/@typespec/openapi3/openapi.0.1.0.yaml ../../website/public/openapi/openapi.0.1.0.yaml` to compare the generated v0.1.0 spec

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Here are the differences:

```
13,14d12
<   - name: Competitions
<     description: Endpoints related to competitions, which are distinct application processes for the same funding opportunity
16,18c14
<     description: Endpoints related to applications for a given competition
<   - name: Forms
<     description: Endpoints related to forms
---
>     description: Endpoints related to applications for funding opportunities
64c60
<       description: Search for opportunities based on the provided filters.
---
>       description: Search for opportunities based on the provided filters
150,151c146,147
<       summary: View opportunity details
<       description: View details about an opportunity.
---
>       summary: View opportunity
>       description: View additional details about an opportunity
776c772
<           description: The status of the opportunity, from a predefined set of options
---
>           description: The status value, from a predefined set of options
779c775
<           description: A custom value for the status
---
>           description: A custom status value
794,799c790
<       description: |-
<         The set of values accepted for opportunity status:
<         - `forecasted`: The opportunity is forecasted and not yet open for applications
<         - `open`: The opportunity is open for applications
<         - `closed`: The opportunity is no longer accepting applications
<         - `custom`: A custom status
---
>       description: The set of values accepted for opportunity status
```

All of the remaining discrepancies are either just changes to descriptions which can't be decorated with a version.
