### PR TITLE
[Issue #344] Add `code.json` for indexing repo

### DIFF
--- a/.github/workflows/update-code-json.yml
+++ b/.github/workflows/update-code-json.yml
@@ -1,0 +1,27 @@
+name: Update code.json
+on:
+  schedule:
+    - cron: 0 0 1 * * # First day of every month
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  update-code-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update code.json
+        uses: DSACMS/automated-codejson-generator@v1.2.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: "main"
+          # TODO(widal001): Set this to true after testing
+          SKIP_PR: "false"

--- a/code.json
+++ b/code.json
@@ -1,0 +1,47 @@
+{
+  "name": "simpler-grants-protocol",
+  "description": "A common standard for sharing data in the grant ecosystem.",
+  "status": "",
+  "permissions": {
+    "licenses": [
+      {
+        "name": "CC0-1.0",
+        "URL": "https://github.com/HHS/simpler-grants-protocol/blob/main/LICENSE.md"
+      }
+    ],
+    "usageType": ["openSource"]
+  },
+  "organization": "Centers for Medicare & Medicaid Services",
+  "repositoryURL": "https://github.com/HHS/simpler-grants-protocol",
+  "repositoryVisibility": "public",
+  "vcs": "git",
+  "laborHours": 4176,
+  "reuseFrequency": {
+    "forks": 5
+  },
+  "languages": [
+    "TypeScript",
+    "MDX",
+    "Python",
+    "TypeSpec",
+    "Astro",
+    "JavaScript",
+    "CSS",
+    "Roff",
+    "Makefile",
+    "Shell"
+  ],
+  "maintenance": "contract",
+  "contractNumber": "",
+  "SBOM": "https://github.com/HHS/simpler-grants-protocol/network/dependencies",
+  "date": {
+    "created": "2024-12-19T21:14:35Z",
+    "lastModified": "2025-10-07T15:56:02Z",
+    "metaDataLastUpdated": "2025-10-07T16:00:26.350Z"
+  },
+  "tags": ["grants", "standards", "api"],
+  "contact": {
+    "email": "simpler@grants.gov"
+  },
+  "feedbackMechanism": "https://github.com/HHS/simpler-grants-protocol/issues"
+}


### PR DESCRIPTION
### Summary

Adds a `code.json` file to support indexing federal open source projects. Visit the [SHARE IT Act](https://dsacms.github.io/share-it-act-lp/) homepage for more information.

- Fixes #344 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds a `code.json` file generated using the [DSACMS form](https://dsacms.github.io/codejson-generator/)
- Sets up a GitHub action using the [DSACMS action](https://github.com/DSACMS/automated-codejson-generator) to update `code.json` on a monthly basis

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The automated action does provide a way to directly commit `code.json` updates to the `main` branch, but doing so requires a PAT with admin privileges (instead of the repo-scoped auto-generated GitHub token). So I want to test out a few runs, opening a PR to make sure it works as expected before we allow it to commit directly.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

I tested this in the sandbox repo and here's an example of [the auto-generated PR](https://github.com/agilesix/simpler-grants-sandbox/pull/85)