### PR TITLE
[Issue #291] Website - Extend schema tab component to include links to source files

### DIFF
--- a/website/src/components/SchemaFormatTabs.astro
+++ b/website/src/components/SchemaFormatTabs.astro
@@ -49,6 +49,55 @@ const jsonSchemaCode = jsonSchema ? extractCode(jsonSchema) : null;
 const typeSpecCode = typeSpec ? extractCode(typeSpec) : null;
 const pythonCode = python ? extractCode(python) : null;
 
+const jsonSchemaUrl = jsonSchema ? extractSchemaUrl(jsonSchema) : null;
+const typeSpecUrl = typeSpec ? extractGithubUrl(typeSpec) : null;
+const pythonUrl = python ? extractGithubUrl(python) : null;
+
+/**
+ * Constructs a schema URL from file path.
+ * @param props - The code block configuration
+ * @returns The schema URL for the file, or null if no file is specified
+ */
+function extractSchemaUrl(props: CodeBlockConfig): string | null {
+  if (props.file) {
+    const baseUrl = "https://commongrants.org/";
+    const pathPrefix = "website/public/";
+    let filePath = props.file.path;
+    
+    // Trim public directory prefix if present
+    if (filePath.startsWith(pathPrefix)) {
+      filePath = filePath.substring(pathPrefix.length);
+    }
+    
+    return `${baseUrl}${filePath}`;
+  }
+  return null;
+}
+
+/**
+ * Extracts a GitHub URL from file configuration.
+ * @param props - The code block configuration
+ * @returns The GitHub URL for the file, or null if no file is specified
+ */
+function extractGithubUrl(props: CodeBlockConfig): string | null {
+  if (props.file) {
+    const baseUrl = "https://github.com/HHS/simpler-grants-protocol/tree/main/";
+    let url = `${baseUrl}/${props.file.path}`;
+    
+    if (props.file.startLine || props.file.endLine) {
+      const start = props.file.startLine || 1;
+      const end = props.file.endLine || start;
+      url += `#L${start}`;
+      if (end > start) {
+        url += `-L${end}`;
+      }
+    }
+    
+    return url;
+  }
+  return null;
+}
+
 /**
  * Extracts code from either a literal string or a file.
  * @param props - The code block configuration
@@ -94,7 +143,7 @@ function extractCode(props: CodeBlockConfig): string {
   {
     jsonSchemaCode && (
       <TabItem label="JSON Schema">
-        <p>The JSON Schema for this model.</p>
+        <p>The {jsonSchemaUrl && <a href={jsonSchemaUrl} target="_blank" rel="noopener noreferrer">JSON Schema</a>} for this model.</p>
         <Code code={jsonSchemaCode} lang="yaml" />
       </TabItem>
     )
@@ -102,7 +151,7 @@ function extractCode(props: CodeBlockConfig): string {
   {
     typeSpecCode && (
       <TabItem label="TypeSpec">
-        <p>The TypeSpec code for this model.</p>
+        <p>The {typeSpecUrl ? <a href={typeSpecUrl} target="_blank" rel="noopener noreferrer">TypeSpec code</a> : "TypeSpec code"} for this model.</p>
         <Code code={typeSpecCode} lang="typespec" />
       </TabItem>
     )
@@ -110,7 +159,7 @@ function extractCode(props: CodeBlockConfig): string {
   {
     pythonCode && (
       <TabItem label="Python">
-        <p>The Python code for this model.</p>
+        <p>The {pythonUrl ? <a href={pythonUrl} target="_blank" rel="noopener noreferrer">Python code</a> : "Python code"} for this model.</p>
         <Code code={pythonCode} lang="python" />
       </TabItem>
     )

--- a/website/src/components/SchemaFormatTabs.astro
+++ b/website/src/components/SchemaFormatTabs.astro
@@ -59,19 +59,20 @@ const pythonUrl = python ? extractGithubUrl(python) : null;
  * @returns The schema URL for the file, or null if no file is specified
  */
 function extractSchemaUrl(props: CodeBlockConfig): string | null {
-  if (props.file) {
-    const baseUrl = "https://commongrants.org/";
-    const pathPrefix = "website/public/";
-    let filePath = props.file.path;
-    
-    // Trim public directory prefix if present
-    if (filePath.startsWith(pathPrefix)) {
-      filePath = filePath.substring(pathPrefix.length);
-    }
-    
-    return `${baseUrl}${filePath}`;
+  if (!props.file) {
+    return null;
   }
-  return null;
+
+  const baseUrl = "https://commongrants.org/";
+  const pathPrefix = "website/public/";
+  let filePath = props.file.path;
+  
+  // Trim public directory prefix if present
+  if (filePath.startsWith(pathPrefix)) {
+    filePath = filePath.substring(pathPrefix.length);
+  }
+  
+  return `${baseUrl}${filePath}`;
 }
 
 /**
@@ -80,22 +81,23 @@ function extractSchemaUrl(props: CodeBlockConfig): string | null {
  * @returns The GitHub URL for the file, or null if no file is specified
  */
 function extractGithubUrl(props: CodeBlockConfig): string | null {
-  if (props.file) {
-    const baseUrl = "https://github.com/HHS/simpler-grants-protocol/tree/main/";
-    let url = `${baseUrl}/${props.file.path}`;
-    
-    if (props.file.startLine || props.file.endLine) {
-      const start = props.file.startLine || 1;
-      const end = props.file.endLine || start;
-      url += `#L${start}`;
-      if (end > start) {
-        url += `-L${end}`;
-      }
-    }
-    
-    return url;
+  if (!props.file) {
+    return null;
   }
-  return null;
+
+  const baseUrl = "https://github.com/HHS/simpler-grants-protocol/tree/main/";
+  let url = `${baseUrl}/${props.file.path}`;
+  
+  if (props.file.startLine || props.file.endLine) {
+    const start = props.file.startLine || 1;
+    const end = props.file.endLine || start;
+    url += `#L${start}`;
+    if (end > start) {
+      url += `-L${end}`;
+    }
+  }
+  
+  return url;
 }
 
 /**

--- a/website/src/content/docs/protocol/filters/date.mdx
+++ b/website/src/content/docs/protocol/filters/date.mdx
@@ -22,8 +22,8 @@ dateRangeFilter:
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/date.py"
-      startLine: 26
-      endLine: 33
+      startLine: 37
+      endLine: 52
 dateComparisonFilter:
   example:
     code: |
@@ -42,8 +42,8 @@ dateComparisonFilter:
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/date.py"
-      startLine: 36
-      endLine: 43
+      startLine: 55
+      endLine: 78
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/money.mdx
+++ b/website/src/content/docs/protocol/filters/money.mdx
@@ -51,8 +51,8 @@ moneyComparisonFilter:
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/money.py"
-      startLine: 64
-      endLine: 71
+      startLine: 72
+      endLine: 87
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/numeric.mdx
+++ b/website/src/content/docs/protocol/filters/numeric.mdx
@@ -42,8 +42,8 @@ numberRangeFilter:
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/numeric.py"
-      startLine: 38
-      endLine: 45
+      startLine: 46
+      endLine: 61
 numberArrayFilter:
   example:
     code: |
@@ -62,8 +62,8 @@ numberArrayFilter:
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/numeric.py"
-      startLine: 48
-      endLine: 57
+      startLine: 64
+      endLine: 81
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/filters/string.mdx
+++ b/website/src/content/docs/protocol/filters/string.mdx
@@ -19,8 +19,8 @@ stringComparisonFilter:
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/string.py"
-      startLine: 23
-      endLine: 30
+      startLine: 31
+      endLine: 49
 stringArrayFilter:
   example:
     code: |
@@ -40,7 +40,7 @@ stringArrayFilter:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/filters/string.py"
       startLine: 13
-      endLine: 20
+      endLine: 28
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";


### PR DESCRIPTION
### Summary

- Fixes #291 
- Time to review: 3 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

This PR:
- Extends `<SchemaFormatTabs>` component to include links to source files 
  - The JSON Schema tab links out to corresponding schema on https://commongrants.org
  - The TypeSpec and Python tabs link out to corresponding source file on GitHub
- Corrects python file line numbers for a handful of filter schemas 

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="466" height="152" alt="Screenshot 2025-08-08 at 4 31 11 PM" src="https://github.com/user-attachments/assets/6d2c7aba-cf8c-43f7-ae03-d385794aecda" />

<img width="467" height="156" alt="Screenshot 2025-08-08 at 4 31 01 PM" src="https://github.com/user-attachments/assets/0181e977-cbf7-4e9f-a0e6-d2d9985c5471" />

<img width="463" height="155" alt="Screenshot 2025-08-08 at 4 30 46 PM" src="https://github.com/user-attachments/assets/6415c083-dd8f-467e-8ce8-e1b6461f4ced" />






