### PR TITLE
[Issue #415] Add optional pagesize param to opportunity.list method 

### DIFF
--- a/lib/python-sdk/common_grants_sdk/client/config.py
+++ b/lib/python-sdk/common_grants_sdk/client/config.py
@@ -34,22 +34,26 @@ class Config:
             raise ValueError("base_url is required")
         if not base_url_value.startswith(("http://", "https://")):
             raise ValueError("base_url must start with http:// or https://")
-        # use type narrowing to avoid mypy type validation errors in client
+        # use type narrowing to avoid type validation errors in client
         self.base_url: str = cast(str, base_url_value)
 
         # set api_key value from param or env var
         api_key_value = api_key if api_key is not None else os.getenv("CG_API_KEY")
         if not api_key_value:
             raise ValueError("api_key is required")
-        # use type narrowing to avoid mypy type validation errors in client
+        # use type narrowing to avoid type validation errors in client
         self.api_key: str = cast(str, api_key_value)
 
         # set timeout value from param, env var, or default
-        self.timeout = timeout or float(
+        timeout_value = timeout or float(
             os.getenv("CG_API_TIMEOUT", self.DEFAULT_TIMEOUT)
         )
+        # use type narrowing to avoid type validation errors in client
+        self.timeout: float = cast(float, timeout_value)
 
         # set page_size value from param, env var, or default
-        self.page_size = page_size or int(
+        page_size_value = page_size or int(
             os.getenv("CG_API_PAGE_SIZE", self.DEFAULT_PAGE_SIZE)
         )
+        # use type narrowing to avoid type validation errors in client
+        self.page_size: int = cast(int, page_size_value)

--- a/lib/python-sdk/common_grants_sdk/client/opportunity.py
+++ b/lib/python-sdk/common_grants_sdk/client/opportunity.py
@@ -1,7 +1,7 @@
 """Opportunity namespace for the CommonGrants API."""
 
 import httpx
-from typing import Callable
+from typing import Callable, Optional
 from uuid import UUID
 
 from .auth import Auth
@@ -37,6 +37,7 @@ class Opportunity:
     def list(
         self,
         page: int,
+        page_size: Optional[int] = None,
     ) -> OpportunitiesListResponse:
         """Fetch a single page of opportunities.
 
@@ -49,11 +50,14 @@ class Opportunity:
         Raises:
             APIError: If the API request fails
         """
+        if page_size is None or page_size < 1:
+            page_size = self.config.page_size
+
         try:
             response = self.http.get(
                 self.url("/common-grants/opportunities"),
                 headers=self.auth.get_headers(),
-                params={"page": page, "pageSize": self.config.page_size},
+                params={"page": page, "pageSize": page_size},
             )
             response.raise_for_status()
             result = OpportunitiesListResponse.model_validate_json(response.text)


### PR DESCRIPTION
### Summary

- Fixes #415 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

Adds optional `page_size` parameter to `Opportunity.list` method

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

This change allows callers of the `Opportunity.list` method to override the `Config.page_size` value

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.
