### PR TITLE
[Issue #354] CLI: Normalizes types in OpenAPI v3 conversion

### DIFF
--- a/lib/cli/src/__tests__/commands/check/utils/convert-openapi-v3.test.ts
+++ b/lib/cli/src/__tests__/commands/check/utils/convert-openapi-v3.test.ts
@@ -1,0 +1,464 @@
+import {
+  convertOpenApiToV3,
+  OpenAPISchema,
+} from "../../../../commands/check/utils/convert-openapi-v3";
+import { OpenAPIV3 } from "openapi-types";
+
+// ############################################################
+// Test Helpers
+// ############################################################
+
+/**
+ * Extract a response schema from a converted OpenAPI document
+ */
+function getResponseSchema(
+  schema: OpenAPISchema,
+  path: string,
+  statusCode: string = "200"
+): OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject {
+  const response = schema.paths[path]?.get?.responses?.[statusCode] as OpenAPIV3.ResponseObject;
+  return response?.content?.["application/json"]?.schema as
+    | OpenAPIV3.SchemaObject
+    | OpenAPIV3.ReferenceObject;
+}
+
+/**
+ * Get a property from a schema object with proper type casting
+ */
+function getSchemaProperty(
+  schema: OpenAPIV3.SchemaObject,
+  propertyName: string
+): OpenAPIV3.SchemaObject {
+  expect(schema.properties?.[propertyName]).toBeDefined();
+  return schema.properties?.[propertyName] as OpenAPIV3.SchemaObject;
+}
+
+/**
+ * Assert that a schema property has the expected type
+ */
+function expectPropertyType(
+  schema: OpenAPIV3.SchemaObject,
+  propertyName: string,
+  expectedType: string
+): void {
+  const property = getSchemaProperty(schema, propertyName);
+  expect(property.type).toBe(expectedType);
+}
+
+/**
+ * Get a reference object from a schema
+ */
+function getReferenceSchema(
+  schema: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject
+): OpenAPIV3.ReferenceObject {
+  return schema as OpenAPIV3.ReferenceObject;
+}
+
+describe("OpenAPI v3.1 to v3.0 Conversion", () => {
+  // ############################################################
+  // Array type normalization
+  // ############################################################
+
+  it("should convert single-element type array to string", () => {
+    // Arrange - Create schema with type as single-element array (OpenAPI 3.1 syntax)
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        field: {
+                          type: ["string"] as unknown as "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - Type array should be converted to string
+    expect(converted.openapi).toBe("3.0.0");
+    const responseSchema = getResponseSchema(converted, "/test") as OpenAPIV3.SchemaObject;
+    expectPropertyType(responseSchema, "field", "string");
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it("should convert type: [object] to type: object", () => {
+    // Arrange - Create schema with type: [object] which causes issues with allOf
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        paginationInfo: {
+                          type: ["object"] as unknown as "object",
+                          allOf: [
+                            {
+                              $ref: "#/components/schemas/PaginationInfo",
+                            },
+                          ],
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          PaginationInfo: {
+            type: "object",
+            properties: {
+              page: { type: "integer" },
+              pageSize: { type: "integer" },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - Type array should be converted to string
+    const responseSchema = getResponseSchema(converted, "/test") as OpenAPIV3.SchemaObject;
+    expectPropertyType(responseSchema, "paginationInfo", "object");
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  it("should handle multiple types with null by taking first non-null type", () => {
+    // Arrange - Create schema with nullable type array (OpenAPI 3.1 syntax)
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        optionalField: {
+                          type: ["string", "null"] as unknown as "string",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - Should take first non-null type
+    const responseSchema = getResponseSchema(converted, "/test") as OpenAPIV3.SchemaObject;
+    expectPropertyType(responseSchema, "optionalField", "string");
+  });
+
+  it("should normalize types in nested objects", () => {
+    // Arrange - Create schema with nested array types
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        nested: {
+                          type: ["object"] as unknown as "object",
+                          properties: {
+                            deepField: {
+                              type: ["integer"] as unknown as "integer",
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - All nested types should be normalized
+    const responseSchema = getResponseSchema(converted, "/test") as OpenAPIV3.SchemaObject;
+    const nestedSchema = getSchemaProperty(responseSchema, "nested");
+    expect(nestedSchema.type).toBe("object");
+    expectPropertyType(nestedSchema, "deepField", "integer");
+  });
+
+  it("should normalize types in array items", () => {
+    // Arrange - Create schema with array types in items
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      type: "object",
+                      properties: {
+                        items: {
+                          type: "array",
+                          items: {
+                            type: ["object"] as unknown as "object",
+                            properties: {
+                              id: {
+                                type: ["string"] as unknown as "string",
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - Types in array items should be normalized
+    const responseSchema = getResponseSchema(converted, "/test") as OpenAPIV3.SchemaObject;
+    const itemsArraySchema = getSchemaProperty(
+      responseSchema,
+      "items"
+    ) as OpenAPIV3.ArraySchemaObject;
+    const itemsSchema = itemsArraySchema.items as OpenAPIV3.SchemaObject;
+    expect(itemsSchema.type).toBe("object");
+    expectPropertyType(itemsSchema, "id", "string");
+  });
+
+  // ############################################################
+  // Schema reference conversion
+  // ############################################################
+
+  it("should convert component schema references to definitions", () => {
+    // Arrange - Create schema with components/schemas references
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/components/schemas/TestModel",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          TestModel: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - References should be converted to #/definitions/
+    const responseSchema = getReferenceSchema(getResponseSchema(converted, "/test"));
+    expect(responseSchema.$ref).toBe("#/definitions/TestModel");
+    expect(converted.definitions).toBeDefined();
+    expect(converted.definitions?.TestModel).toBeDefined();
+    expect(converted.components).toBeUndefined();
+  });
+
+  it("should move schemas from components to definitions", () => {
+    // Arrange - Create schema with components/schemas
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {},
+      components: {
+        schemas: {
+          Model1: {
+            type: "object",
+            properties: {
+              field1: { type: "string" },
+            },
+          },
+          Model2: {
+            type: "object",
+            properties: {
+              field2: { type: "number" },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - Schemas should be in definitions, not components
+    expect(converted.definitions).toBeDefined();
+    expect(converted.definitions?.Model1).toEqual({
+      type: "object",
+      properties: {
+        field1: { type: "string" },
+      },
+    });
+    expect(converted.definitions?.Model2).toEqual({
+      type: "object",
+      properties: {
+        field2: { type: "number" },
+      },
+    });
+    expect(converted.components).toBeUndefined();
+  });
+
+  it("should convert $defs references to definitions", () => {
+    // Arrange - Create schema with $defs references
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {
+        "/test": {
+          get: {
+            responses: {
+              "200": {
+                description: "Success",
+                content: {
+                  "application/json": {
+                    schema: {
+                      $ref: "#/$defs/TestModel",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - $defs references should be converted to #/definitions/
+    const responseSchema = getReferenceSchema(getResponseSchema(converted, "/test"));
+    expect(responseSchema.$ref).toBe("#/definitions/TestModel");
+  });
+
+  // ############################################################
+  // Version update
+  // ############################################################
+
+  it("should update openapi version to 3.0.0", () => {
+    // Arrange - Create schema with version 3.1.0
+    const schema: OpenAPISchema = {
+      openapi: "3.1.0",
+      info: {
+        title: "Test API",
+        version: "1.0.0",
+      },
+      paths: {},
+    };
+
+    // Act
+    const converted = convertOpenApiToV3(schema);
+
+    // Assert - Version should be updated to 3.0.0
+    expect(converted.openapi).toBe("3.0.0");
+  });
+});


### PR DESCRIPTION
### Summary

Fixes an error with `check spec` that occurs when the OpenAPI spec schemas have array values for `type` (e.g. `type: [object]`) instead of string values (e.g. `type: object`) by simply taking the first type in the array.

- Fixes #354 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Creates a `normalizeType()` function that takes the first type value if `type` is an array
- Updates the `convertOpenApiToV3()` function to use this new function
- Adds unit tests to validate type normalization

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Technically [OpenAPI v3.0 doesn't support array values for the `type` attribute](https://swagger.io/docs/specification/v3_0/data-models/data-types/) so forcing the type into a string by taking the first value is technically the "correct" behavior if we're converting the spec to OpenAPI v3.0 syntax. However the errors we're seeing aren't an inherent limitation of OpenAPI v3.0 parsing, just a side effect of how we're comparing the types.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

**1. In `simpler-grants-gov/api`**

  - Hack `common_grants_blueprint.py` so that it invokes `yaml.dump` with the non-transformed spec instead of the transformed spec
  - Run `make openapi-spec-common-grants` to generate local file `openapi-cg.generated.yml` 
  - (Optional) Edit `openapi-cg.generated.yml` to remove known validation errors: change `status_code` to `status`, remove `internal_request_id`
  - (Optional) Copy the edited file somewhere easily-accessible to the CLI and rename it to `openapi-apiflask-example.yaml`

**2. In `simpler-grants-protocol/lib/cli` using `main`**

  -  Check the OpenAPI spec against itself:
    ```
    npm run start check spec <path>/openapi-apiflask-example.yaml --base <path>/openapi-apiflask-example.yaml
    ```
  -  You should see ~13 errors that look something like this:

```
Validation error: Spec validation failed:
13 errors
=================================
Route conflicts
  GET /common-grants/opportunities
    4 issues found:
    Response schema conflict
      MIME Type: application/json
      Location: .items[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .paginationInfo
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .errors[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .errors[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
  POST /common-grants/opportunities/search
    6 issues found:
    Response schema conflict
      MIME Type: application/json
      Location: .items[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .paginationInfo
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .sortInfo
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .filterInfo
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .errors[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .errors[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
  GET /common-grants/opportunities/{oppId}
    3 issues found:
    Response schema conflict
      MIME Type: application/json
      Location: .data
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .errors[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
    Response schema conflict
      MIME Type: application/json
      Location: .errors[0]
      Issue: Mismatched types
      Message: Type mismatch. Base is 'object', impl is 'object'
```

**3. Re-run from feature branch** 

- Checkout `issue-354-fixing-openapi-type-arrays`
- Re-run command:
    ```
    npm run start check spec <path>/openapi-apiflask-example.yaml --base <path>/openapi-apiflask-example.yaml
    ```
- You should see the following:
```
Spec is valid and compliant with base spec
```