### PR TITLE
[Issue #171] Validate form library mappings

### DIFF
--- a/website/.prettierrc
+++ b/website/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "trailingComma": "all",
+  "tabWidth": 2
+}

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -17,6 +17,7 @@
         "@jsonforms/vanilla-renderers": "^3.5.1",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
+        "ajv": "^8.17.1",
         "astro": "^5.5.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@types/ajv": "^0.0.5",
         "@types/swagger-ui-react": "^5.18.0",
         "cspell": "^8.17.1",
         "eslint": "^9.17.0",
@@ -4101,6 +4103,13 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/@types/ajv": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@types/ajv/-/ajv-0.0.5.tgz",
+      "integrity": "sha512-0UD98SZLwPk6cTMZoLs8W4XSAWgqT9nyoZiBw+uXEPf1u5h+Dn2ztMG4Is9pDA+9D7GKbCTfIkQK/hNgoWVQcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -4866,6 +4875,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,15 +19,18 @@
         "@types/react-dom": "^18.3.0",
         "ajv": "^8.17.1",
         "astro": "^5.5.6",
+        "js-yaml": "^4.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sharp": "^0.32.5",
         "swagger-ui-react": "^5.20.2",
+        "tsx": "^4.20.3",
         "typescript": "^5.7.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
         "@types/ajv": "^0.0.5",
+        "@types/js-yaml": "^4.0.9",
         "@types/swagger-ui-react": "^5.18.0",
         "cspell": "^8.17.1",
         "eslint": "^9.17.0",
@@ -50,24 +53,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "11.7.2",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
-      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.15",
-        "js-yaml": "^4.1.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@apidevtools/openapi-schemas": {
@@ -104,6 +89,24 @@
       },
       "peerDependencies": {
         "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.7.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.7.2.tgz",
+      "integrity": "sha512-4gY54eEGEstClvEkGnwVkTkrx0sqwemEFG5OSRRn3tD91XH0+Q8XIkYIfo7IwEWPpJZwILb9GUXeShtplRc/eA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@astrojs/check": {
@@ -4185,7 +4188,8 @@
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -7605,6 +7609,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -8543,6 +8559,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -11556,6 +11573,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/ret": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
@@ -12491,6 +12517,25 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "@jsonforms/vanilla-renderers": "^3.5.1",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
+    "ajv": "^8.17.1",
     "astro": "^5.5.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -43,6 +44,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@types/ajv": "^0.0.5",
     "@types/swagger-ui-react": "^5.18.0",
     "cspell": "^8.17.1",
     "eslint": "^9.17.0",

--- a/website/package.json
+++ b/website/package.json
@@ -22,7 +22,8 @@
     "checks": "npm run check:lint && npm run check:format && npm run check:astro && npm run check:spelling",
     "audit:moderate": "npm audit --audit-level=moderate",
     "audit:high": "npm audit --audit-level=high",
-    "audit:critical": "npm audit --audit-level=critical"
+    "audit:critical": "npm audit --audit-level=critical",
+    "validate:schemas": "tsx src/scripts/validate-schemas.ts"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",

--- a/website/package.json
+++ b/website/package.json
@@ -37,15 +37,18 @@
     "@types/react-dom": "^18.3.0",
     "ajv": "^8.17.1",
     "astro": "^5.5.6",
+    "js-yaml": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sharp": "^0.32.5",
     "swagger-ui-react": "^5.20.2",
+    "tsx": "^4.20.3",
     "typescript": "^5.7.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@types/ajv": "^0.0.5",
+    "@types/js-yaml": "^4.0.9",
     "@types/swagger-ui-react": "^5.18.0",
     "cspell": "^8.17.1",
     "eslint": "^9.17.0",

--- a/website/public/schemas/yaml/Address.yaml
+++ b/website/public/schemas/yaml/Address.yaml
@@ -35,6 +35,8 @@ required:
   - stateOrProvince
   - country
   - postalCode
+unevaluatedProperties:
+  not: {}
 examples:
   - street1: 123 Main St
     city: Anytown

--- a/website/public/schemas/yaml/AddressCollection.yaml
+++ b/website/public/schemas/yaml/AddressCollection.yaml
@@ -10,6 +10,8 @@ properties:
     description: Additional addresses keyed by a descriptive label (e.g., "work", "home", "international").
 required:
   - primary
+unevaluatedProperties:
+  not: {}
 examples:
   - primary:
       street1: 456 Main St

--- a/website/public/schemas/yaml/AppFormResponse.yaml
+++ b/website/public/schemas/yaml/AppFormResponse.yaml
@@ -40,6 +40,8 @@ required:
   - status
   - createdAt
   - lastModifiedAt
+unevaluatedProperties:
+  not: {}
 examples:
   - applicationId: 123e4567-e89b-12d3-a456-426614174000
     id: 123e4567-e89b-12d3-a456-426614174000

--- a/website/public/schemas/yaml/AppStatus.yaml
+++ b/website/public/schemas/yaml/AppStatus.yaml
@@ -13,6 +13,8 @@ properties:
     description: A human-readable description of the status
 required:
   - value
+unevaluatedProperties:
+  not: {}
 examples:
   - value: submitted
     description: The application has been submitted.

--- a/website/public/schemas/yaml/ApplicantType.yaml
+++ b/website/public/schemas/yaml/ApplicantType.yaml
@@ -13,6 +13,8 @@ properties:
     description: The description of the applicant type
 required:
   - value
+unevaluatedProperties:
+  not: {}
 examples:
   - value: individual
     description: An individual applicant

--- a/website/public/schemas/yaml/ApplicationBase.yaml
+++ b/website/public/schemas/yaml/ApplicationBase.yaml
@@ -46,6 +46,8 @@ required:
   - status
   - createdAt
   - lastModifiedAt
+unevaluatedProperties:
+  not: {}
 examples:
   - id: 123e4567-e89b-12d3-a456-426614174000
     name: My Application

--- a/website/public/schemas/yaml/ApplicationSubmissionError.yaml
+++ b/website/public/schemas/yaml/ApplicationSubmissionError.yaml
@@ -11,6 +11,8 @@ required:
   - status
 allOf:
   - $ref: Error.yaml
+unevaluatedProperties:
+  not: {}
 examples:
   - status: 400
     message: Application submission failed due to validation errors

--- a/website/public/schemas/yaml/CompetitionBase.yaml
+++ b/website/public/schemas/yaml/CompetitionBase.yaml
@@ -54,6 +54,8 @@ required:
   - forms
   - createdAt
   - lastModifiedAt
+unevaluatedProperties:
+  not: {}
 examples:
   - id: b7c1e2f4-8a3d-4e2a-9c5b-1f2e3d4c5b6a
     opportunityId: b7c1e2f4-8a3d-4e2a-9c5b-1f2e3d4c5b6b

--- a/website/public/schemas/yaml/CompetitionForms.yaml
+++ b/website/public/schemas/yaml/CompetitionForms.yaml
@@ -10,6 +10,8 @@ properties:
     description: The validation rules for the competition forms
 required:
   - forms
+unevaluatedProperties:
+  not: {}
 examples:
   - forms:
       formA:

--- a/website/public/schemas/yaml/CompetitionStatus.yaml
+++ b/website/public/schemas/yaml/CompetitionStatus.yaml
@@ -13,6 +13,8 @@ properties:
     description: A human-readable description of the status
 required:
   - value
+unevaluatedProperties:
+  not: {}
 examples:
   - value: open
     customValue: custom

--- a/website/public/schemas/yaml/CompetitionTimeline.yaml
+++ b/website/public/schemas/yaml/CompetitionTimeline.yaml
@@ -11,6 +11,8 @@ properties:
   otherDates:
     $ref: "#/$defs/RecordEvent"
     description: The date the competition was created
+unevaluatedProperties:
+  not: {}
 examples:
   - openDate:
       name: Open Date

--- a/website/public/schemas/yaml/CustomField.yaml
+++ b/website/public/schemas/yaml/CustomField.yaml
@@ -21,6 +21,8 @@ required:
   - name
   - fieldType
   - value
+unevaluatedProperties:
+  not: {}
 examples:
   - name: eligibilityType
     fieldType: array

--- a/website/public/schemas/yaml/DateComparisonFilter.yaml
+++ b/website/public/schemas/yaml/DateComparisonFilter.yaml
@@ -18,4 +18,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to a date value

--- a/website/public/schemas/yaml/DateRangeEvent.yaml
+++ b/website/public/schemas/yaml/DateRangeEvent.yaml
@@ -24,6 +24,8 @@ required:
   - endDate
 allOf:
   - $ref: EventBase.yaml
+unevaluatedProperties:
+  not: {}
 examples:
   - name: Application period
     eventType: dateRange

--- a/website/public/schemas/yaml/DateRangeFilter.yaml
+++ b/website/public/schemas/yaml/DateRangeFilter.yaml
@@ -25,6 +25,8 @@ properties:
     required:
       - min
       - max
+    unevaluatedProperties:
+      not: {}
     examples:
       - min: 2021-01-01
         max: 2021-01-02
@@ -32,4 +34,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to a range of date values

--- a/website/public/schemas/yaml/DefaultFilter.yaml
+++ b/website/public/schemas/yaml/DefaultFilter.yaml
@@ -16,4 +16,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: A base filter model that can be used to create more specific filter models

--- a/website/public/schemas/yaml/EmailCollection.yaml
+++ b/website/public/schemas/yaml/EmailCollection.yaml
@@ -10,6 +10,8 @@ properties:
     description: Additional email addresses keyed by a descriptive label (e.g., "work", "personal", "support").
 required:
   - primary
+unevaluatedProperties:
+  not: {}
 examples:
   - primary: john.doe@example.com
     otherEmails:

--- a/website/public/schemas/yaml/File.yaml
+++ b/website/public/schemas/yaml/File.yaml
@@ -31,6 +31,8 @@ required:
   - name
   - createdAt
   - lastModifiedAt
+unevaluatedProperties:
+  not: {}
 examples:
   - downloadUrl: https://example.com/file.pdf
     name: example.pdf

--- a/website/public/schemas/yaml/Form.yaml
+++ b/website/public/schemas/yaml/Form.yaml
@@ -36,6 +36,8 @@ properties:
 required:
   - id
   - name
+unevaluatedProperties:
+  not: {}
 examples:
   - id: b7c1e2f4-8a3d-4e2a-9c5b-1f2e3d4c5b6a
     name: Form A

--- a/website/public/schemas/yaml/FormResponseBase.yaml
+++ b/website/public/schemas/yaml/FormResponseBase.yaml
@@ -36,6 +36,8 @@ required:
   - status
   - createdAt
   - lastModifiedAt
+unevaluatedProperties:
+  not: {}
 examples:
   - id: 123e4567-e89b-12d3-a456-426614174000
     formId: 123e4567-e89b-12d3-a456-426614174000

--- a/website/public/schemas/yaml/FormResponseStatus.yaml
+++ b/website/public/schemas/yaml/FormResponseStatus.yaml
@@ -13,6 +13,8 @@ properties:
     description: A human-readable description of the status
 required:
   - value
+unevaluatedProperties:
+  not: {}
 examples:
   - value: inProgress
     description: The form response is in progress

--- a/website/public/schemas/yaml/MappingConstantFunction.yaml
+++ b/website/public/schemas/yaml/MappingConstantFunction.yaml
@@ -5,6 +5,8 @@ properties:
   const: {}
 required:
   - const
+unevaluatedProperties:
+  not: {}
 examples:
   - const: "123"
 description: Returns a constant value.

--- a/website/public/schemas/yaml/MappingFieldFunction.yaml
+++ b/website/public/schemas/yaml/MappingFieldFunction.yaml
@@ -6,6 +6,8 @@ properties:
     type: string
 required:
   - field
+unevaluatedProperties:
+  not: {}
 examples:
   - field: summary.opportunity_amount
 description: Returns the value of a field in the source data.

--- a/website/public/schemas/yaml/MappingSwitchFunction.yaml
+++ b/website/public/schemas/yaml/MappingSwitchFunction.yaml
@@ -16,8 +16,12 @@ properties:
     required:
       - field
       - case
+    unevaluatedProperties:
+      not: {}
 required:
   - switch
+unevaluatedProperties:
+  not: {}
 examples:
   - switch:
       field: summary.opportunity_status

--- a/website/public/schemas/yaml/Money.yaml
+++ b/website/public/schemas/yaml/Money.yaml
@@ -11,6 +11,8 @@ properties:
 required:
   - amount
   - currency
+unevaluatedProperties:
+  not: {}
 examples:
   - amount: "-50.50"
     currency: USD

--- a/website/public/schemas/yaml/MoneyComparisonFilter.yaml
+++ b/website/public/schemas/yaml/MoneyComparisonFilter.yaml
@@ -14,4 +14,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to a monetary value

--- a/website/public/schemas/yaml/MoneyRangeFilter.yaml
+++ b/website/public/schemas/yaml/MoneyRangeFilter.yaml
@@ -15,6 +15,8 @@ properties:
     required:
       - min
       - max
+    unevaluatedProperties:
+      not: {}
     examples:
       - min:
           amount: "1000"
@@ -26,4 +28,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to a range of monetary values

--- a/website/public/schemas/yaml/Name.yaml
+++ b/website/public/schemas/yaml/Name.yaml
@@ -20,6 +20,8 @@ properties:
 required:
   - firstName
   - lastName
+unevaluatedProperties:
+  not: {}
 examples:
   - prefix: Dr.
     firstName: Jane

--- a/website/public/schemas/yaml/NumberArrayFilter.yaml
+++ b/website/public/schemas/yaml/NumberArrayFilter.yaml
@@ -17,4 +17,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to an array of numeric values

--- a/website/public/schemas/yaml/NumberComparisonFilter.yaml
+++ b/website/public/schemas/yaml/NumberComparisonFilter.yaml
@@ -13,4 +13,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to a numeric value

--- a/website/public/schemas/yaml/NumberRangeFilter.yaml
+++ b/website/public/schemas/yaml/NumberRangeFilter.yaml
@@ -15,6 +15,8 @@ properties:
     required:
       - min
       - max
+    unevaluatedProperties:
+      not: {}
     examples:
       - min: 1000
         max: 10000
@@ -22,4 +24,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to a numeric range

--- a/website/public/schemas/yaml/OppDefaultFilters.yaml
+++ b/website/public/schemas/yaml/OppDefaultFilters.yaml
@@ -68,6 +68,8 @@ properties:
       be excluded from the search.
 allOf:
   - $ref: "#/$defs/RecordDefaultFilter"
+unevaluatedProperties:
+  not: {}
 description: The standard set of filters supported for opportunity searches
 $defs:
   RecordDefaultFilter:

--- a/website/public/schemas/yaml/OppFilters.yaml
+++ b/website/public/schemas/yaml/OppFilters.yaml
@@ -69,6 +69,8 @@ properties:
   customFilters:
     $ref: "#/$defs/RecordDefaultFilter"
     description: Additional implementation-defined filters to apply to the search
+unevaluatedProperties:
+  not: {}
 description: Filters to apply when searching for opportunities
 $defs:
   RecordDefaultFilter:

--- a/website/public/schemas/yaml/OppFunding.yaml
+++ b/website/public/schemas/yaml/OppFunding.yaml
@@ -23,6 +23,8 @@ properties:
   estimatedAwardCount:
     type: integer
     description: Estimated number of awards that will be granted
+unevaluatedProperties:
+  not: {}
 examples:
   - totalAmountAvailable:
       amount: "1000000.00"

--- a/website/public/schemas/yaml/OppSorting.yaml
+++ b/website/public/schemas/yaml/OppSorting.yaml
@@ -11,3 +11,5 @@ required:
   - sortBy
 allOf:
   - $ref: SortBodyParams.yaml
+unevaluatedProperties:
+  not: {}

--- a/website/public/schemas/yaml/OppStatus.yaml
+++ b/website/public/schemas/yaml/OppStatus.yaml
@@ -13,6 +13,8 @@ properties:
     description: A human-readable description of the status
 required:
   - value
+unevaluatedProperties:
+  not: {}
 examples:
   - value: open
     description: The opportunity is currently accepting applications

--- a/website/public/schemas/yaml/OppTimeline.yaml
+++ b/website/public/schemas/yaml/OppTimeline.yaml
@@ -14,6 +14,8 @@ properties:
       An optional map of other key dates or events in the opportunity timeline
 
       Examples might include a deadline for questions, anticipated award date, etc.
+unevaluatedProperties:
+  not: {}
 examples:
   - postDate:
       name: Application posted date

--- a/website/public/schemas/yaml/OpportunityDetails.yaml
+++ b/website/public/schemas/yaml/OpportunityDetails.yaml
@@ -9,4 +9,6 @@ properties:
     description: The competitions associated with the opportunity
 allOf:
   - $ref: OpportunityBase.yaml
+unevaluatedProperties:
+  not: {}
 description: A funding opportunity with additional details, like available competitions.

--- a/website/public/schemas/yaml/OrgSocialLinks.yaml
+++ b/website/public/schemas/yaml/OrgSocialLinks.yaml
@@ -29,6 +29,8 @@ properties:
   otherSocials:
     $ref: "#/$defs/RecordUrl"
     description: Additional social media profiles not covered by the standard fields.
+unevaluatedProperties:
+  not: {}
 examples:
   - website: https://www.example.com
     facebook: https://www.facebook.com/example

--- a/website/public/schemas/yaml/OrganizationBase.yaml
+++ b/website/public/schemas/yaml/OrganizationBase.yaml
@@ -44,6 +44,8 @@ properties:
 required:
   - id
   - name
+unevaluatedProperties:
+  not: {}
 examples:
   - id: 083b4567-e89d-42c8-a439-6c1234567890
     name: Example Organization

--- a/website/public/schemas/yaml/OtherEvent.yaml
+++ b/website/public/schemas/yaml/OtherEvent.yaml
@@ -18,6 +18,8 @@ required:
   - eventType
 allOf:
   - $ref: EventBase.yaml
+unevaluatedProperties:
+  not: {}
 examples:
   - name: Info sessions
     eventType: other

--- a/website/public/schemas/yaml/PCSOrgType.yaml
+++ b/website/public/schemas/yaml/PCSOrgType.yaml
@@ -10,6 +10,8 @@ required:
   - class
 allOf:
   - $ref: PCSTerm.yaml
+unevaluatedProperties:
+  not: {}
 description: |-
   A Philanthropy Classification System (PCS) term for organization types.
 

--- a/website/public/schemas/yaml/PCSPopulation.yaml
+++ b/website/public/schemas/yaml/PCSPopulation.yaml
@@ -10,6 +10,8 @@ required:
   - class
 allOf:
   - $ref: PCSTerm.yaml
+unevaluatedProperties:
+  not: {}
 description: |-
   A Philanthropy Classification System (PCS) term for populations served.
 

--- a/website/public/schemas/yaml/PCSSubject.yaml
+++ b/website/public/schemas/yaml/PCSSubject.yaml
@@ -10,6 +10,8 @@ required:
   - class
 allOf:
   - $ref: PCSTerm.yaml
+unevaluatedProperties:
+  not: {}
 description: |-
   A Philanthropy Classification System (PCS) term for the subject of the grant.
 

--- a/website/public/schemas/yaml/PCSSupportStrategy.yaml
+++ b/website/public/schemas/yaml/PCSSupportStrategy.yaml
@@ -10,6 +10,8 @@ required:
   - class
 allOf:
   - $ref: PCSTerm.yaml
+unevaluatedProperties:
+  not: {}
 description: |-
   A Philanthropy Classification System (PCS) term for support strategies.
 

--- a/website/public/schemas/yaml/PCSTransactionType.yaml
+++ b/website/public/schemas/yaml/PCSTransactionType.yaml
@@ -10,6 +10,8 @@ required:
   - class
 allOf:
   - $ref: PCSTerm.yaml
+unevaluatedProperties:
+  not: {}
 description: |-
   A Philanthropy Classification System (PCS) term for transaction types.
 

--- a/website/public/schemas/yaml/PaginatedBodyParams.yaml
+++ b/website/public/schemas/yaml/PaginatedBodyParams.yaml
@@ -14,4 +14,6 @@ properties:
     maximum: 2147483647
     default: 100
     description: The number of items to return per page
+unevaluatedProperties:
+  not: {}
 description: Body parameters for paginated routes

--- a/website/public/schemas/yaml/PaginatedQueryParams.yaml
+++ b/website/public/schemas/yaml/PaginatedQueryParams.yaml
@@ -14,4 +14,6 @@ properties:
     maximum: 2147483647
     default: 100
     description: The number of items to return per page
+unevaluatedProperties:
+  not: {}
 description: Query parameters for paginated routes

--- a/website/public/schemas/yaml/PaginatedResultsInfo.yaml
+++ b/website/public/schemas/yaml/PaginatedResultsInfo.yaml
@@ -28,4 +28,6 @@ properties:
 required:
   - page
   - pageSize
+unevaluatedProperties:
+  not: {}
 description: Details about the paginated results

--- a/website/public/schemas/yaml/PersonBase.yaml
+++ b/website/public/schemas/yaml/PersonBase.yaml
@@ -25,6 +25,8 @@ properties:
     description: Custom fields for the person.
 required:
   - name
+unevaluatedProperties:
+  not: {}
 examples:
   - name:
       prefix: Dr.

--- a/website/public/schemas/yaml/Phone.yaml
+++ b/website/public/schemas/yaml/Phone.yaml
@@ -19,6 +19,8 @@ properties:
 required:
   - countryCode
   - number
+unevaluatedProperties:
+  not: {}
 examples:
   - countryCode: "+1"
     number: 555-123-4567

--- a/website/public/schemas/yaml/PhoneCollection.yaml
+++ b/website/public/schemas/yaml/PhoneCollection.yaml
@@ -13,6 +13,8 @@ properties:
     description: Additional phone numbers not covered by the standard fields.
 required:
   - primary
+unevaluatedProperties:
+  not: {}
 examples:
   - primary:
       countryCode: "+1"

--- a/website/public/schemas/yaml/ProjectTimeline.yaml
+++ b/website/public/schemas/yaml/ProjectTimeline.yaml
@@ -14,6 +14,8 @@ properties:
   timelineDetails:
     type: string
     description: Details about the timeline that don't fit into the other fields.
+unevaluatedProperties:
+  not: {}
 $defs:
   RecordEvent:
     type: object

--- a/website/public/schemas/yaml/ProposalBase.yaml
+++ b/website/public/schemas/yaml/ProposalBase.yaml
@@ -26,6 +26,8 @@ properties:
   customFields:
     $ref: "#/$defs/RecordCustomField"
     description: The project's custom fields.
+unevaluatedProperties:
+  not: {}
 examples:
   - title: Example Project
     description: Example project to serve community needs.

--- a/website/public/schemas/yaml/ProposalContacts.yaml
+++ b/website/public/schemas/yaml/ProposalContacts.yaml
@@ -10,6 +10,8 @@ properties:
     description: Other points of contact for the proposal. For example, key personnel, authorized representatives, etc.
 required:
   - primary
+unevaluatedProperties:
+  not: {}
 $defs:
   RecordPersonBase:
     type: object

--- a/website/public/schemas/yaml/ProposalOpportunity.yaml
+++ b/website/public/schemas/yaml/ProposalOpportunity.yaml
@@ -13,6 +13,8 @@ properties:
     description: The opportunity's custom fields.
 required:
   - id
+unevaluatedProperties:
+  not: {}
 description: The opportunity to which this proposal is related
 $defs:
   RecordCustomField:

--- a/website/public/schemas/yaml/ProposalOrgs.yaml
+++ b/website/public/schemas/yaml/ProposalOrgs.yaml
@@ -10,6 +10,8 @@ properties:
     description: Other organizations that are supporting the proposal. For example, a fiscal sponsor, partners, etc.
 required:
   - primary
+unevaluatedProperties:
+  not: {}
 $defs:
   RecordOrganizationBase:
     type: object

--- a/website/public/schemas/yaml/SingleDateEvent.yaml
+++ b/website/public/schemas/yaml/SingleDateEvent.yaml
@@ -17,6 +17,8 @@ required:
   - date
 allOf:
   - $ref: EventBase.yaml
+unevaluatedProperties:
+  not: {}
 examples:
   - name: Opportunity close date
     eventType: singleDate

--- a/website/public/schemas/yaml/SortQueryParams.yaml
+++ b/website/public/schemas/yaml/SortQueryParams.yaml
@@ -18,4 +18,6 @@ properties:
     description: The order to sort by
 required:
   - sortBy
+unevaluatedProperties:
+  not: {}
 description: Query parameters for sorting

--- a/website/public/schemas/yaml/SortedResultsInfo.yaml
+++ b/website/public/schemas/yaml/SortedResultsInfo.yaml
@@ -25,4 +25,6 @@ properties:
 required:
   - sortBy
   - sortOrder
+unevaluatedProperties:
+  not: {}
 description: Information about the sort order of the items returned

--- a/website/public/schemas/yaml/StringArrayFilter.yaml
+++ b/website/public/schemas/yaml/StringArrayFilter.yaml
@@ -16,4 +16,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: Filters by comparing a field to an array of string values

--- a/website/public/schemas/yaml/StringComparisonFilter.yaml
+++ b/website/public/schemas/yaml/StringComparisonFilter.yaml
@@ -15,4 +15,6 @@ properties:
 required:
   - operator
   - value
+unevaluatedProperties:
+  not: {}
 description: A filter that applies a comparison to a string value

--- a/website/public/schemas/yaml/Success.yaml
+++ b/website/public/schemas/yaml/Success.yaml
@@ -15,3 +15,5 @@ properties:
 required:
   - status
   - message
+unevaluatedProperties:
+  not: {}

--- a/website/public/schemas/yaml/SystemMetadata.yaml
+++ b/website/public/schemas/yaml/SystemMetadata.yaml
@@ -13,6 +13,8 @@ properties:
 required:
   - createdAt
   - lastModifiedAt
+unevaluatedProperties:
+  not: {}
 examples:
   - createdAt: 2025-01-01T17:01:01
     lastModifiedAt: 2025-01-02T17:30:00

--- a/website/src/components/forms/playground/index.tsx
+++ b/website/src/components/forms/playground/index.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useMemo, useEffect } from "react";
 
 // Internal utilities
 import type { FormData, TransformOutput } from "@/lib/types";
-import { mapJson } from "@/lib/transformation";
+import { transformWithMapping } from "@/lib/transformation";
 import { schemas } from "@/lib/schemas";
 
 // Components
@@ -41,6 +41,45 @@ const getValidSchemaId = (id: string | null, fallbackId: string): string => {
   }
   return id;
 };
+
+/**
+ * Maps JSON data from one form schema to another using the common data format as an intermediary.
+ *
+ * @param data - The source form data
+ * @param sourceId - The ID of the source form schema
+ * @param targetId - The ID of the target form schema
+ * @returns A TransformOutput object containing the transformation results
+ */
+function mapJson(
+  data: FormData,
+  sourceId: string,
+  targetId: string,
+): TransformOutput {
+  const sourceSchema = schemas[sourceId];
+  const targetSchema = schemas[targetId];
+
+  if (!sourceSchema || !targetSchema) {
+    throw new Error("Source or target schema not found");
+  }
+
+  const commonData = transformWithMapping(
+    data,
+    sourceSchema.mappingToCommon as FormData,
+  );
+
+  const targetData = transformWithMapping(
+    commonData,
+    targetSchema.mappingFromCommon as FormData,
+  );
+
+  return {
+    timestamp: Date.now(),
+    source: sourceId,
+    target: targetId,
+    commonData,
+    targetData,
+  };
+}
 
 export default function FormMappingPlayground() {
   // #########################################################

--- a/website/src/content/forms/formA/json-schema.json
+++ b/website/src/content/forms/formA/json-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "applicantName": {

--- a/website/src/content/forms/formB/json-schema.json
+++ b/website/src/content/forms/formB/json-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "project_name": { "type": "string", "title": "Research Project Name" },

--- a/website/src/content/forms/formC/json-schema.json
+++ b/website/src/content/forms/formC/json-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "projectTitle": { "type": "string", "title": "Project Title" },

--- a/website/src/content/forms/formD/json-schema.json
+++ b/website/src/content/forms/formD/json-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
     "projectDetails": {

--- a/website/src/content/forms/key-contact/json-schema.json
+++ b/website/src/content/forms/key-contact/json-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "title": "Key Contact Form (FID 683)",
   "description": "JSON schema for Grants.gov Key Contact form fields",

--- a/website/src/content/forms/sf424-mandatory/json-schema.json
+++ b/website/src/content/forms/sf424-mandatory/json-schema.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "SF424 Mandatory Form",
   "description": "Standard Form 424 - Application for Federal Assistance (Mandatory Fields)",
   "type": "object",

--- a/website/src/lib/schemas.ts
+++ b/website/src/lib/schemas.ts
@@ -1,7 +1,6 @@
 import type { VerticalLayout, JsonSchema } from "@jsonforms/core";
 import type { FormSchemaMap, FormSchema, FormData, JsonValue } from "./types";
 import formsIndex from "@/content/forms/index.json";
-import { validateCommonGrantsMappings } from "./validation";
 
 // Import all form files using Vite's glob pattern
 // Implementation Notes:
@@ -126,15 +125,6 @@ function loadFormDataWithGlob(formId: string, formLabel: string): FormSchema {
   if (!schema || !ui || !mappingTo || !mappingFrom || !defaultData) {
     throw new Error(`Missing required files for form ${formId}`);
   }
-
-  // Validate the mappings between the form and the CommonGrants data model
-  validateCommonGrantsMappings({
-    formId,
-    formSchema: schema.default,
-    mappingToCommon: mappingTo.default,
-    mappingFromCommon: mappingFrom.default,
-    defaultData: defaultData.default,
-  });
 
   // Get metadata from forms index
   const formInfo = formsIndex.find((form) => form.id === formId);

--- a/website/src/lib/transformation.ts
+++ b/website/src/lib/transformation.ts
@@ -1,5 +1,4 @@
-import type { JsonValue, FormData, TransformOutput } from "./types";
-import { schemas } from "./schemas";
+import type { JsonValue } from "./types";
 
 /**
  * This module provides a utility function for transforming data using a mapping.
@@ -207,43 +206,4 @@ export function transformWithMapping(
 
   // Recursively walk the mapping until all nested transformations are applied
   return transformNode(mapping, depth) as Record<string, JsonValue>;
-}
-
-/**
- * Maps JSON data from one form schema to another using the common data format as an intermediary.
- *
- * @param data - The source form data
- * @param sourceId - The ID of the source form schema
- * @param targetId - The ID of the target form schema
- * @returns A TransformOutput object containing the transformation results
- */
-export function mapJson(
-  data: FormData,
-  sourceId: string,
-  targetId: string,
-): TransformOutput {
-  const sourceSchema = schemas[sourceId];
-  const targetSchema = schemas[targetId];
-
-  if (!sourceSchema || !targetSchema) {
-    throw new Error("Source or target schema not found");
-  }
-
-  const commonData = transformWithMapping(
-    data,
-    sourceSchema.mappingToCommon as FormData,
-  );
-
-  const targetData = transformWithMapping(
-    commonData,
-    targetSchema.mappingFromCommon as FormData,
-  );
-
-  return {
-    timestamp: Date.now(),
-    source: sourceId,
-    target: targetId,
-    commonData,
-    targetData,
-  };
 }

--- a/website/src/lib/validation.ts
+++ b/website/src/lib/validation.ts
@@ -1,0 +1,128 @@
+import type { JsonValue } from "./types";
+import type { JsonSchema } from "@jsonforms/core";
+import { transformWithMapping } from "./transformation";
+import Ajv from "ajv";
+
+/**
+ * Validation error details
+ */
+interface ValidationError {
+  path: string;
+  message: string;
+  value?: unknown;
+}
+
+/**
+ * Validation result containing success status and any errors
+ */
+interface ValidationResult {
+  isValid: boolean;
+  errors: ValidationError[];
+}
+
+interface CommonGrantsValidationProps {
+  formId: string;
+  formSchema: JsonSchema;
+  mappingToCommon: Record<string, JsonValue>;
+  mappingFromCommon: Record<string, JsonValue>;
+  defaultData: Record<string, JsonValue>;
+}
+
+// Create an Ajv instance with common options
+const ajv = new Ajv({
+  allErrors: true, // Return all errors, not just the first one
+  verbose: true, // Include more detailed error information
+  strict: false, // Allow additional properties not in schema
+});
+
+/**
+ * Validates data against a JSON schema using Ajv
+ */
+function validateAgainstSchema(
+  data: unknown,
+  schema: JsonSchema
+): ValidationResult {
+  try {
+    const validate = ajv.compile(schema);
+    const isValid = validate(data);
+
+    if (isValid) {
+      return {
+        isValid: true,
+        errors: [],
+      };
+    }
+
+    // Convert Ajv errors to our ValidationError format
+    const errors: ValidationError[] = (validate.errors || []).map((error) => ({
+      path: error.instancePath || error.schemaPath || "",
+      message: error.message || "Validation failed",
+      value: error.data,
+    }));
+
+    return {
+      isValid: false,
+      errors,
+    };
+  } catch (error) {
+    // If Ajv compilation fails, return a validation error
+    return {
+      isValid: false,
+      errors: [
+        {
+          path: "",
+          message: `Schema compilation failed: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+    };
+  }
+}
+
+/**
+ * Validates the mappings between a form and the CommonGrants data model
+ *
+ * It does this by:
+ * 1. Transforming the form data to CommonGrants using the form's `mappingToCommon` attribute
+ * 2. Validating the CommonGrants data against the CommonGrants schema
+ * 3. Transforming the CommonGrants data back using the form's `mappingFromCommon` attribute
+ * 4. Validating the final transformation output against the form schema
+ *
+ * It logs any validation warnings to the console.
+ *
+ */
+export function validateCommonGrantsMappings(
+  props: CommonGrantsValidationProps
+) {
+  // 1. Transform the form data to CommonGrants
+  const commonData = transformWithMapping(
+    props.defaultData,
+    props.mappingToCommon
+  );
+
+  // 2. Validate the CommonGrants data against the CommonGrants schema
+  const mappingToCommon = validateAgainstSchema(commonData, {});
+  if (!mappingToCommon.isValid) {
+    console.warn(
+      `${props.formId}: Failed mapping to CommonGrants`,
+      mappingToCommon.errors
+    );
+  }
+
+  // 3. Transform the CommonGrants data back to the form data
+  const transformedData = transformWithMapping(
+    commonData,
+    props.mappingFromCommon as Record<string, JsonValue>
+  );
+
+  // 4. Validate the final transformation output against the form schema
+  const mappingFromCommon = validateAgainstSchema(
+    transformedData,
+    props.formSchema
+  );
+  if (!mappingFromCommon.isValid) {
+    console.warn(
+      `${props.formId}: Failed mapping from CommonGrants`,
+      mappingFromCommon.errors
+    );
+  }
+}

--- a/website/src/lib/validation.ts
+++ b/website/src/lib/validation.ts
@@ -40,7 +40,7 @@ const ajv = new Ajv({
  */
 function validateAgainstSchema(
   data: unknown,
-  schema: JsonSchema
+  schema: JsonSchema,
 ): ValidationResult {
   try {
     const validate = ajv.compile(schema);
@@ -91,12 +91,12 @@ function validateAgainstSchema(
  *
  */
 export function validateCommonGrantsMappings(
-  props: CommonGrantsValidationProps
+  props: CommonGrantsValidationProps,
 ) {
   // 1. Transform the form data to CommonGrants
   const commonData = transformWithMapping(
     props.defaultData,
-    props.mappingToCommon
+    props.mappingToCommon,
   );
 
   // 2. Validate the CommonGrants data against the CommonGrants schema
@@ -104,25 +104,25 @@ export function validateCommonGrantsMappings(
   if (!mappingToCommon.isValid) {
     console.warn(
       `${props.formId}: Failed mapping to CommonGrants`,
-      mappingToCommon.errors
+      mappingToCommon.errors,
     );
   }
 
   // 3. Transform the CommonGrants data back to the form data
   const transformedData = transformWithMapping(
     commonData,
-    props.mappingFromCommon as Record<string, JsonValue>
+    props.mappingFromCommon as Record<string, JsonValue>,
   );
 
   // 4. Validate the final transformation output against the form schema
   const mappingFromCommon = validateAgainstSchema(
     transformedData,
-    props.formSchema
+    props.formSchema,
   );
   if (!mappingFromCommon.isValid) {
     console.warn(
       `${props.formId}: Failed mapping from CommonGrants`,
-      mappingFromCommon.errors
+      mappingFromCommon.errors,
     );
   }
 }

--- a/website/src/scripts/validate-schemas.ts
+++ b/website/src/scripts/validate-schemas.ts
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+import { validateCommonGrantsMappings } from "../lib/validation.js";
+import type { JsonValue } from "../lib/types.js";
+import type { JsonSchema } from "@jsonforms/core";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+interface ValidationSummary {
+  totalForms: number;
+  formsWithErrors: number;
+  formsWithWarnings: number;
+  formsValid: number;
+  errors: Array<{
+    formId: string;
+    error: string;
+  }>;
+}
+
+interface FormInfo {
+  id: string;
+  title: string;
+  description?: string;
+  owner?: string;
+  url?: string;
+}
+
+/**
+ * Load form data from filesystem
+ */
+function loadFormData(formId: string, formLabel: string) {
+  const formsDir = join(__dirname, "../content/forms");
+  const formDir = join(formsDir, formId);
+
+  // Check if form directory exists
+  if (!existsSync(formDir)) {
+    throw new Error(`Form directory not found: ${formDir}`);
+  }
+
+  // Load all required files
+  const schemaPath = join(formDir, "json-schema.json");
+  const uiPath = join(formDir, "ui-schema.json");
+  const mappingToPath = join(formDir, "mapping-to-cg.json");
+  const mappingFromPath = join(formDir, "mapping-from-cg.json");
+  const defaultDataPath = join(formDir, "default-data.json");
+
+  const schema = JSON.parse(readFileSync(schemaPath, "utf-8"));
+  const ui = JSON.parse(readFileSync(uiPath, "utf-8"));
+  const mappingTo = JSON.parse(readFileSync(mappingToPath, "utf-8"));
+  const mappingFrom = JSON.parse(readFileSync(mappingFromPath, "utf-8"));
+  const defaultData = JSON.parse(readFileSync(defaultDataPath, "utf-8"));
+
+  return {
+    id: formId,
+    label: formLabel,
+    description: "",
+    owner: "",
+    url: undefined,
+    formSchema: schema,
+    formUI: ui,
+    mappingToCommon: mappingTo,
+    mappingFromCommon: mappingFrom,
+    defaultData,
+    statistics: {
+      totalQuestions: 0,
+      mappedQuestions: 0,
+      mappingPercentage: 0,
+    },
+  };
+}
+
+/**
+ * Load all forms from the forms index
+ */
+function loadAllForms() {
+  const formsIndexPath = join(__dirname, "../content/forms/index.json");
+  const formsIndex: FormInfo[] = JSON.parse(
+    readFileSync(formsIndexPath, "utf-8")
+  );
+
+  const schemas: Record<string, ReturnType<typeof loadFormData>> = {};
+
+  for (const form of formsIndex) {
+    try {
+      const formData = loadFormData(form.id, form.title);
+      schemas[form.id] = formData;
+    } catch (error) {
+      console.error(`Failed to load schema for form ${form.id}:`, error);
+      throw error;
+    }
+  }
+
+  return schemas;
+}
+
+/**
+ * Validates all form schemas and provides a comprehensive report
+ */
+async function validateAllSchemas(): Promise<ValidationSummary> {
+  console.log("🔍 Starting validation of all form schemas...\n");
+
+  const summary: ValidationSummary = {
+    totalForms: 0,
+    formsWithErrors: 0,
+    formsWithWarnings: 0,
+    formsValid: 0,
+    errors: [],
+  };
+
+  try {
+    // Load all schemas
+    const schemas = loadAllForms();
+    summary.totalForms = Object.keys(schemas).length;
+
+    console.log(`📋 Found ${summary.totalForms} forms to validate\n`);
+
+    // Validate each schema
+    for (const [formId, schema] of Object.entries(schemas)) {
+      console.log(`\n🔍 Validating form: ${formId}`);
+      console.log(`   Label: ${schema.label}`);
+
+      try {
+        // Capture console.warn output to detect validation warnings
+        const originalWarn = console.warn;
+        const warnings: string[] = [];
+
+        console.warn = (...args: unknown[]) => {
+          warnings.push(args.join(" "));
+          originalWarn(...args);
+        };
+
+        // Run validation using the existing validation function
+        validateCommonGrantsMappings({
+          formId,
+          formSchema: schema.formSchema as JsonSchema,
+          mappingToCommon: schema.mappingToCommon as Record<string, JsonValue>,
+          mappingFromCommon: schema.mappingFromCommon as Record<
+            string,
+            JsonValue
+          >,
+          defaultData: schema.defaultData,
+        });
+
+        // Restore console.warn
+        console.warn = originalWarn;
+
+        if (warnings.length > 0) {
+          summary.formsWithWarnings++;
+          console.log(`   ⚠️  Validation warnings: ${warnings.length}`);
+          warnings.forEach((warning) => {
+            console.log(`      - ${warning}`);
+          });
+        } else {
+          summary.formsValid++;
+          console.log(`   ✅ Valid`);
+        }
+      } catch (error) {
+        summary.formsWithErrors++;
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        summary.errors.push({ formId, error: errorMessage });
+        console.log(`   ❌ Error: ${errorMessage}`);
+      }
+    }
+  } catch (error) {
+    console.error("❌ Failed to load schemas:", error);
+    summary.errors.push({
+      formId: "SCHEMA_LOADING",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  return summary;
+}
+
+/**
+ * Prints a formatted validation summary
+ */
+function printSummary(summary: ValidationSummary): void {
+  console.log("\n" + "=".repeat(60));
+  console.log("📊 VALIDATION SUMMARY");
+  console.log("=".repeat(60));
+
+  console.log(`Total Forms: ${summary.totalForms}`);
+  console.log(`✅ Valid: ${summary.formsValid}`);
+  console.log(`⚠️  With Warnings: ${summary.formsWithWarnings}`);
+  console.log(`❌ With Errors: ${summary.formsWithErrors}`);
+
+  if (summary.errors.length > 0) {
+    console.log("\n🚨 ERRORS:");
+    summary.errors.forEach(({ formId, error }) => {
+      console.log(`   ${formId}: ${error}`);
+    });
+  }
+
+  const successRate =
+    summary.totalForms > 0
+      ? Math.round((summary.formsValid / summary.totalForms) * 100)
+      : 0;
+
+  console.log(`\n📈 Success Rate: ${successRate}%`);
+
+  if (summary.formsWithErrors > 0) {
+    console.log("\n❌ Validation failed - some forms have errors");
+    process.exit(1);
+  } else if (summary.formsWithWarnings > 0) {
+    console.log("\n⚠️  Validation completed with warnings");
+  } else {
+    console.log("\n✅ All forms validated successfully!");
+  }
+}
+
+/**
+ * Main function
+ */
+async function main(): Promise<void> {
+  const startTime = Date.now();
+
+  try {
+    const summary = await validateAllSchemas();
+    printSummary(summary);
+
+    const duration = Date.now() - startTime;
+    console.log(`\n⏱️  Validation completed in ${duration}ms`);
+  } catch (error) {
+    console.error("❌ Validation script failed:", error);
+    process.exit(1);
+  }
+}
+
+// Run the script if called directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/website/src/scripts/validate-schemas.ts
+++ b/website/src/scripts/validate-schemas.ts
@@ -80,7 +80,7 @@ function loadFormData(formId: string, formLabel: string) {
 function loadAllForms() {
   const formsIndexPath = join(__dirname, "../content/forms/index.json");
   const formsIndex: FormInfo[] = JSON.parse(
-    readFileSync(formsIndexPath, "utf-8")
+    readFileSync(formsIndexPath, "utf-8"),
   );
 
   const schemas: Record<string, ReturnType<typeof loadFormData>> = {};

--- a/website/tspconfig.yaml
+++ b/website/tspconfig.yaml
@@ -4,3 +4,5 @@ emit:
 options:
   "@typespec/openapi3":
     "omit-unreachable-types": false
+  "@typespec/json-schema":
+    "seal-object-schemas": true


### PR DESCRIPTION
### Summary

- Relates to #171 
- Time to review: 4 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Updates the CommonGrants JSON schema emitters to explicitly disallow additional properties
- Adds `npm run validate:schemas` to validate the form library schema mappings against the CommonGrants data models
- Adds a few dependencies to support this validation

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

#### Instructions to review

1. Checkout the PR locally
2. Run `npm run validate:schemas` from the root of the `website` directory

#### Notes 
Since setting up automatic validation was a bit more work than I anticipated, I want to merge in the validation code first, then I'll fix the form mappings to pass the validation in a separate PR.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Here's the PR preview: https://cg-pr-293.billy-daly.workers.dev/

You should see this output when you run `npm run validate:schemas` locally:

<img width="1438" height="719" alt="Screenshot 2025-08-06 at 10 11 09 PM" src="https://github.com/user-attachments/assets/c618f2c0-8954-4d70-99f9-4ff7a2f146e4" />

