### PR TITLE
Update automated-codejson-generator to use main branch

### DIFF
--- a/.github/workflows/update-code-json.yml
+++ b/.github/workflows/update-code-json.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Update code.json
-        uses: DSACMS/automated-codejson-generator@v1.2.0
+        uses: DSACMS/automated-codejson-generator@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: "main"


### PR DESCRIPTION
This patch moves the workflow for automatically creating codeJSON from @v1.2.0 which has breaking changes to @main, which should be a permanent fix.