### PR TITLE
[Issue #422] Fix script for generating release notes

### DIFF
--- a/.github/scripts/validate-and-generate-release-notes.sh
+++ b/.github/scripts/validate-and-generate-release-notes.sh
@@ -82,13 +82,13 @@ if [[ -n "$PREVIOUS_TAG" ]]; then
   NOTES=$(gh api repos/"$REPOSITORY"/releases/generate-notes \
     -f tag_name="$RELEASE_TAG" \
     -f previous_tag_name="$PREVIOUS_TAG" \
-    -f configuration_file="$CONFIG_FILE" \
+    -f configuration_file_path="$CONFIG_FILE" \
     -q '.body')
 else
   echo "Generating release notes for $RELEASE_TAG"
   NOTES=$(gh api repos/"$REPOSITORY"/releases/generate-notes \
     -f tag_name="$RELEASE_TAG" \
-    -f configuration_file="$CONFIG_FILE" \
+    -f configuration_file_path="$CONFIG_FILE" \
     -q '.body')
 fi
 


### PR DESCRIPTION
### Summary

Fixes the generate release notes script. The old script used the wrong query param to pass the config file to the generate release notes API (`configuration_file` instead of `configuration_file_path`)

- Fixes #422 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Fixes the config file query param in `validate-and-generate-release-notes.sh`

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

To validate this I created a temporary `common-grants-sdk@0.3.3` tag since the generate release notes API endpoint only works if the tag you pass is tied to a commit after the config files were added to the `main` branch of the repo.

Once we merge this in I'll delete that tag.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Here's the [dry-run with the temporary v0.3.3 tag](https://github.com/HHS/simpler-grants-protocol/actions/runs/19507017868)

<img width="1064" height="734" alt="Screenshot 2025-11-19 at 10 36 45 AM" src="https://github.com/user-attachments/assets/c1a5f410-1988-443e-845c-70e542cbfaef" />

Here's the comparison of all commits between the two tags, showing that we're filtering out non-relevant PRs.

> [!NOTE]
> I've since deleted the temporary tag we created to validate this behavior.

<img width="1440" height="900" alt="Screenshot 2025-11-19 at 10 39 23 AM" src="https://github.com/user-attachments/assets/912c531c-cd7d-4e79-91d7-61d29b26bdc9" />

