### PR TITLE
[Issue #442] Fix website deployment workflow

### DIFF
--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -35,14 +35,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install, build, and upload your site
-        uses: withastro/action@v5
+      - name: Build website
+        run: pnpm --filter website build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: ./website # Path to the root of our Astro project
+          path: ./website/dist
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    # Only deploy from main branch
+    if: github.ref == 'refs/heads/main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
### Summary

Fixes and simplifies the `cd-deploy-website.yml` workflow after it broke when we switched to `pnpm` from `npm`.

- Fixes #442 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Removes the Astro action in favor of using the `upload-pages-artifact` action directly
- Skips deployment step if running deploy workflow manually from a branch

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Shifting the website to pnpm workspace broke the previous Astro action because it couldn't find a lockfile in the same directory as the website. Reviewing the Astro action made me realize we can actually just use the upload-pages-artifact directly instead.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

I was able to test everything up until the actual deployment to GitHub pages (which can only happen from `main`) using a [workflow dispatch from this branch](https://github.com/HHS/simpler-grants-protocol/actions/runs/20312582269/job/58347572269)

<img width="1440" height="900" alt="Screenshot 2025-12-17 at 1 09 49 PM" src="https://github.com/user-attachments/assets/bc28420c-a0ba-4f01-9894-045824de9edb" />

