### PR TITLE
[Issue #446] Fixes script to generate release notes

### DIFF
--- a/.github/scripts/validate-and-generate-release-notes.sh
+++ b/.github/scripts/validate-and-generate-release-notes.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # Script to validate tags and generate release notes
-# Usage: validate-and-generate-release-notes.sh --prefix PREFIX --config-file CONFIG --release-tag TAG [--previous-tag PREV_TAG] [--dry-run] [--repository REPO] [--github-output OUTPUT_FILE]
+# Usage: validate-and-generate-release-notes.sh \
+#  --prefix PREFIX \
+#  --config-file CONFIG \
+#  --release-tag TAG \
+#  [--previous-tag PREV_TAG] \
+#  [--dry-run] \
+#  [--repository REPO] \
+#  [--github-output OUTPUT_FILE]
 
 set -e
 
@@ -28,8 +35,13 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --previous-tag)
-      # Checks if the next argument ($2) exists and is not another option (does not start with --)
-      if [[ -n "$2" ]] && [[ ! "$2" =~ ^-- ]]; then
+      # Optional argument: accepts a value if the next argument exists and isn't another flag
+      # Handles these scenarios:
+      #   --previous-tag "v1.0.0"      → PREVIOUS_TAG="v1.0.0", shift 2
+      #   --previous-tag ""            → PREVIOUS_TAG="", shift 2 (explicit empty string)
+      #   --previous-tag --other-flag  → PREVIOUS_TAG unchanged, shift 1 (next arg is a flag)
+      #   --previous-tag (at end)      → PREVIOUS_TAG unchanged, shift 1 (no more args)
+      if [[ $# -gt 1 ]] && [[ ! "$2" =~ ^-- ]]; then
         PREVIOUS_TAG="$2"
         shift 2
       else


### PR DESCRIPTION
### Summary

Fixes how the `validate-and-generate-release-notes.sh` handles the option `--previous-tag ""` which was breaking the CD workflows that were triggered without providing a previous tag.

- Fixes #446 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Fixes `validate-and-generate-release-notes.sh` to skip over the `--previous-tag` option when passed an empty string `""`
- Improves code comments related to that parsing option

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

The script failed if it received `--previous-tag ""` as an option because the script only ignored the previous tag if it was omitted or received no argument. This updates the option parsing to also skip parsing the previous tag option when set to an empty string `""`

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

#### Testing locally

1. Recreate the issue on `main` by running this from the root of the repo. It should fail with `Unknown option: `
   ```
   .github/scripts/validate-and-generate-release-notes.sh \
      --prefix "@common-grants/cli@" \
      --config-file ".github/release-config/lib-cli.yml" \
      --release-tag "@common-grants/cli@0.2.4" \
      --previous-tag "" \
      --repository "HHS/simpler-grants-protocol" \
      --dry-run
   ```
2. Checkout this PR branch and re-run the script, and it should pass with:
   ```
    ✓ Latest tag '@common-grants/cli@0.2.4' is valid
    Generating release notes for @common-grants/cli@0.2.4
    
    === DRY RUN MODE - Release notes preview ===
    Latest tag: @common-grants/cli@0.2.4
    Previous tag: 
    
    <!-- Release notes generated using configuration in .github/release-config/lib-cli.yml at @common-grants/cli@0.2.4 -->
    
    
    
    **Full Changelog**: https://github.com/HHS/simpler-grants-protocol/compare/common-grants-sdk@0.4.0...@common-grants/cli@0.2.4
    === End of preview ===
   ```
<img width="987" height="598" alt="Screenshot 2025-12-16 at 9 34 19 AM" src="https://github.com/user-attachments/assets/9e5ea263-027f-4f95-ae31-073e7d47fd5c" />


#### Testing with GitHub action

Here's a dry run with [the CLI workflow](https://github.com/HHS/simpler-grants-protocol/actions/runs/20271619100/job/58208731985). 

<img width="1440" height="900" alt="Screenshot 2025-12-16 at 9 38 19 AM" src="https://github.com/user-attachments/assets/00fdfbe5-41f7-4a16-a534-fa06084bf93e" />

And here's another test with the [Py SDK workflow](https://github.com/HHS/simpler-grants-protocol/actions/runs/20271752676/job/58209215227):

<img width="1440" height="776" alt="Screenshot 2025-12-16 at 9 40 35 AM" src="https://github.com/user-attachments/assets/e66c1ecf-6ca1-4e30-96d4-c36da14ea910" />
