### PR TITLE
fix(ci): handle missing FIDER_TOKEN in coplanning sync dry-run

### DIFF
--- a/.github/workflows/coplanning-sync-gh-to-fider.yml
+++ b/.github/workflows/coplanning-sync-gh-to-fider.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: "3.13"
 
       - name: Run script (dry run)
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.FIDER_API_TOKEN != ''
         run: |
           python run.py \
             --org "${{ github.repository_owner }}" \


### PR DESCRIPTION
## Summary
- Skip the GitHub-to-Fider dry-run step when `FIDER_API_TOKEN` is empty
- Leave the workflow_dispatch real-run path unchanged

## Verification
- YAML parsed successfully
- Workflow diff only changes the dry-run step guard