### PR TITLE
[Issue #261] Add links to navbar

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -32,6 +32,7 @@ export default defineConfig({
       customCss: ["./src/styles/custom.css"],
       components: {
         Header: "./src/components/starlight-overrides/Header.astro",
+        PageFrame: "./src/components/starlight-overrides/PageFrame.astro",
       },
       plugins: [
         // Generate the OpenAPI documentation pages.

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -31,7 +31,7 @@ export default defineConfig({
       favicon: "/favicon.ico",
       customCss: ["./src/styles/custom.css"],
       components: {
-        Header: "./src/components/Header.astro",
+        Header: "./src/components/starlight-overrides/Header.astro",
       },
       plugins: [
         // Generate the OpenAPI documentation pages.

--- a/website/src/components/NavMenuItem.astro
+++ b/website/src/components/NavMenuItem.astro
@@ -11,7 +11,13 @@ const { label, items } = Astro.props;
 ---
 
 <div class="nav-menu-item">
-  <button class="nav-menu-button" aria-haspopup="true">
+  <button
+    class="nav-menu-button"
+    aria-haspopup="true"
+    aria-expanded="false"
+    aria-controls="nav-menu-{label.toLowerCase().replace(/\s+/g, '-')}"
+    id="nav-button-{label.toLowerCase().replace(/\s+/g, '-')}"
+  >
     {label}
     <svg
       class="nav-menu-arrow"
@@ -31,10 +37,15 @@ const { label, items } = Astro.props;
     </svg>
   </button>
 
-  <div class="nav-menu-dropdown">
+  <div
+    class="nav-menu-dropdown"
+    role="menu"
+    aria-labelledby="nav-button-{label.toLowerCase().replace(/\s+/g, '-')}"
+    id="nav-menu-{label.toLowerCase().replace(/\s+/g, '-')}"
+  >
     {
       items.map((item) => (
-        <a href={item.href} class="nav-menu-link">
+        <a href={item.href} class="nav-menu-link" role="menuitem" tabindex="-1">
           {item.label}
         </a>
       ))
@@ -75,12 +86,14 @@ const { label, items } = Astro.props;
     outline-offset: 2px;
   }
 
-  .nav-menu-item:focus-within .nav-menu-button {
+  .nav-menu-item:focus-within .nav-menu-button,
+  .nav-menu-item.open .nav-menu-button {
     background-color: var(--sl-color-gray-6);
     color: var(--sl-color-accent-high);
   }
 
-  .nav-menu-item:focus-within .nav-menu-arrow {
+  .nav-menu-item:focus-within .nav-menu-arrow,
+  .nav-menu-item.open .nav-menu-arrow {
     transform: rotate(180deg);
   }
 
@@ -113,7 +126,8 @@ const { label, items } = Astro.props;
     margin-top: 0.25rem;
   }
 
-  .nav-menu-item:focus-within .nav-menu-dropdown {
+  .nav-menu-item:focus-within .nav-menu-dropdown,
+  .nav-menu-item.open .nav-menu-dropdown {
     opacity: 1;
     visibility: visible;
     transform: translateY(0);
@@ -150,15 +164,143 @@ const { label, items } = Astro.props;
 </style>
 
 <script>
-  // Simple click handler to prevent default button behavior
+  // Enhanced accessibility and Safari compatibility
   document.addEventListener("DOMContentLoaded", () => {
     const navButtons = document.querySelectorAll(".nav-menu-button");
 
     navButtons.forEach((button) => {
+      const navMenuItem = button.closest(".nav-menu-item");
+      const dropdown = navMenuItem?.querySelector(".nav-menu-dropdown");
+      const menuItems = dropdown?.querySelectorAll(".nav-menu-link");
+
+      if (!navMenuItem || !dropdown || !menuItems) return;
+
+      let currentIndex = -1;
+
+      // Toggle dropdown function
+      const toggleDropdown = (isOpen: boolean) => {
+        const wasOpen = navMenuItem.classList.contains("open");
+
+        if (isOpen && !wasOpen) {
+          // Open dropdown
+          navMenuItem.classList.add("open");
+          button.setAttribute("aria-expanded", "true");
+          currentIndex = -1;
+        } else if (!isOpen && wasOpen) {
+          // Close dropdown
+          navMenuItem.classList.remove("open");
+          button.setAttribute("aria-expanded", "false");
+          currentIndex = -1;
+          // Return focus to button
+          (button as HTMLElement).focus();
+        }
+      };
+
+      // Close all other dropdowns
+      const closeOtherDropdowns = () => {
+        document.querySelectorAll(".nav-menu-item.open").forEach((item) => {
+          if (item !== navMenuItem) {
+            const otherButton = item.querySelector(
+              ".nav-menu-button",
+            ) as HTMLButtonElement;
+            item.classList.remove("open");
+            otherButton?.setAttribute("aria-expanded", "false");
+          }
+        });
+      };
+
+      // Handle button click
       button.addEventListener("click", (e) => {
-        // Prevent default button behavior - we want focus to move to dropdown
         e.preventDefault();
+        const isOpen = navMenuItem.classList.contains("open");
+        closeOtherDropdowns();
+        toggleDropdown(!isOpen);
       });
+
+      // Handle button keyboard events
+      button.addEventListener("keydown", (e) => {
+        const keyEvent = e as KeyboardEvent;
+        switch (keyEvent.key) {
+          case "Enter":
+          case " ":
+            e.preventDefault();
+            closeOtherDropdowns();
+            toggleDropdown(!navMenuItem.classList.contains("open"));
+            break;
+          case "ArrowDown":
+            e.preventDefault();
+            if (!navMenuItem.classList.contains("open")) {
+              closeOtherDropdowns();
+              toggleDropdown(true);
+            }
+            currentIndex = 0;
+            (menuItems[0] as HTMLElement)?.focus();
+            break;
+          case "ArrowUp":
+            e.preventDefault();
+            if (!navMenuItem.classList.contains("open")) {
+              closeOtherDropdowns();
+              toggleDropdown(true);
+            }
+            currentIndex = menuItems.length - 1;
+            (menuItems[menuItems.length - 1] as HTMLElement)?.focus();
+            break;
+        }
+      });
+
+      // Handle menu item keyboard events
+      menuItems.forEach((item, index) => {
+        item.addEventListener("keydown", (e) => {
+          const keyEvent = e as KeyboardEvent;
+          switch (keyEvent.key) {
+            case "ArrowDown":
+              e.preventDefault();
+              currentIndex = (index + 1) % menuItems.length;
+              (menuItems[currentIndex] as HTMLElement)?.focus();
+              break;
+            case "ArrowUp":
+              e.preventDefault();
+              currentIndex = index === 0 ? menuItems.length - 1 : index - 1;
+              (menuItems[currentIndex] as HTMLElement)?.focus();
+              break;
+            case "Escape":
+              e.preventDefault();
+              toggleDropdown(false);
+              break;
+            case "Tab":
+              // Allow tab to close dropdown and continue navigation
+              toggleDropdown(false);
+              break;
+          }
+        });
+      });
+    });
+
+    // Close dropdowns when clicking outside
+    document.addEventListener("click", (e) => {
+      const target = e.target as Element;
+      if (target && !target.closest(".nav-menu-item")) {
+        document.querySelectorAll(".nav-menu-item.open").forEach((item) => {
+          const button = item.querySelector(
+            ".nav-menu-button",
+          ) as HTMLButtonElement;
+          item.classList.remove("open");
+          button?.setAttribute("aria-expanded", "false");
+        });
+      }
+    });
+
+    // Close dropdowns when pressing Escape (global)
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        document.querySelectorAll(".nav-menu-item.open").forEach((item) => {
+          const button = item.querySelector(
+            ".nav-menu-button",
+          ) as HTMLButtonElement;
+          item.classList.remove("open");
+          button?.setAttribute("aria-expanded", "false");
+        });
+      }
     });
   });
 </script>

--- a/website/src/components/NavMenuItem.astro
+++ b/website/src/components/NavMenuItem.astro
@@ -1,0 +1,170 @@
+---
+export interface Props {
+  label: string;
+  items: Array<{
+    label: string;
+    href: string;
+  }>;
+}
+
+const { label, items } = Astro.props;
+---
+
+<div class="nav-menu-item">
+  <button class="nav-menu-button" aria-haspopup="true">
+    {label}
+    <svg
+      class="nav-menu-arrow"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M3 4.5L6 7.5L9 4.5"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"></path>
+    </svg>
+  </button>
+
+  <div class="nav-menu-dropdown">
+    {
+      items.map((item) => (
+        <a href={item.href} class="nav-menu-link">
+          {item.label}
+        </a>
+      ))
+    }
+  </div>
+</div>
+
+<style>
+  .nav-menu-item {
+    position: relative;
+    display: inline-block;
+  }
+
+  .nav-menu-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: none;
+    border: none;
+    color: var(--sl-color-text);
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    border-radius: 0.375rem;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+  }
+
+  .nav-menu-button:hover {
+    background-color: var(--sl-color-hairline);
+    color: var(--sl-color-accent);
+  }
+
+  .nav-menu-button:focus {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+
+  .nav-menu-item:focus-within .nav-menu-button {
+    background-color: var(--sl-color-hairline);
+    color: var(--sl-color-accent);
+  }
+
+  .nav-menu-item:focus-within .nav-menu-arrow {
+    transform: rotate(180deg);
+  }
+
+  .nav-menu-arrow {
+    transition: transform 0.2s ease;
+    flex-shrink: 0;
+  }
+
+  .nav-menu-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    min-width: 12rem;
+    background-color: var(--sl-color-bg);
+    border: 1px solid var(--sl-color-hairline-shade);
+    border-radius: 0.5rem;
+    box-shadow:
+      0 10px 15px -3px rgba(0, 0, 0, 0.1),
+      0 4px 6px -2px rgba(0, 0, 0, 0.05);
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(-0.5rem);
+    transition:
+      opacity 0.2s ease,
+      visibility 0.2s ease,
+      transform 0.2s ease;
+    padding: 0.5rem 0;
+    margin-top: 0.25rem;
+  }
+
+  .nav-menu-item:focus-within .nav-menu-dropdown {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+  }
+
+  .nav-menu-link {
+    display: block;
+    padding: 0.75rem 1rem;
+    color: var(--sl-color-text);
+    text-decoration: none;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+    border: none;
+    background: none;
+    width: 100%;
+    text-align: left;
+    cursor: pointer;
+    font-weight: 500;
+    font-size: 0.9rem;
+  }
+
+  .nav-menu-link:hover,
+  .nav-menu-link:focus {
+    background-color: var(--sl-color-hairline);
+    color: var(--sl-color-accent);
+    outline: none;
+  }
+
+  .nav-menu-link:focus {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: -2px;
+  }
+
+  /* Dark mode adjustments */
+  :global(.dark) .nav-menu-dropdown {
+    background-color: var(--sl-color-bg);
+    border-color: var(--sl-color-hairline-shade);
+  }
+</style>
+
+<script>
+  // Simple click handler to prevent default button behavior
+  document.addEventListener("DOMContentLoaded", () => {
+    const navButtons = document.querySelectorAll(".nav-menu-button");
+
+    navButtons.forEach((button) => {
+      button.addEventListener("click", (e) => {
+        // Prevent default button behavior - we want focus to move to dropdown
+        e.preventDefault();
+      });
+    });
+  });
+</script>

--- a/website/src/components/NavMenuItem.astro
+++ b/website/src/components/NavMenuItem.astro
@@ -55,7 +55,7 @@ const { label, items } = Astro.props;
     padding: 0.5rem 0.75rem;
     background: none;
     border: none;
-    color: var(--sl-color-text);
+    color: var(--sl-color-white);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
@@ -66,18 +66,18 @@ const { label, items } = Astro.props;
   }
 
   .nav-menu-button:hover {
-    background-color: var(--sl-color-hairline);
-    color: var(--sl-color-accent);
+    background-color: var(--sl-color-gray-6);
+    color: var(--sl-color-accent-high);
   }
 
   .nav-menu-button:focus {
-    outline: 2px solid var(--sl-color-accent);
+    outline: 2px solid var(--sl-color-accent-high);
     outline-offset: 2px;
   }
 
   .nav-menu-item:focus-within .nav-menu-button {
-    background-color: var(--sl-color-hairline);
-    color: var(--sl-color-accent);
+    background-color: var(--sl-color-gray-6);
+    color: var(--sl-color-accent-high);
   }
 
   .nav-menu-item:focus-within .nav-menu-arrow {
@@ -95,8 +95,8 @@ const { label, items } = Astro.props;
     left: 0;
     right: 0;
     min-width: 12rem;
-    background-color: var(--sl-color-bg);
-    border: 1px solid var(--sl-color-hairline-shade);
+    background-color: var(--sl-color-black);
+    border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.5rem;
     box-shadow:
       0 10px 15px -3px rgba(0, 0, 0, 0.1),
@@ -122,7 +122,7 @@ const { label, items } = Astro.props;
   .nav-menu-link {
     display: block;
     padding: 0.75rem 1rem;
-    color: var(--sl-color-text);
+    color: var(--sl-color-white);
     text-decoration: none;
     transition:
       background-color 0.2s ease,
@@ -138,20 +138,14 @@ const { label, items } = Astro.props;
 
   .nav-menu-link:hover,
   .nav-menu-link:focus {
-    background-color: var(--sl-color-hairline);
-    color: var(--sl-color-accent);
+    background-color: var(--sl-color-gray-6);
+    color: var(--sl-color-accent-high);
     outline: none;
   }
 
   .nav-menu-link:focus {
-    outline: 2px solid var(--sl-color-accent);
+    outline: 2px solid var(--sl-color-accent-high);
     outline-offset: -2px;
-  }
-
-  /* Dark mode adjustments */
-  :global(.dark) .nav-menu-dropdown {
-    background-color: var(--sl-color-bg);
-    border-color: var(--sl-color-hairline-shade);
   }
 </style>
 

--- a/website/src/components/starlight-overrides/Header.astro
+++ b/website/src/components/starlight-overrides/Header.astro
@@ -8,6 +8,7 @@ import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
 import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
 import MobileMenuToggle from "@astrojs/starlight/components/MobileMenuToggle.astro";
 import { LinkButton } from "@astrojs/starlight/components";
+import NavMenuItem from "../NavMenuItem.astro";
 
 /**
  * Render the `Search` component if Pagefind is enabled or the default search component has been overridden.
@@ -21,6 +22,33 @@ const ctaConfig = {
   text: "Get in touch",
   url: "https://forms.gle/XUJuEnNtaZkdc1MQ6",
 };
+const NavMenuItems = [
+  {
+    label: "Learn more",
+    items: [
+      { label: "Getting started", href: "/getting-started" },
+      { label: "About CommonGrants", href: "/about" },
+      { label: "Form library", href: "/forms/library" },
+    ],
+  },
+  {
+    label: "Protocol",
+    items: [
+      { label: "Specification", href: "/protocol/specification" },
+      { label: "OpenAPI docs", href: "/protocol/api-docs" },
+      { label: "Types", href: "/protocol/types" },
+      { label: "Fields", href: "/protocol/fields" },
+      { label: "Models", href: "/protocol/models" },
+    ],
+  },
+  {
+    label: "Guides",
+    items: [
+      { label: "Using Python", href: "/guides/using-python" },
+      { label: "Using TypeScript", href: "/guides/using-typescript" },
+    ],
+  },
+];
 ---
 
 <div class="header">
@@ -31,6 +59,11 @@ const ctaConfig = {
     {shouldRenderSearch && <Search />}
   </div>
   <div class="sl-hidden md:sl-flex print:hidden right-group">
+    {
+      NavMenuItems.map((item) => (
+        <NavMenuItem label={item.label} items={item.items ?? []} />
+      ))
+    }
     <div class="sl-flex social-icons">
       <SocialIcons />
     </div>

--- a/website/src/components/starlight-overrides/Header.astro
+++ b/website/src/components/starlight-overrides/Header.astro
@@ -27,7 +27,7 @@ const ctaConfig = {
   <div class="title-wrapper sl-flex">
     <SiteTitle />
   </div>
-  <div class="sl-flex print:hidden">
+  <div class="sl-flex print:hidden search-container">
     {shouldRenderSearch && <Search />}
   </div>
   <div class="sl-hidden md:sl-flex print:hidden right-group">
@@ -53,6 +53,10 @@ const ctaConfig = {
 
 <style>
   @layer starlight.core {
+    .search-container {
+      max-width: 10rem;
+    }
+
     .header {
       display: flex;
       gap: var(--sl-nav-gap);
@@ -104,12 +108,9 @@ const ctaConfig = {
         );
         display: grid;
         grid-template-columns:
-        /* 1 (site title): runs up until the main content column's left edge or the width of the title, whichever is the largest  */
+        /* 1 (site title): runs up until width of the title */
           minmax(
-            calc(
-              var(--__sidebar-width) +
-                max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))
-            ),
+            calc(max(0rem, var(--__main-column-fr) - var(--sl-nav-gap))),
             auto
           )
           /* 2 (search box): all free space that is available. */

--- a/website/src/components/starlight-overrides/Header.astro
+++ b/website/src/components/starlight-overrides/Header.astro
@@ -6,6 +6,7 @@ import Search from "@astrojs/starlight/components/Search.astro";
 import SiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
 import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
 import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
+import MobileMenuToggle from "@astrojs/starlight/components/MobileMenuToggle.astro";
 import { LinkButton } from "@astrojs/starlight/components";
 
 /**
@@ -46,6 +47,7 @@ const ctaConfig = {
         </LinkButton>
       )
     }
+    <MobileMenuToggle />
   </div>
 </div>
 

--- a/website/src/components/starlight-overrides/PageFrame.astro
+++ b/website/src/components/starlight-overrides/PageFrame.astro
@@ -58,9 +58,6 @@ const { hasSidebar, sidebar } = Astro.locals.starlightRoute;
       padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
       padding-inline-end: var(--sl-nav-pad-x);
       background-color: var(--sl-color-bg-nav);
-    }
-
-    :global([data-has-sidebar]) .header {
       padding-inline-end: calc(
         var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
       );

--- a/website/src/components/starlight-overrides/PageFrame.astro
+++ b/website/src/components/starlight-overrides/PageFrame.astro
@@ -1,0 +1,116 @@
+---
+import MobileMenuToggle from "@astrojs/starlight/components/MobileMenuToggle.astro";
+import Sidebar from "@astrojs/starlight/components/Sidebar.astro";
+
+const { hasSidebar, sidebar } = Astro.locals.starlightRoute;
+---
+
+<div class="page sl-flex">
+  <header class="header"><slot name="header" /></header>
+  {
+    hasSidebar && (
+      <nav
+        class="sidebar print:hidden"
+        aria-label={Astro.locals.t("sidebarNav.accessibleLabel")}
+      >
+        <MobileMenuToggle />
+        <div id="starlight__sidebar" class="sidebar-pane">
+          <div class="sidebar-content sl-flex">
+            <slot name="sidebar" />
+          </div>
+        </div>
+      </nav>
+    )
+  }
+  {
+    !hasSidebar && (
+      <nav
+        class="sidebar print:hidden"
+        aria-label={Astro.locals.t("sidebarNav.accessibleLabel")}
+      >
+        <MobileMenuToggle />
+        <div id="starlight__sidebar-splash" class="sidebar-pane md:sl-hidden">
+          <div class="sidebar-content sl-flex">
+            <Sidebar sidebar={sidebar} />
+          </div>
+        </div>
+      </nav>
+    )
+  }
+  <div class="main-frame"><slot /></div>
+</div>
+
+<style>
+  @layer starlight.core {
+    .page {
+      flex-direction: column;
+      min-height: 100vh;
+    }
+
+    .header {
+      z-index: var(--sl-z-index-navbar);
+      position: fixed;
+      inset-inline-start: 0;
+      inset-block-start: 0;
+      width: 100%;
+      height: var(--sl-nav-height);
+      border-bottom: 1px solid var(--sl-color-hairline-shade);
+      padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
+      padding-inline-end: var(--sl-nav-pad-x);
+      background-color: var(--sl-color-bg-nav);
+    }
+
+    :global([data-has-sidebar]) .header {
+      padding-inline-end: calc(
+        var(--sl-nav-gap) + var(--sl-nav-pad-x) + var(--sl-menu-button-size)
+      );
+    }
+
+    .sidebar-pane {
+      visibility: var(--sl-sidebar-visibility, hidden);
+      position: fixed;
+      z-index: var(--sl-z-index-menu);
+      inset-block: var(--sl-nav-height) 0;
+      inset-inline-start: 0;
+      width: 100%;
+      background-color: var(--sl-color-black);
+      overflow-y: auto;
+    }
+
+    :global([aria-expanded="true"]) ~ .sidebar-pane {
+      --sl-sidebar-visibility: visible;
+    }
+
+    .sidebar-content {
+      height: 100%;
+      min-height: max-content;
+      padding: 1rem var(--sl-sidebar-pad-x) 0;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    @media (min-width: 50rem) {
+      .sidebar-content::after {
+        content: "";
+        padding-bottom: 1px;
+      }
+    }
+
+    .main-frame {
+      padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
+      padding-inline-start: var(--sl-content-inline-start);
+    }
+
+    @media (min-width: 50rem) {
+      :global([data-has-sidebar]) .header {
+        padding-inline-end: var(--sl-nav-pad-x);
+      }
+      .sidebar-pane {
+        --sl-sidebar-visibility: visible;
+        width: var(--sl-sidebar-width);
+        background-color: var(--sl-color-bg-sidebar);
+        border-inline-end: 1px solid var(--sl-color-hairline-shade);
+      }
+    }
+  }
+</style>


### PR DESCRIPTION
### Summary

Add links to the navbar so folks can access docs from the landing page without first clicking on "Read docs" 

- Fixes #261 
- Time to review: 10 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Overrides default [`PageFrame` component](https://github.com/withastro/starlight/blob/main/packages/starlight/components/PageFrame.astro) to expose `MobileMenuToggle` on pages with the "splash" template (i.e. the landing page)
- Adds a `NavMenuItem` component
- Updates the existing `Header` override component to include `NavMenuItem`
- Resizes the `Search` component to fit the `NavMenuItem`

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

There might be a slightly more elegant way to expose the `MobileMenuItem` on splash pages that does require overriding the entire component, but I couldn't find an easy way to do that. I have an open question in the [Astro discord channel](https://discord.com/channels/830184174198718474/1412458154620620820) and we can incorporate better feedback in a subsequent PR.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Test the [PR preview](https://cg-pr-307.billy-daly.workers.dev/)

<img width="1440" height="784" alt="Screenshot 2025-09-02 at 3 28 54 PM" src="https://github.com/user-attachments/assets/8f50bbaa-0275-4c60-afd8-aa6a39dfd946" />
<img width="399" height="692" alt="Screenshot 2025-09-02 at 3 29 08 PM" src="https://github.com/user-attachments/assets/32b735f6-05d1-4a98-a395-bf44ef06ffa4" />
<img width="1440" height="777" alt="Screenshot 2025-09-02 at 3 29 27 PM" src="https://github.com/user-attachments/assets/792253f3-6304-4dc6-82e7-efe417195938" />

