### PR TITLE
[FastAPI template] Bugfix to avoid namespace collisions

### DIFF
--- a/templates/fast-api/src/common_grants/services/utils.py
+++ b/templates/fast-api/src/common_grants/services/utils.py
@@ -12,8 +12,8 @@ from common_grants.schemas import (
     OppStatusOptions,
 )
 
-# note: derivative implementations should set NAMESPACE to a non-nil UUID 
-NAMESPACE = UUID("00000000-0000-0000-0000-000000000000") 
+# note: derivative implementations should set NAMESPACE to a non-nil UUID
+NAMESPACE = UUID("00000000-0000-0000-0000-000000000000")
 
 
 def build_applied_filters(filters: OppFilters) -> dict[str, Any]:


### PR DESCRIPTION
### Summary

- Fixes #[issue number]
- Time to review: 1 minute

### Changes proposed
> What was added, updated, or removed in this PR.

The service layer in FastAPI template defines a namespace, and that namespace gets duplicated into APIs that are bootstrapped from the template (e.g. the California API example and the upcoming Pennsylvania API example). This PR simply changes the namespace in FastAPI template to a value that obviously must be changed in bootstrapped APIs, to avoid potential for collisions. 

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
