### PR TITLE
fix(ci): add ruff rule ignores and separate linter dep group in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -97,7 +97,16 @@ updates:
       interval: "weekly"
       day: "wednesday"
     groups:
+      linter-tools:
+        patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
       all-deps:
+        exclude-patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
         patterns: ["*"]
     ignore:
       - dependency-name: "*"
@@ -113,7 +122,16 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      linter-tools:
+        patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
       all-deps:
+        exclude-patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
         patterns: ["*"]
     ignore:
       - dependency-name: "*"
@@ -130,7 +148,16 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      linter-tools:
+        patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
       all-deps:
+        exclude-patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
         patterns: ["*"]
     ignore:
       - dependency-name: "*"
@@ -147,7 +174,16 @@ updates:
     schedule:
       interval: "monthly"
     groups:
+      linter-tools:
+        patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
       all-deps:
+        exclude-patterns:
+          - "ruff"
+          - "black"
+          - "mypy"
         patterns: ["*"]
     ignore:
       - dependency-name: "*"

--- a/DEPENDENCY_MANAGEMENT.md
+++ b/DEPENDENCY_MANAGEMENT.md
@@ -6,6 +6,7 @@
 - Group minor/patch updates by manifest (e.g. `pnpm-lock.yaml` or `poetry.lock`) into a single PR
 - Ignore major bumps for packages — these are handled manually to control breaking changes
 - Catalog-managed deps (TypeSpec, vitest, etc.) bypass Dependabot entirely due to pnpm catalog bugs
+- Separate linter tools (ruff, black, mypy) into their own Dependabot group for Python projects so linter updates don't block other dependency updates
 
 This repo uses a split strategy for automated dependency updates: Dependabot handles most things, and a scheduled GitHub Actions workflow handles the rest. Expect roughly 3-5 dependency PRs per week in normal operation.
 
@@ -39,10 +40,10 @@ Dependabot runs on three "worlds":
 |-----------|----------|-------|
 | `templates/express-js` | Weekly, Tuesdays | All deps grouped |
 | `templates/quickstart` | Weekly, Tuesdays | All deps grouped |
-| `lib/python-sdk` | Weekly, Wednesdays | pip/Poetry, all deps grouped |
-| `templates/fast-api` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
-| `examples/pa-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
-| `examples/ca-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
+| `lib/python-sdk` | Weekly, Wednesdays | pip/Poetry, linters grouped separately |
+| `templates/fast-api` | Monthly | pip/Poetry, ignores `common-grants-sdk`, linters grouped separately |
+| `examples/pa-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk`, linters grouped separately |
+| `examples/ca-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk`, linters grouped separately |
 
 **World C: GitHub Actions** (weekly, Mondays)
 - All Actions grouped into a single PR

--- a/examples/ca-opportunity-example/pyproject.toml
+++ b/examples/ca-opportunity-example/pyproject.toml
@@ -39,9 +39,13 @@ extend-safe-fixes = [
 ignore = [
   "ARG002", # argument unused
   "ANN204", # missing type annotation for special method
+  "B905", # zip-without-explicit-strict: zip() without explicit strict= parameter
   "D203", # no blank line before class
   "D212", # multi-line summary first line
   "FA", # flake8-future-annotations ruleset
   "FAST002", # missing type annotation for dependency
+  "PLC0415", # import-outside-top-level: import not at top of file
+  "RUF043", # pytest-raises-ambiguous-pattern: match= pattern with unescaped metacharacters
+  "RUF059", # unused-unpacked-variable: unpacked variable never used
 ]
 select = ["ALL"]

--- a/examples/ca-opportunity-example/src/common_grants/utils/date_transform.py
+++ b/examples/ca-opportunity-example/src/common_grants/utils/date_transform.py
@@ -168,7 +168,7 @@ def transform_seasonal(value: str, output_format: DateFormat) -> datetime:
 
     """
     # Extract the first season and year if there's a range
-    season_year = value.split("-")[0].strip()
+    season_year = value.split("-", maxsplit=1)[0].strip()
 
     # Parse season and year, ignoring modifiers like "Late", "Early", etc.
     season_match = re.match(

--- a/examples/ca-opportunity-example/tests/common_grants/routes/test_opportunities.py
+++ b/examples/ca-opportunity-example/tests/common_grants/routes/test_opportunities.py
@@ -2,9 +2,8 @@
 
 from uuid import uuid4
 
-from fastapi.testclient import TestClient
-
 from common_grants.utils.opp_data_source import OpportunityDataSource
+from fastapi.testclient import TestClient
 
 
 class TestListOpportunities:

--- a/examples/ca-opportunity-example/tests/common_grants/services/test_opportunity.py
+++ b/examples/ca-opportunity-example/tests/common_grants/services/test_opportunity.py
@@ -1,14 +1,13 @@
 """Tests for the opportunity service layer."""
 
 import pytest
+from common_grants.services.opportunity import OpportunityService
 from common_grants_sdk.schemas.pydantic import (
     OppFilters,
     OppSortBy,
     OppSorting,
     PaginatedBodyParams,
 )
-
-from common_grants.services.opportunity import OpportunityService
 
 
 class TestOpportunityService:

--- a/examples/ca-opportunity-example/tests/common_grants/services/test_utils.py
+++ b/examples/ca-opportunity-example/tests/common_grants/services/test_utils.py
@@ -4,16 +4,15 @@ from datetime import date
 from typing import cast
 from uuid import UUID
 
+from common_grants.services.utils import (
+    build_applied_filters,
+    mock_opportunity,
+)
 from common_grants_sdk.schemas.pydantic import (
     EventType,
     OppFilters,
     OppStatusOptions,
     SingleDateEvent,
-)
-
-from common_grants.services.utils import (
-    build_applied_filters,
-    mock_opportunity,
 )
 
 
@@ -80,12 +79,12 @@ class TestMockOpportunity:
 
         assert opp.key_dates is not None
         assert opp.key_dates.post_date is not None
-        post_date_event = cast(SingleDateEvent, opp.key_dates.post_date)
+        post_date_event = cast("SingleDateEvent", opp.key_dates.post_date)
         assert post_date_event.date == app_opens
         assert post_date_event.name == "Application Posted"
         assert post_date_event.event_type == EventType.SINGLE_DATE
         assert opp.key_dates.close_date is not None
-        close_date_event = cast(SingleDateEvent, opp.key_dates.close_date)
+        close_date_event = cast("SingleDateEvent", opp.key_dates.close_date)
         assert close_date_event.date == app_deadline
         assert close_date_event.name == "Application Deadline"
         assert close_date_event.event_type == EventType.SINGLE_DATE
@@ -144,6 +143,6 @@ class TestMockOpportunity:
 
         assert opp.key_dates is not None
         assert opp.key_dates.post_date is not None
-        post_date_event = cast(SingleDateEvent, opp.key_dates.post_date)
+        post_date_event = cast("SingleDateEvent", opp.key_dates.post_date)
         assert post_date_event.date == app_opens
         assert opp.key_dates.close_date is None

--- a/examples/ca-opportunity-example/tests/common_grants/utils/test_date_transform.py
+++ b/examples/ca-opportunity-example/tests/common_grants/utils/test_date_transform.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 
 import pytest
-
 from common_grants.utils.date_transform import (
     DateFormat,
     transform_date,

--- a/examples/ca-opportunity-example/tests/common_grants/utils/test_opp_data_source.py
+++ b/examples/ca-opportunity-example/tests/common_grants/utils/test_opp_data_source.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import pytest
-
 from common_grants.utils.opp_data_source import OpportunityDataSource
 
 

--- a/examples/ca-opportunity-example/tests/common_grants/utils/test_opp_transform.py
+++ b/examples/ca-opportunity-example/tests/common_grants/utils/test_opp_transform.py
@@ -5,10 +5,9 @@ from datetime import date, datetime
 from typing import Any
 
 import pytest
+from common_grants.utils.opp_transform import OpportunityTransformer
 from common_grants_sdk.schemas.pydantic.fields import CustomFieldType
 from common_grants_sdk.schemas.pydantic.models import OppStatusOptions
-
-from common_grants.utils.opp_transform import OpportunityTransformer
 
 
 class TestOpportunityTransformer:

--- a/examples/ca-opportunity-example/tests/conftest.py
+++ b/examples/ca-opportunity-example/tests/conftest.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
+from common_grants.api import app
 from common_grants_sdk.schemas.pydantic import (
     EventType,
     Money,
@@ -15,8 +16,6 @@ from common_grants_sdk.schemas.pydantic import (
     SingleDateEvent,
 )
 from fastapi.testclient import TestClient
-
-from common_grants.api import app
 
 
 @pytest.fixture(scope="session", name="client")

--- a/examples/pa-opportunity-example/tests/common_grants/routes/test_opportunities.py
+++ b/examples/pa-opportunity-example/tests/common_grants/routes/test_opportunities.py
@@ -2,9 +2,8 @@
 
 from uuid import uuid4
 
-from fastapi.testclient import TestClient
-
 from common_grants.utils.opp_data_source import OpportunityDataSource
+from fastapi.testclient import TestClient
 
 
 class TestListOpportunities:

--- a/examples/pa-opportunity-example/tests/common_grants/utils/test_opp_data_source.py
+++ b/examples/pa-opportunity-example/tests/common_grants/utils/test_opp_data_source.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import pytest
-
 from common_grants.utils.opp_data_source import OpportunityDataSource
 
 

--- a/examples/pa-opportunity-example/tests/common_grants/utils/test_opp_transform.py
+++ b/examples/pa-opportunity-example/tests/common_grants/utils/test_opp_transform.py
@@ -5,10 +5,9 @@ from datetime import date, datetime
 from typing import Any
 
 import pytest
+from common_grants.utils.opp_transform import OpportunityTransformer
 from common_grants_sdk.schemas.pydantic.fields import CustomFieldType
 from common_grants_sdk.schemas.pydantic.models import OppStatusOptions
-
-from common_grants.utils.opp_transform import OpportunityTransformer
 
 
 class TestOpportunityTransformer:

--- a/examples/pa-opportunity-example/tests/conftest.py
+++ b/examples/pa-opportunity-example/tests/conftest.py
@@ -4,6 +4,7 @@ from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
+from common_grants.api import app
 from common_grants_sdk.schemas.pydantic import (
     EventType,
     Money,
@@ -15,8 +16,6 @@ from common_grants_sdk.schemas.pydantic import (
     SingleDateEvent,
 )
 from fastapi.testclient import TestClient
-
-from common_grants.api import app
 
 
 @pytest.fixture(scope="session", name="client")

--- a/templates/fast-api/tests/common_grants/routes/test_opportunities.py
+++ b/templates/fast-api/tests/common_grants/routes/test_opportunities.py
@@ -2,9 +2,8 @@
 
 from uuid import uuid4
 
-from fastapi.testclient import TestClient
-
 from common_grants.services.opportunity import OpportunityService
+from fastapi.testclient import TestClient
 
 
 class TestListOpportunities:

--- a/templates/fast-api/tests/conftest.py
+++ b/templates/fast-api/tests/conftest.py
@@ -4,9 +4,6 @@ from datetime import date, datetime, timezone
 from uuid import uuid4
 
 import pytest
-from common_grants_sdk.schemas.pydantic.fields import EventType, SingleDateEvent
-from fastapi.testclient import TestClient
-
 from common_grants.api import app
 from common_grants.schemas import (
     Money,
@@ -16,6 +13,8 @@ from common_grants.schemas import (
     OppStatusOptions,
     OppTimeline,
 )
+from common_grants_sdk.schemas.pydantic.fields import EventType, SingleDateEvent
+from fastapi.testclient import TestClient
 
 
 @pytest.fixture(scope="session", name="client")


### PR DESCRIPTION
## Summary

- Auto-fix ruff 0.15.x import sorting (I001) and type-checking (TC006, PLC0207) violations across all 3 Python projects using `select = ["ALL"]`
- Add rule ignores for unfixable ruff 0.15.x rules (B905, PLC0415, RUF043, RUF059) in `ca-opportunity-example/pyproject.toml`
- Add `linter-tools` Dependabot group (ruff, black, mypy) to all 4 Python pip ecosystem entries so linter bumps get their own PR
- Update `DEPENDENCY_MANAGEMENT.md` strategy section and World B table to document the linter group change

## Details

When Dependabot bumps ruff to newer versions, new rules enforced by `select = ["ALL"]` can break CI. Separating linter tools into their own Dependabot group means linter version bumps won't block other dependency updates, and rule ignore additions can be handled in a focused PR.

## Verification

All 3 projects pass `make check-lint` (exit 0):
- `templates/fast-api`
- `examples/pa-opportunity-example`
- `examples/ca-opportunity-example`