### PR TITLE
[Issue #348] Repo level mapping

### DIFF
--- a/.github/automations/deps_mapping/diagram.py
+++ b/.github/automations/deps_mapping/diagram.py
@@ -9,6 +9,12 @@ STATUS_CLASSES = {
     "Done": ":::Done",
     "Closed": ":::Done",
 }
+STATUS_ICONS = {
+    "In Progress": "🛠️",
+    "In Review": "🛠️",
+    "Done": "✔️",
+    "Closed": "✔️",
+}
 
 
 # #######################################################
@@ -225,13 +231,15 @@ def format_subgraph_items(issues: list[Issue]) -> str:
     items = []
     for issue in issues:
         if issue.status in STATUS_CLASSES:
+            title = f"{issue.title} {STATUS_ICONS[issue.status]}"
             status_class = STATUS_CLASSES[issue.status]
         else:
+            title = issue.title
             status_class = ""
         items.append(
             ISSUE_TEMPLATE.format(
                 slug=issue.slug,
-                title=issue.title,
+                title=title,
                 status_class=status_class,
             )
         )

--- a/.github/workflows/deps-mapping-repo.yml
+++ b/.github/workflows/deps-mapping-repo.yml
@@ -3,7 +3,8 @@ name: "Dependency mapping: Repo level"
 on:
   pull_request: # run on every PR
   workflow_dispatch:
-  # TODO: Enable scheduled runs
+  schedule:
+    - cron: "0 0 * * 1" # run weekly at midnight on Monday
 
 permissions:
   issues: write
@@ -44,7 +45,23 @@ jobs:
             --scope "repo"
 
       - name: Commit changes to PR
+        # Commit changes to PR when triggered by a PR, and don't skip CI
+        # We don't want to skip CI because it will prevent the bump version workflow
+        # from running on the main branch after the PR is merged
         if: github.event_name == 'pull_request'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -am "docs: Update README with dependency diagram"
+            git push
+          fi
+
+      - name: Commit changes to main
+        # Commit changes to main with skip CI when triggered manually or on a schedule
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
### Summary

Schedules repo-level mapping on a weekly basis and supports directly committing to `main` (when scheduled or triggered manually)

- Fixes #348 
- Time to review: 3 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds icon to issue title in diagram based on status
- Schedules repo-level mapping to to run on a weekly basis
- Removes `[skip ci]` from PR commit to allow CI to run after PR is merge into `main`
- Adds step to directly commit to main when workflow is scheduled or triggered manually

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The reason we're taking `[skip ci]` out of the PR commit message is that the default merge strategy, squash commit, preserves the text of each individual commit message by default. If left in the squash commit message, the bump version workflow wouldn't run on `main` after merge.

Since the PR step only commits if there are changes to the diagram, multiple runs should be idempotent and we shouldn't get stuck in a loop (one common reason for skipping CI)

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
