### PR TITLE
[Issue #499] Refactoring opportunity to opportunities

### DIFF
--- a/lib/python-sdk/common_grants_sdk/client/client.py
+++ b/lib/python-sdk/common_grants_sdk/client/client.py
@@ -8,7 +8,7 @@ from .auth import Auth
 from .config import Config
 from .response import SuccessResponse
 from .exceptions import raise_api_error
-from .opportunity import Opportunity
+from .opportunities import Opportunities
 from .pagination import pagination
 from .types import ItemsT
 from ..schemas.pydantic.responses import Paginated
@@ -32,7 +32,7 @@ class Client:
         self.config = config or Config()
         self.auth = auth or Auth.api_key(self.config.api_key)
         self.http = httpx.Client(timeout=self.config.timeout)
-        self.opportunity = Opportunity(client=self)
+        self.opportunities = Opportunities(client=self)
 
     def post(self, path: str, **kwargs) -> httpx.Response:
         """Simple wrapper around self.http.post.

--- a/lib/python-sdk/common_grants_sdk/client/opportunities.py
+++ b/lib/python-sdk/common_grants_sdk/client/opportunities.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from .client import Client
 
 
-class Opportunity:
+class Opportunities:
     """Class for fetching opportunity data from CommonGrants API."""
 
     def __init__(self, client: "Client"):

--- a/lib/python-sdk/examples/README.md
+++ b/lib/python-sdk/examples/README.md
@@ -58,7 +58,7 @@ poetry run python examples/list_opportunity.py
 
 ```
 
-** Output Example: **
+**Output Example:**
 ```
 Found 3 opportunities:
   - 573525f2-8e15-4405-83fb-e6523511d893: STEM Education Grant Program, custom field value: 12345, custom field description: Legacy system opportunity ID
@@ -71,7 +71,7 @@ poetry run python examples/get_opportunity.py <opportunityId>
 
 ```
 
-** Output Example: ** 
+**Output Example:** 
 ```
 Opportunity 573525f2-8e15-4405-83fb-e6523511d893:
   Title: STEM Education Grant Program
@@ -84,7 +84,7 @@ poetry run python examples/search_opportunity.py <searchTerm>
 
 ```
 
-** Output Example: ** 
+**Output Example:** 
 ```
 Found 2 opportunities:
  - 573525f2-8e15-4405-83fb-e6523511d893: STEM Education Grant Program custom field value: 12345, custom field description: Legacy system opportunity ID
@@ -97,7 +97,7 @@ Found 2 opportunities:
 poetry run python examples/custom_fields.py
 ```
 
-** Output Example: **
+**Output Example:**
 ```
 12345
 TEST_GROUP
@@ -109,7 +109,7 @@ TEST_GROUP
 poetry run python examples/get_custom_fields.py
 ```
 
-** Output Example: **
+**Output Example:**
 
 ```
 name='legacyId' field_type=<CustomFieldType.OBJECT: 'object'> schema_url=None value={'system': 'legacy', 'id': 123} description=None

--- a/lib/python-sdk/examples/get_opportunity.py
+++ b/lib/python-sdk/examples/get_opportunity.py
@@ -36,7 +36,7 @@ fields = {
 opp = OpportunityBase.with_custom_fields(custom_fields=fields, model_name="Opportunity")
 
 
-opportunity = client.opportunity.get(opp_id, schema=opp)
+opportunity = client.opportunities.get(opp_id, schema=opp)
 
 print(f"Opportunity {opp_id}:")
 print(f"  Title: {opportunity.title}")

--- a/lib/python-sdk/examples/list_opportunity.py
+++ b/lib/python-sdk/examples/list_opportunity.py
@@ -31,7 +31,7 @@ fields = {
 opp = OpportunityBase.with_custom_fields(custom_fields=fields, model_name="Opportunity")
 
 
-response = client.opportunity.list(page=1, schema=opp)
+response = client.opportunities.list(page=1, schema=opp)
 
 print(f"Found {len(response.items)} opportunities:")
 for item in response.items:

--- a/lib/python-sdk/examples/search_opportunity.py
+++ b/lib/python-sdk/examples/search_opportunity.py
@@ -34,7 +34,7 @@ fields = {
 opp = OpportunityBase.with_custom_fields(custom_fields=fields, model_name="Opportunity")
 
 
-response = client.opportunity.search(
+response = client.opportunities.search(
     search=search, status=[OppStatusOptions.OPEN], page=1, schema=opp
 )
 

--- a/lib/python-sdk/tests/client/test_client.py
+++ b/lib/python-sdk/tests/client/test_client.py
@@ -26,7 +26,7 @@ class TestClient:
             client = Client(config=config, auth=auth)
             assert client.config.base_url == "https://api.example.com"
             assert client.auth == auth
-            assert isinstance(client.opportunity, type(client.opportunity))
+            assert isinstance(client.opportunities, type(client.opportunities))
 
     def test_client_initialization_defaults_auth(self, monkeypatch):
         """Test client initialization with default auth from config."""
@@ -107,9 +107,9 @@ class TestClient:
         with patch("common_grants_sdk.client.client.httpx.Client"):
             config = Config(base_url="https://api.example.com", api_key="test-key")
             client = Client(config=config)
-            assert hasattr(client, "opportunity")
-            assert hasattr(client.opportunity, "get")
-            assert hasattr(client.opportunity, "list")
+            assert hasattr(client, "opportunities")
+            assert hasattr(client.opportunities, "get")
+            assert hasattr(client.opportunities, "list")
 
     def test_client_context_manager(self):
         """Test client as context manager."""

--- a/lib/python-sdk/tests/client/test_opportunities.py
+++ b/lib/python-sdk/tests/client/test_opportunities.py
@@ -104,7 +104,7 @@ def client(mock_httpx_client):
     client = Client(config=config, auth=auth)
     client.http = mock_httpx_client
     # Update opportunity's http reference
-    client.opportunity.http = mock_httpx_client
+    client.opportunities.http = mock_httpx_client
     return client
 
 
@@ -126,7 +126,7 @@ class TestOpportunityGet:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        opp = client.opportunity.get(opp_id)
+        opp = client.opportunities.get(opp_id)
         assert isinstance(opp, OpportunityBase)
         assert str(opp.id) == str(opp_id)
 
@@ -160,7 +160,7 @@ class TestOpportunityGet:
         opp_base = OpportunityBase.with_custom_fields(
             custom_fields=fields, model_name="Opportuntiy"
         )
-        opp = client.opportunity.get(opp_id_str, schema=opp_base)
+        opp = client.opportunities.get(opp_id_str, schema=opp_base)
         assert isinstance(opp, opp_base)
         assert str(opp.id) == opp_id_str
         assert opp.custom_fields.legacy_id.value == 12345
@@ -181,7 +181,7 @@ class TestOpportunityGet:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.get(opp_id)
+            client.opportunities.get(opp_id)
         assert exc_info.value.error.status == 404
 
     def test_get_opportunity_401(self, client, mock_httpx_client):
@@ -200,7 +200,7 @@ class TestOpportunityGet:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.get(opp_id)
+            client.opportunities.get(opp_id)
         assert exc_info.value.error.status == 401
 
     def test_get_opportunity_500(self, client, mock_httpx_client):
@@ -219,7 +219,7 @@ class TestOpportunityGet:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.get(opp_id)
+            client.opportunities.get(opp_id)
         assert exc_info.value.error.status == 500
 
     def test_get_opportunity_invalid_response(self, client, mock_httpx_client):
@@ -235,7 +235,7 @@ class TestOpportunityGet:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(ValidationError):
-            client.opportunity.get(opp_id)
+            client.opportunities.get(opp_id)
 
     def test_get_opportunity_request_error(self, client, mock_httpx_client):
         """Test getting an opportunity with request error."""
@@ -243,7 +243,7 @@ class TestOpportunityGet:
         mock_httpx_client.get = Mock(side_effect=httpx.RequestError("Connection error"))
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.get(opp_id)
+            client.opportunities.get(opp_id)
         assert exc_info.value.error.status == 0
         assert "Connection error" in exc_info.value.error.message
 
@@ -270,7 +270,7 @@ class TestOpportunityList:
             custom_fields=fields, model_name="Opportuntiy"
         )
 
-        response = client.opportunity.list(page=1, schema=opp_base)
+        response = client.opportunities.list(page=1, schema=opp_base)
 
         assert isinstance(response, OpportunitiesListResponse)
         assert len(response.items) == 2
@@ -302,7 +302,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        response = client.opportunity.list(page=2)
+        response = client.opportunities.list(page=2)
         assert response.pagination_info.page == 2
 
         call_args = mock_httpx_client.get.call_args
@@ -318,7 +318,7 @@ class TestOpportunityList:
         )
         client = Client(config=config, auth=auth)
         client.http = mock_httpx_client
-        client.opportunity.http = mock_httpx_client
+        client.opportunities.http = mock_httpx_client
 
         sample_response = {
             "status": 200,
@@ -339,7 +339,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        client.opportunity.list(page=1)
+        client.opportunities.list(page=1)
         call_args = mock_httpx_client.get.call_args
         assert call_args[1]["params"]["pageSize"] == 50
 
@@ -355,7 +355,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        client.opportunity.list(page=1, page_size=25)
+        client.opportunities.list(page=1, page_size=25)
         call_args = mock_httpx_client.get.call_args
         assert call_args[1]["params"]["pageSize"] == 25
 
@@ -370,7 +370,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        client.opportunity.list(page=1, page_size=None)
+        client.opportunities.list(page=1, page_size=None)
         call_args = mock_httpx_client.get.call_args
         assert call_args[1]["params"]["pageSize"] == 100  # config default
 
@@ -385,7 +385,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        client.opportunity.list(page=1, page_size=0)
+        client.opportunities.list(page=1, page_size=0)
         call_args = mock_httpx_client.get.call_args
         assert (
             call_args[1]["params"]["pageSize"] == 100
@@ -402,7 +402,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        client.opportunity.list(page=1, page_size=-1)
+        client.opportunities.list(page=1, page_size=-1)
         call_args = mock_httpx_client.get.call_args
         assert (
             call_args[1]["params"]["pageSize"] == 100
@@ -423,7 +423,7 @@ class TestOpportunityList:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.list(page=1)
+            client.opportunities.list(page=1)
         assert exc_info.value.error.status == 404
 
     def test_list_opportunities_401(self, client, mock_httpx_client):
@@ -441,7 +441,7 @@ class TestOpportunityList:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.list(page=1)
+            client.opportunities.list(page=1)
         assert exc_info.value.error.status == 401
 
     def test_list_opportunities_validation_error(self, client, mock_httpx_client):
@@ -456,14 +456,14 @@ class TestOpportunityList:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(ValidationError):
-            client.opportunity.list(page=1)
+            client.opportunities.list(page=1)
 
     def test_list_opportunities_request_error(self, client, mock_httpx_client):
         """Test listing opportunities with request error."""
         mock_httpx_client.get = Mock(side_effect=httpx.RequestError("Connection error"))
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.list(page=1)
+            client.opportunities.list(page=1)
         assert exc_info.value.error.status == 0
         assert "Connection error" in exc_info.value.error.message
 
@@ -478,7 +478,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        response = client.opportunity.list(page=None)
+        response = client.opportunities.list(page=None)
         assert isinstance(response, OpportunitiesListResponse)
         assert len(response.items) == 2
         assert all(isinstance(item, OpportunityBase) for item in response.items)
@@ -555,7 +555,7 @@ class TestOpportunityList:
 
         mock_httpx_client.get = Mock(side_effect=mock_get)
 
-        response = client.opportunity.list(page=None)
+        response = client.opportunities.list(page=None)
         assert isinstance(response, OpportunitiesListResponse)
         # Should have all 5 items from all 3 pages
         assert len(response.items) == 5
@@ -617,7 +617,7 @@ class TestOpportunityList:
 
         mock_httpx_client.get = Mock(side_effect=mock_get)
 
-        response = client.opportunity.list(page=None, page_size=3)
+        response = client.opportunities.list(page=None, page_size=3)
         assert isinstance(response, OpportunitiesListResponse)
         assert len(response.items) == 4
         assert response.pagination_info.page_size == 4
@@ -648,7 +648,7 @@ class TestOpportunityList:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.get = Mock(return_value=mock_response)
 
-        response = client.opportunity.list(page=None)
+        response = client.opportunities.list(page=None)
         assert isinstance(response, OpportunitiesListResponse)
         assert len(response.items) == 0
         assert response.pagination_info.total_items == 0
@@ -671,7 +671,7 @@ class TestOpportunityList:
         mock_httpx_client.get = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.list(page=None)
+            client.opportunities.list(page=None)
         assert exc_info.value.error.status == 500
 
     def test_list_all_opportunities_error_on_subsequent_page(
@@ -715,7 +715,7 @@ class TestOpportunityList:
         mock_httpx_client.get = Mock(side_effect=mock_get)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.list(page=None)
+            client.opportunities.list(page=None)
         assert exc_info.value.error.status == 500
 
 
@@ -740,7 +740,7 @@ class TestOpportunitySearch:
             custom_fields=fields, model_name="Opportuntiy"
         )
 
-        response = client.opportunity.search(
+        response = client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], schema=opp_base
         )
 
@@ -770,7 +770,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        response = client.opportunity.search(
+        response = client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=2
         )
         assert response.pagination_info.page == 2
@@ -785,7 +785,7 @@ class TestOpportunitySearch:
         )
         client = Client(config=config, auth=auth)
         client.http = mock_httpx_client
-        client.opportunity.http = mock_httpx_client
+        client.opportunities.http = mock_httpx_client
 
         sample_response = {
             "status": 200,
@@ -813,7 +813,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        client.opportunity.search(
+        client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=1
         )
         call_args = mock_httpx_client.post.call_args
@@ -831,7 +831,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        client.opportunity.search(
+        client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=1, page_size=25
         )
         call_args = mock_httpx_client.post.call_args
@@ -848,7 +848,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        client.opportunity.search(
+        client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=1, page_size=None
         )
         call_args = mock_httpx_client.post.call_args
@@ -865,7 +865,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        client.opportunity.search(
+        client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=1, page_size=0
         )
         call_args = mock_httpx_client.post.call_args
@@ -884,7 +884,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        client.opportunity.search(
+        client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=1, page_size=-1
         )
         call_args = mock_httpx_client.post.call_args
@@ -907,7 +907,7 @@ class TestOpportunitySearch:
         mock_httpx_client.post = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.search(
+            client.opportunities.search(
                 search="local", status=[OppStatusOptions.OPEN], page=1
             )
         assert exc_info.value.error.status == 404
@@ -927,7 +927,7 @@ class TestOpportunitySearch:
         mock_httpx_client.post = Mock(return_value=mock_response)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.search(
+            client.opportunities.search(
                 search="local", status=[OppStatusOptions.OPEN], page=1
             )
         assert exc_info.value.error.status == 401
@@ -944,7 +944,7 @@ class TestOpportunitySearch:
         mock_httpx_client.post = Mock(return_value=mock_response)
 
         with pytest.raises(ValidationError):
-            client.opportunity.search(
+            client.opportunities.search(
                 search="local", status=[OppStatusOptions.OPEN], page=1
             )
 
@@ -955,7 +955,7 @@ class TestOpportunitySearch:
         )
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.search(
+            client.opportunities.search(
                 search="local", status=[OppStatusOptions.OPEN], page=1
             )
         assert exc_info.value.error.status == 0
@@ -972,7 +972,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        response = client.opportunity.search(
+        response = client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=None
         )
         assert isinstance(response, OpportunitiesSearchResponse)
@@ -1072,7 +1072,7 @@ class TestOpportunitySearch:
 
         mock_httpx_client.post = Mock(side_effect=mock_post)
 
-        response = client.opportunity.search(
+        response = client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=None
         )
         assert isinstance(response, OpportunitiesSearchResponse)
@@ -1120,7 +1120,7 @@ class TestOpportunitySearch:
         mock_response.raise_for_status = Mock()
         mock_httpx_client.post = Mock(return_value=mock_response)
 
-        response = client.opportunity.search(
+        response = client.opportunities.search(
             search="local", status=[OppStatusOptions.OPEN], page=None
         )
         assert isinstance(response, OpportunitiesSearchResponse)
@@ -1169,7 +1169,7 @@ class TestOpportunitySearch:
         mock_httpx_client.post = Mock(side_effect=mock_post)
 
         with pytest.raises(APIError) as exc_info:
-            client.opportunity.search(
+            client.opportunities.search(
                 search="local", status=[OppStatusOptions.OPEN], page=None
             )
         assert exc_info.value.error.status == 500


### PR DESCRIPTION
### Summary

- Fixes #499 
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

This PR contains a refactor to the `client.opportunities` code to change it from the singular `opportunity` to `opportunity`.  This is to match the typescript SDK.

It also contains a formatting update in the example readme where some of the bolded section titles contained extra spaces.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Ran the pipeline checks and the built in unit tests.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="832" height="195" alt="image" src="https://github.com/user-attachments/assets/73e0a5a7-68c5-47f3-bf25-527bc4d6d7b2" />

1. Go into `lib/ts-sdk` and run `pnpm example:server`
2. In a separate terminal session cd `lib/python-sdk` 
3. Run `poetry run python examples/list_opportunity.py`
4. Run `poetry run python examples/get_opportunity.py <ID YOU GOT FROM LIST COMMAND>
5. Run `poetry run python examples/search_opportunity.py education`

Each of the last 3 commands should run and return example data from the dummy API
