### PR TITLE
[Issue 271] Update FastAPI template and docs

### DIFF
--- a/templates/fast-api/poetry.lock
+++ b/templates/fast-api/poetry.lock
@@ -121,20 +121,18 @@ files = [
 
 [[package]]
 name = "common-grants-sdk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python SDK for the CommonGrants protocol"
 optional = false
-python-versions = "^3.11"
+python-versions = "<4.0,>=3.11"
 groups = ["main"]
-files = []
-develop = true
+files = [
+    {file = "common_grants_sdk-0.2.0-py3-none-any.whl", hash = "sha256:06245e62eac3284e28a56b534d9315431030d23c862d83f74acdea0ad7fe3710"},
+    {file = "common_grants_sdk-0.2.0.tar.gz", hash = "sha256:d1e9cbac4fc73d8f0345fc4868bb992ab6ea8f62f1e873f3191d33f9f9ca36f0"},
+]
 
 [package.dependencies]
-pydantic = "^2.0.3"
-
-[package.source]
-type = "directory"
-url = "../../lib/python-sdk"
+pydantic = ">=2.0.3,<3.0.0"
 
 [[package]]
 name = "coverage"
@@ -1379,4 +1377,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "f9a149929d5c5ee687d29f472f502a7f14c6560fe2fe3862c5f2b8a2b680aaf3"
+content-hash = "e74adc3d892ec5358a200a7694366a6d1ca18c23171fb0447f30a08789ce7c6f"

--- a/templates/fast-api/pyproject.toml
+++ b/templates/fast-api/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 version = "0.1.0"
 
 [tool.poetry.dependencies]
-common-grants-sdk = {path = "../../lib/python-sdk", develop = true}
+common-grants-sdk = "^0.2.0"
 fastapi = {extras = ["standard"], version = "^0.115.11"}
 python = "^3.11"
 pyyaml = "^6.0.2"

--- a/templates/template.json
+++ b/templates/template.json
@@ -21,12 +21,12 @@
     "config": {},
     "files": [
       {
-        "path": "./fast-api/src/common_grants/api.py",
-        "destination": "src/common_grants/api.py"
-      },
-      {
         "path": "./fast-api/src/common_grants/__init__.py",
         "destination": "src/common_grants/__init__.py"
+      },
+      {
+        "path": "./fast-api/src/common_grants/api.py",
+        "destination": "src/common_grants/api.py"
       },
       {
         "path": "./fast-api/src/common_grants/routes/__init__.py",
@@ -41,68 +41,12 @@
         "destination": "src/common_grants/schemas/__init__.py"
       },
       {
-        "path": "./fast-api/src/common_grants/schemas/fields.py",
-        "destination": "src/common_grants/schemas/fields.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/sorting.py",
-        "destination": "src/common_grants/schemas/sorting.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/response.py",
-        "destination": "src/common_grants/schemas/response.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/pagination.py",
-        "destination": "src/common_grants/schemas/pagination.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/models/__init__.py",
-        "destination": "src/common_grants/schemas/models/__init__.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/models/opp_search.py",
-        "destination": "src/common_grants/schemas/models/opp_search.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/models/opp_timeline.py",
-        "destination": "src/common_grants/schemas/models/opp_timeline.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/models/opp_funding.py",
-        "destination": "src/common_grants/schemas/models/opp_funding.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/models/opp_base.py",
-        "destination": "src/common_grants/schemas/models/opp_base.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/models/opp_status.py",
-        "destination": "src/common_grants/schemas/models/opp_status.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/filters/__init__.py",
-        "destination": "src/common_grants/schemas/filters/__init__.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/filters/base.py",
-        "destination": "src/common_grants/schemas/filters/base.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/filters/string_filters.py",
-        "destination": "src/common_grants/schemas/filters/string_filters.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/filters/date_filters.py",
-        "destination": "src/common_grants/schemas/filters/date_filters.py"
-      },
-      {
-        "path": "./fast-api/src/common_grants/schemas/filters/money_filters.py",
-        "destination": "src/common_grants/schemas/filters/money_filters.py"
-      },
-      {
         "path": "./fast-api/src/common_grants/services/__init__.py",
         "destination": "src/common_grants/services/__init__.py"
+      },
+      {
+        "path": "./fast-api/src/common_grants/scripts/generate_openapi.py",
+        "destination": "src/common_grants/scripts/generate_openapi.py"
       },
       {
         "path": "./fast-api/src/common_grants/services/opportunity.py",
@@ -137,72 +81,8 @@
         "destination": "tests/common_grants/routes/test_opportunities.py"
       },
       {
-        "path": "./fast-api/tests/common_grants/schemas/__init__.py",
-        "destination": "tests/common_grants/schemas/__init__.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/test_filters.py",
-        "destination": "tests/common_grants/schemas/test_filters.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/test_opportunity.py",
-        "destination": "tests/common_grants/schemas/test_opportunity.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/models/__init__.py",
-        "destination": "tests/common_grants/schemas/models/__init__.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/models/test_opp_base.py",
-        "destination": "tests/common_grants/schemas/models/test_opp_base.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/models/test_opp_timeline.py",
-        "destination": "tests/common_grants/schemas/models/test_opp_timeline.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/models/test_opp_status.py",
-        "destination": "tests/common_grants/schemas/models/test_opp_status.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/models/test_opp_funding.py",
-        "destination": "tests/common_grants/schemas/models/test_opp_funding.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/filters/__init__.py",
-        "destination": "tests/common_grants/schemas/filters/__init__.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/filters/test_base.py",
-        "destination": "tests/common_grants/schemas/filters/test_base.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/filters/test_money_filters.py",
-        "destination": "tests/common_grants/schemas/filters/test_money_filters.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/filters/test_date_filters.py",
-        "destination": "tests/common_grants/schemas/filters/test_date_filters.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/filters/test_string_filters.py",
-        "destination": "tests/common_grants/schemas/filters/test_string_filters.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/fields/__init__.py",
-        "destination": "tests/common_grants/schemas/fields/__init__.py"
-      },
-      {
-        "path": "./fast-api/tests/common_grants/schemas/fields/test_fields.py",
-        "destination": "tests/common_grants/schemas/fields/test_fields.py"
-      },
-      {
         "path": "./fast-api/pyproject.toml",
         "destination": "pyproject.toml"
-      },
-      {
-        "path": "./fast-api/poetry.lock",
-        "destination": "poetry.lock"
       },
       {
         "path": "./fast-api/.gitignore",

--- a/website/src/content/docs/protocol/fields/custom-field.mdx
+++ b/website/src/content/docs/protocol/fields/custom-field.mdx
@@ -21,9 +21,9 @@ customField:
       endLine: 62
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 171
-      endLine: 193
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/custom.py"
+      startLine: 23
+      endLine: 45
 customFieldType:
   example:
     code: "string"
@@ -37,9 +37,9 @@ customFieldType:
       endLine: 15
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 160
-      endLine: 168
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/custom.py"
+      startLine: 12
+      endLine: 20
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/fields/event.mdx
+++ b/website/src/content/docs/protocol/fields/event.mdx
@@ -14,9 +14,9 @@ eventType:
       endLine: 26
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 65
-      endLine: 70
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/event.py"
+      startLine: 13
+      endLine: 18
 event:
   example:
     code: |
@@ -37,9 +37,9 @@ event:
       endLine: 42
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 156
-      endLine: 156
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/event.py"
+      startLine: 104
+      endLine: 104
 eventBase:
   example:
     code: |
@@ -58,9 +58,9 @@ eventBase:
       endLine: 59
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 74
-      endLine: 92
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/event.py"
+      startLine: 22
+      endLine: 38
 singleDateEvent:
   example:
     code: |
@@ -81,9 +81,9 @@ singleDateEvent:
       endLine: 77
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 94
-      endLine: 110
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/event.py"
+      startLine: 42
+      endLine: 56
 dateRangeEvent:
   example:
     code: |
@@ -105,9 +105,9 @@ dateRangeEvent:
       endLine: 101
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 112
-      endLine: 140
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/event.py"
+      startLine: 60
+      endLine: 86
 otherEvent:
   example:
     code: |
@@ -127,9 +127,9 @@ otherEvent:
       endLine: 119
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 142
-      endLine: 154
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/event.py"
+      startLine: 90
+      endLine: 100
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/fields/metadata.mdx
+++ b/website/src/content/docs/protocol/fields/metadata.mdx
@@ -18,9 +18,9 @@ systemMetadata:
       endLine: 30
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 197
-      endLine: 210
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/metadata.py"
+      startLine: 10
+      endLine: 22
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/fields/money.mdx
+++ b/website/src/content/docs/protocol/fields/money.mdx
@@ -18,9 +18,9 @@ money:
       endLine: 28
   python:
     file:
-      path: "lib/python-sdk/common_grants_sdk/schemas/fields.py"
-      startLine: 49
-      endLine: 61
+      path: "lib/python-sdk/common_grants_sdk/schemas/fields/money.py"
+      startLine: 10
+      endLine: 22
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/base.mdx
+++ b/website/src/content/docs/protocol/filters/base.mdx
@@ -18,9 +18,9 @@ defaultFilter:
       endLine: 83
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/base.py"
-      startLine: 55
-      endLine: 68
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/base.py"
+      startLine: 57
+      endLine: 70
 equivalenceOperators:
   example:
     code: '"eq"'
@@ -34,9 +34,9 @@ equivalenceOperators:
       endLine: 14
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/base.py"
-      startLine: 13
-      endLine: 17
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/base.py"
+      startLine: 15
+      endLine: 19
 comparisonOperators:
   example:
     code: '"gt"'
@@ -50,9 +50,9 @@ comparisonOperators:
       endLine: 29
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/base.py"
-      startLine: 20
-      endLine: 26
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/base.py"
+      startLine: 22
+      endLine: 28
 stringOperators:
   example:
     code: '"like"'
@@ -66,9 +66,9 @@ stringOperators:
       endLine: 47
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/base.py"
-      startLine: 36
-      endLine: 40
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/base.py"
+      startLine: 38
+      endLine: 42
 arrayOperators:
   example:
     code: '"in"'
@@ -82,9 +82,9 @@ arrayOperators:
       endLine: 38
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/base.py"
-      startLine: 29
-      endLine: 33
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/base.py"
+      startLine: 31
+      endLine: 35
 rangeOperators:
   example:
     code: '"between"'
@@ -98,9 +98,9 @@ rangeOperators:
       endLine: 56
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/base.py"
-      startLine: 43
-      endLine: 47
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/base.py"
+      startLine: 45
+      endLine: 49
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/date.mdx
+++ b/website/src/content/docs/protocol/filters/date.mdx
@@ -21,9 +21,9 @@ dateRangeFilter:
       endLine: 38
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/date_filters.py"
-      startLine: 18
-      endLine: 32
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/date.py"
+      startLine: 26
+      endLine: 33
 dateComparisonFilter:
   example:
     code: |
@@ -41,9 +41,9 @@ dateComparisonFilter:
       endLine: 18
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/date_filters.py"
-      startLine: 35
-      endLine: 42
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/date.py"
+      startLine: 36
+      endLine: 43
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/money.mdx
+++ b/website/src/content/docs/protocol/filters/money.mdx
@@ -27,9 +27,9 @@ moneyRangeFilter:
       endLine: 39
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/money_filters.py"
-      startLine: 42
-      endLine: 60
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/money.py"
+      startLine: 43
+      endLine: 50
 moneyComparisonFilter:
   example:
     code: |
@@ -50,9 +50,9 @@ moneyComparisonFilter:
       endLine: 18
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/money_filters.py"
-      startLine: 63
-      endLine: 70
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/money.py"
+      startLine: 64
+      endLine: 71
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/numeric.mdx
+++ b/website/src/content/docs/protocol/filters/numeric.mdx
@@ -16,6 +16,11 @@ numberComparisonFilter:
       path: "lib/core/lib/core/filters/numeric.tsp"
       startLine: 11
       endLine: 19
+  python:
+    file:
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/numeric.py"
+      startLine: 26
+      endLine: 35
 numberRangeFilter:
   example:
     code: |
@@ -34,6 +39,11 @@ numberRangeFilter:
       path: "lib/core/lib/core/filters/numeric.tsp"
       startLine: 25
       endLine: 36
+  python:
+    file:
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/numeric.py"
+      startLine: 38
+      endLine: 45
 numberArrayFilter:
   example:
     code: |
@@ -49,6 +59,11 @@ numberArrayFilter:
       path: "lib/core/lib/core/filters/numeric.tsp"
       startLine: 42
       endLine: 50
+  python:
+    file:
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/numeric.py"
+      startLine: 48
+      endLine: 57
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";
@@ -70,6 +85,7 @@ Filters by comparing a field to a numeric value.
   example={frontmatter.numberComparisonFilter.example}
   jsonSchema={frontmatter.numberComparisonFilter.jsonSchema}
   typeSpec={frontmatter.numberComparisonFilter.typeSpec}
+  python={frontmatter.numberComparisonFilter.python}
 />
 
 ## NumberRangeFilter
@@ -98,6 +114,7 @@ Filters by comparing a field to a range of numeric values.
   example={frontmatter.numberRangeFilter.example}
   jsonSchema={frontmatter.numberRangeFilter.jsonSchema}
   typeSpec={frontmatter.numberRangeFilter.typeSpec}
+  python={frontmatter.numberRangeFilter.python}
 />
 
 ## NumberArrayFilter
@@ -117,4 +134,5 @@ Filters by comparing a field to an array of numeric values.
   example={frontmatter.numberArrayFilter.example}
   jsonSchema={frontmatter.numberArrayFilter.jsonSchema}
   typeSpec={frontmatter.numberArrayFilter.typeSpec}
+  python={frontmatter.numberArrayFilter.python}
 />

--- a/website/src/content/docs/protocol/filters/string.mdx
+++ b/website/src/content/docs/protocol/filters/string.mdx
@@ -18,9 +18,9 @@ stringComparisonFilter:
       endLine: 17
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/string_filters.py"
-      startLine: 22
-      endLine: 29
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/string.py"
+      startLine: 23
+      endLine: 30
 stringArrayFilter:
   example:
     code: |
@@ -38,9 +38,9 @@ stringArrayFilter:
       endLine: 31
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/filters/string_filters.py"
-      startLine: 12
-      endLine: 19
+      path: "lib/python-sdk/common_grants_sdk/schemas/filters/string.py"
+      startLine: 13
+      endLine: 20
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/pagination.mdx
+++ b/website/src/content/docs/protocol/pagination.mdx
@@ -14,9 +14,9 @@ paginatedQueryParams:
       endLine: 22
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/pagination.py"
-      startLine: 10
-      endLine: 23
+      path: "lib/python-sdk/common_grants_sdk/schemas/pagination.py"
+      startLine: 28
+      endLine: 29
 paginatedBodyParams:
   example:
     code: |
@@ -34,9 +34,9 @@ paginatedBodyParams:
       endLine: 35
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/pagination.py"
-      startLine: 10
-      endLine: 23
+      path: "lib/python-sdk/common_grants_sdk/schemas/pagination.py"
+      startLine: 24
+      endLine: 25
 paginatedResultsInfo:
   example:
     code: |
@@ -56,9 +56,9 @@ paginatedResultsInfo:
       endLine: 56
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/pagination.py"
-      startLine: 10
-      endLine: 38
+      path: "lib/python-sdk/common_grants_sdk/schemas/pagination.py"
+      startLine: 32
+      endLine: 46
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/responses/error.mdx
+++ b/website/src/content/docs/protocol/responses/error.mdx
@@ -21,6 +21,11 @@ error:
       path: "lib/core/lib/core/responses/error.tsp"
       startLine: 15
       endLine: 27
+  python:
+    file:
+      path: "lib/python-sdk/common_grants_sdk/schemas/responses/error.py"
+      startLine: 10
+      endLine: 26
 applicationSubmissionError:
   example:
     code: |
@@ -66,6 +71,7 @@ Default response schema for 4xx and 5xx HTTP status codes.
   example={frontmatter.error.example}
   jsonSchema={frontmatter.error.jsonSchema}
   typeSpec={frontmatter.error.typeSpec}
+  python={frontmatter.error.python}
 />
 
 ### Usage

--- a/website/src/content/docs/protocol/responses/filtered.mdx
+++ b/website/src/content/docs/protocol/responses/filtered.mdx
@@ -75,9 +75,9 @@ filtered:
       endLine: 146
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/response.py"
-      startLine: 75
-      endLine: 93
+      path: "lib/python-sdk/common_grants_sdk/schemas/responses/success.py"
+      startLine: 57
+      endLine: 78
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/responses/paginated.mdx
+++ b/website/src/content/docs/protocol/responses/paginated.mdx
@@ -58,9 +58,9 @@ paginated:
       endLine: 79
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/pagination.py"
-      startLine: 45
-      endLine: 52
+      path: "lib/python-sdk/common_grants_sdk/schemas/responses/success.py"
+      startLine: 32
+      endLine: 42
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/responses/sorted.mdx
+++ b/website/src/content/docs/protocol/responses/sorted.mdx
@@ -65,9 +65,9 @@ sorted:
       endLine: 107
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/response.py"
-      startLine: 75
-      endLine: 88
+      path: "lib/python-sdk/common_grants_sdk/schemas/responses/success.py"
+      startLine: 45
+      endLine: 54
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/responses/success.mdx
+++ b/website/src/content/docs/protocol/responses/success.mdx
@@ -24,9 +24,9 @@ success:
       endLine: 17
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/response.py"
-      startLine: 13
-      endLine: 25
+      path: "lib/python-sdk/common_grants_sdk/schemas/responses/success.py"
+      startLine: 17
+      endLine: 29
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/sorting.mdx
+++ b/website/src/content/docs/protocol/sorting.mdx
@@ -14,9 +14,9 @@ sortOrder:
       endLine: 24
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/sorting.py"
-      startLine: 32
-      endLine: 36
+      path: "lib/python-sdk/common_grants_sdk/schemas/sorting.py"
+      startLine: 9
+      endLine: 13
 sortQueryParams:
   example:
     code: "/common-grants/opportunities?sortBy=lastModifiedAt&sortOrder=asc"
@@ -30,9 +30,9 @@ sortQueryParams:
       endLine: 42
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/sorting.py"
-      startLine: 24
-      endLine: 41
+      path: "lib/python-sdk/common_grants_sdk/schemas/sorting.py"
+      startLine: 35
+      endLine: 43
 sortBodyParams:
   example:
     code: |
@@ -50,9 +50,9 @@ sortBodyParams:
       endLine: 57
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/sorting.py"
-      startLine: 24
-      endLine: 41
+      path: "lib/python-sdk/common_grants_sdk/schemas/sorting.py"
+      startLine: 46
+      endLine: 54
 sortedResultsInfo:
   example:
     code: |
@@ -71,9 +71,9 @@ sortedResultsInfo:
       endLine: 75
   python:
     file:
-      path: "templates/fast-api/src/common_grants/schemas/response.py"
-      startLine: 28
-      endLine: 50
+      path: "lib/python-sdk/common_grants_sdk/schemas/sorting.py"
+      startLine: 57
+      endLine: 69
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";


### PR DESCRIPTION
### Summary

- Fixes #271 
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

This PR does the following:
- Update dependency in FastAPI template `pyproject.toml` to use PySDK published version 0.2.0 instead of local dev version
- Update FastAPI template `template.json` to remove dead code refs and update remaining refs for accuracy
- Update python sections in Website *.mdx docs to use paths and line numbers of schema implementations that have been migrated from FastAPI template to PySDK

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
