### PR TITLE
[Issue #612] Ignore major Dependabot bumps and group Python SDK deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,9 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # Major bumps handled manually to control breaking changes
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       # Internal workspace deps
       - dependency-name: "@common-grants/*"
       # Catalog-managed deps — handled by scheduled workflow instead
@@ -61,6 +64,8 @@ updates:
       all-deps:
         patterns: ["*"]
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@common-grants/*"
     labels: ["dependencies"]
     commit-message:
@@ -77,6 +82,8 @@ updates:
       all-deps:
         patterns: ["*"]
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "@common-grants/*"
     labels: ["dependencies"]
     commit-message:
@@ -89,6 +96,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      all-deps:
+        patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "python"]
     commit-message:
       prefix: "chore"
@@ -103,6 +116,8 @@ updates:
       all-deps:
         patterns: ["*"]
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "common-grants-sdk"
     labels: ["dependencies", "python"]
     commit-message:
@@ -118,6 +133,8 @@ updates:
       all-deps:
         patterns: ["*"]
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "common-grants-sdk"
     labels: ["dependencies", "python"]
     commit-message:
@@ -133,6 +150,8 @@ updates:
       all-deps:
         patterns: ["*"]
     ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "common-grants-sdk"
     labels: ["dependencies", "python"]
     commit-message:
@@ -149,6 +168,9 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies"]
     commit-message:
       prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -168,9 +168,6 @@ updates:
     groups:
       actions:
         patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     labels: ["dependencies"]
     commit-message:
       prefix: "chore"

--- a/.github/workflows/ci-website-preview.yml
+++ b/.github/workflows/ci-website-preview.yml
@@ -49,14 +49,14 @@ jobs:
 
       # Preview deployment (only on PRs)
       - name: Deploy PR preview
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         run: pnpm wrangler deploy --name cg-pr-${{ github.event.pull_request.number }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Find existing comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         id: find-comment
         uses: peter-evans/find-comment@v3
         with:
@@ -65,7 +65,7 @@ jobs:
           body-includes: Website Preview Deployed
 
       - name: Post preview link comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}

--- a/DEPENDENCY_MANAGEMENT.md
+++ b/DEPENDENCY_MANAGEMENT.md
@@ -1,5 +1,12 @@
 # Dependency Management
 
+## Strategy
+
+- Group GitHub Actions major bumps into a single PR
+- Group minor/patch updates by manifest (e.g. `pnpm-lock.yaml` or `poetry.lock`) into a single PR
+- Ignore major bumps for packages — these are handled manually to control breaking changes
+- Catalog-managed deps (TypeSpec, vitest, etc.) bypass Dependabot entirely due to pnpm catalog bugs
+
 This repo uses a split strategy for automated dependency updates: Dependabot handles most things, and a scheduled GitHub Actions workflow handles the rest. Expect roughly 3-5 dependency PRs per week in normal operation.
 
 ## Why two systems?
@@ -23,7 +30,7 @@ Dependabot runs on three "worlds":
 - Updates non-catalog deps across all workspace packages
 - Groups Astro/Starlight packages together (`website-framework` group)
 - Groups all other minor/patch updates together (`minor-patch` group)
-- Major version bumps get individual PRs (not grouped) for careful review
+- Major version bumps are ignored (handled manually)
 - Ignores `@common-grants/*` (internal workspace deps) and all catalog-managed deps
 
 **World B: Isolated lockfile directories** (weekly or monthly)
@@ -32,7 +39,7 @@ Dependabot runs on three "worlds":
 |-----------|----------|-------|
 | `templates/express-js` | Weekly, Tuesdays | All deps grouped |
 | `templates/quickstart` | Weekly, Tuesdays | All deps grouped |
-| `lib/python-sdk` | Weekly, Wednesdays | pip/Poetry |
+| `lib/python-sdk` | Weekly, Wednesdays | pip/Poetry, all deps grouped |
 | `templates/fast-api` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
 | `examples/pa-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
 | `examples/ca-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk` |

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3018,8 +3018,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -5094,8 +5094,9 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -8551,7 +8552,7 @@ snapshots:
       '@swagger-api/apidom-core': 1.8.0
       '@swagger-api/apidom-error': 1.8.0
       '@types/ramda': 0.30.2
-      axios: 1.13.6
+      axios: 1.15.0
       minimatch: 10.2.4
       ramda: 0.30.1
       ramda-adjunct: 5.1.0(ramda@0.30.1)
@@ -9406,11 +9407,11 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.13.6:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
-      proxy-from-env: 1.1.0
+      proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
@@ -11943,7 +11944,7 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
+  proxy-from-env@2.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary

Follow-up to #647 — addresses issues surfaced by Dependabot's first run after the config was introduced.

## Changes

### 1. Ignore major version bumps for packages (`.github/dependabot.yml`)

Added `version-update:semver-major` ignore rule to all 7 package-level Dependabot entries (npm + pip). Major bumps for packages will be handled manually to control breaking changes. GitHub Actions majors are **not** ignored — Actions use major tags as their primary versioning interface, so those bumps remain grouped into a single PR.

### 2. Group Python SDK deps (`.github/dependabot.yml`)

Added `groups.all-deps` to the `/lib/python-sdk` entry, matching the pattern already used by templates and examples. Batches all Python SDK dependency updates into a single PR instead of one per dependency.

### 3. Skip website preview deploy on Dependabot PRs (`.github/workflows/ci-website-preview.yml`)

Dependabot runs can't access Cloudflare secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`), causing the preview deploy step to fail. Added `github.actor != 'dependabot[bot]'` guard to the deploy, comment lookup, and comment post steps.

### 4. Fix axios audit vulnerability (`pnpm-lock.yaml`)

Bumped transitive `axios` from 1.13.6 to 1.15.0 (via lockfile resolution) to fix critical SSRF vulnerability [GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5). The dep chain `swagger-ui-react → swagger-client → @swagger-api/apidom-reference → axios` already permitted `^1.12.2`, so no `package.json` changes were needed.

### 5. Document dependency management strategy (`DEPENDENCY_MANAGEMENT.md`)

Added a strategy overview section at the top of the doc summarizing the overarching rules. Updated stale references (major bumps are now ignored, Python SDK deps are now grouped).

## Context

After #647 merged, Dependabot opened 20+ PRs — individual PRs for every major bump, ungrouped Python SDK deps, and failed CI from inaccessible Cloudflare secrets and a new axios vulnerability. This PR reduces the noise, fixes CI, and documents the strategy.