### PR TITLE
[Issue #312] Fix co-planning issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-internal-coplanning.md
+++ b/.github/ISSUE_TEMPLATE/5-internal-coplanning.md
@@ -1,6 +1,6 @@
 ---
 name: Internal - Co-planning Proposal
-description: Describe a co-planning proposal
+about: Describe a co-planning proposal
 type: Epic
 labels: ["co-planning"]
 ---


### PR DESCRIPTION
### Summary

Issue template didn't render correctly because I had the wrong key in the frontmatter. It needs to be `about` instead of `description`

- Fixes #312 
- Time to review: 1 minute

### Changes proposed
> What was added, updated, or removed in this PR.

Changes frontmatter key from `description` to `about`

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

N/A

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1440" height="900" alt="Screenshot 2025-09-04 at 8 14 23 PM" src="https://github.com/user-attachments/assets/f5fbf723-b39d-46c4-b652-413baac3811a" />
<img width="1440" height="900" alt="Screenshot 2025-09-04 at 8 14 38 PM" src="https://github.com/user-attachments/assets/c60cc860-b08b-4530-86e9-4f9077b49315" />

