### PR TITLE
Fix GitHub to Fider co-planning sync

### DIFF
--- a/.github/automations/coplanning/fider.py
+++ b/.github/automations/coplanning/fider.py
@@ -50,7 +50,10 @@ def parse_posts(posts: list[dict], fider_url: str) -> dict[str, PostData]:
         matches = pattern.findall(description)
         if not matches:
             continue
-        github_url = matches[-1]  # Take the last match (captured group)
+        # Take the last match if there are multiple GitHub issue URLs in the post
+        # This is because the source GitHub issue URL is always inserted
+        # at the end of the fider post by utils.format_post_description()
+        github_url = matches[-1]
         fider_url = f"{FIDER_URL}/posts/{post.get('number')}"
         posts_dict[github_url] = PostData(
             url=fider_url,


### PR DESCRIPTION
### Summary

Fixes a how this script parses GitHub links in Fider posts that caused an error when a Fider post includes the links for multiple issues (e.g. referencing a dependency)

Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Changes the regex pattern to use the full `\[GitHub issue\]\((https://github\.com/[^/]+/[^/]+/issues/[0-9]+)\)` in stead of just scanning for any GitHub issue link
- Changes the match extraction to pull the _last_ match since the `format_post_description()` always inserts the link to the source issue at the end of the post description

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We weren't successfully parsing all of the GitHub issues from the Fider posts because some posts had multiple GitHub issue URLs (referencing other issues that were already mapped to Fider posts), which caused us to try to re-insert the same post.

<img width="1059" height="673" alt="Screenshot 2025-09-24 at 12 40 13 PM" src="https://github.com/user-attachments/assets/e55d24ba-c58c-464c-80f3-e1802bc87212" />

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Triggering a real run from this branch _does_ succeed:

<img width="1440" height="900" alt="Screenshot 2025-09-24 at 12 50 50 PM" src="https://github.com/user-attachments/assets/a75f6626-afe8-4b6d-8d95-141e8caa3666" />

Same with the Fider to GitHub sync:

<img width="1440" height="900" alt="Screenshot 2025-09-24 at 12 52 40 PM" src="https://github.com/user-attachments/assets/7c1068b2-9d0b-4d95-ad43-999627f69e9d" />
