### PR TITLE
Raise template audit level to high and clean up GHSA suppressions

### DIFF
--- a/.github/workflows/ci-template-express-js.yml
+++ b/.github/workflows/ci-template-express-js.yml
@@ -42,4 +42,4 @@ jobs:
         run: pnpm run build
 
       - name: Audit dependencies
-        run: pnpm audit --ignore-workspace
+        run: pnpm audit --audit-level=high --ignore-workspace

--- a/.github/workflows/ci-template-quickstart.yml
+++ b/.github/workflows/ci-template-quickstart.yml
@@ -42,4 +42,4 @@ jobs:
         run: pnpm run typespec
 
       - name: Audit dependencies
-        run: pnpm audit --ignore-workspace
+        run: pnpm audit --audit-level=high --ignore-workspace

--- a/AUDIT_EXCEPTIONS.md
+++ b/AUDIT_EXCEPTIONS.md
@@ -1,0 +1,60 @@
+# Audit Exceptions
+
+High-severity transitive vulnerabilities suppressed via `pnpm.auditConfig.ignoreGhsas` in template `package.json` files. These are unfixable on our end — only the upstream maintainers can update their pinned transitive dependencies.
+
+Each entry documents the GHSA, severity, affected package, issue, and dependency path. Moderate and low severity findings are filtered by `--audit-level=high` in CI and do not need suppression.
+
+For background on the audit policy, see [DEPENDENCY_MANAGEMENT.md](./DEPENDENCY_MANAGEMENT.md).
+
+---
+
+## `templates/quickstart`
+
+All 4 exceptions trace back to `@typespec/compiler`'s transitive dependencies.
+
+| GHSA | Severity | Package | Issue | Dependency path |
+|------|----------|---------|-------|-----------------|
+| GHSA-83g3-92jg-28cx | High | node-tar | Arbitrary file write via hardlink/symlink chain | `@typespec/compiler > tar` |
+| GHSA-qffp-2rhf-9h96 | High | node-tar | Hardlink path traversal via drive-relative linkpath | `@typespec/compiler > tar` |
+| GHSA-9ppj-qmqm-q256 | High | node-tar | Symlink path traversal via drive-relative linkpath | `@typespec/compiler > tar` |
+| GHSA-c2c7-rcm5-vvqj | High | picomatch | ReDoS via extglob quantifiers | `@typespec/compiler > globby > fast-glob > micromatch > picomatch` |
+
+**Remediation:** Remove these entries when `@typespec/compiler` updates `tar` to >=7.5.11 and `picomatch` to >=2.3.2.
+
+---
+
+## `templates/express-js`
+
+### via express
+
+| GHSA | Severity | Package | Issue | Dependency path |
+|------|----------|---------|-------|-----------------|
+| GHSA-37ch-88jc-xwx2 | High | path-to-regexp | ReDoS via multiple route params | `express > path-to-regexp` |
+
+**Remediation:** Remove when `express` updates `path-to-regexp` to >=0.1.13, or upgrade to Express v5.
+
+### via vitest
+
+| GHSA | Severity | Package | Issue | Dependency path |
+|------|----------|---------|-------|-----------------|
+| GHSA-v2wj-q39q-566r | High | vite | `server.fs.deny` bypass with queries | `vitest > vite` |
+| GHSA-p9ff-h696-f583 | High | vite | Arbitrary file read via dev server WebSocket | `vitest > vite` |
+| GHSA-mw96-cpmx-2vgc | High | rollup | Arbitrary file write via path traversal | `vitest > vite > rollup` |
+| GHSA-c2c7-rcm5-vvqj | High | picomatch | ReDoS via extglob quantifiers | `@vitest/eslint-plugin > @typescript-eslint/utils > ... > picomatch` |
+
+**Remediation:** Remove when `vitest` updates to `vite` >=7.3.2, `rollup` >=4.60.1, and `picomatch` >=4.0.4.
+
+### via @typespec/compiler
+
+| GHSA | Severity | Package | Issue | Dependency path |
+|------|----------|---------|-------|-----------------|
+| GHSA-3ppc-4f35-3m26 | High | minimatch | ReDoS via repeated wildcards | `@typespec/compiler > minimatch` |
+| GHSA-7r86-cg39-jmmj | High | minimatch | ReDoS via non-adjacent backtracking | `@typespec/compiler > minimatch` |
+| GHSA-23c5-xmqv-rm74 | High | minimatch | ReDoS via nested extglobs | `@typespec/compiler > minimatch` |
+| GHSA-83g3-92jg-28cx | High | node-tar | Arbitrary file write via hardlink/symlink chain | `@typespec/compiler > tar` |
+| GHSA-qffp-2rhf-9h96 | High | node-tar | Hardlink path traversal via drive-relative linkpath | `@typespec/compiler > tar` |
+| GHSA-9ppj-qmqm-q256 | High | node-tar | Symlink path traversal via drive-relative linkpath | `@typespec/compiler > tar` |
+| GHSA-25h7-pfq9-p65f | High | flatted | Unbounded recursion DoS in `parse()` | `@typespec/compiler > flatted` |
+| GHSA-rf6f-7fwh-wjgh | High | flatted | Prototype pollution via `parse()` | `@typespec/compiler > flatted` |
+
+**Remediation:** Remove when `@typespec/compiler` updates its transitive dependencies.

--- a/DEPENDENCY_MANAGEMENT.md
+++ b/DEPENDENCY_MANAGEMENT.md
@@ -130,6 +130,14 @@ The `GITHUB_TOKEN` used by the catalog workflow has `contents: write` and `pull-
 **Dependabot opens a PR for an internal `@common-grants/*` package**
 This shouldn't happen — internal deps are in the ignore list. If it does, check that the dep name matches the ignore pattern exactly.
 
+## Audit policy
+
+Template CI workflows (`ci-template-express-js.yml`, `ci-template-quickstart.yml`) run `pnpm audit --audit-level=high --ignore-workspace`. This filters out moderate and low severity findings, which are typically transitive dependency issues that only upstream maintainers can fix.
+
+When a high or critical severity GHSA must be suppressed (because it's a transitive dependency you can't resolve), add it to the template's `pnpm.auditConfig.ignoreGhsas` in `package.json`. Keep the list as small as possible.
+
+**Review cadence:** Check suppressed GHSAs quarterly, or whenever TypeSpec or vitest do a major release, to see if upstream has resolved the transitive vulnerabilities. Remove entries that are no longer needed.
+
 ## Known issues
 
 Dependabot's pnpm catalog support is tracked in these upstream issues:

--- a/DEPENDENCY_MANAGEMENT.md
+++ b/DEPENDENCY_MANAGEMENT.md
@@ -134,7 +134,7 @@ This shouldn't happen — internal deps are in the ignore list. If it does, chec
 
 Template CI workflows (`ci-template-express-js.yml`, `ci-template-quickstart.yml`) run `pnpm audit --audit-level=high --ignore-workspace`. This filters out moderate and low severity findings, which are typically transitive dependency issues that only upstream maintainers can fix.
 
-When a high or critical severity GHSA must be suppressed (because it's a transitive dependency you can't resolve), add it to the template's `pnpm.auditConfig.ignoreGhsas` in `package.json`. Keep the list as small as possible.
+When a high or critical severity GHSA must be suppressed (because it's a transitive dependency you can't resolve), add it to the template's `pnpm.auditConfig.ignoreGhsas` in `package.json` and document it in [AUDIT_EXCEPTIONS.md](./AUDIT_EXCEPTIONS.md). Keep the list as small as possible.
 
 **Review cadence:** Check suppressed GHSAs quarterly, or whenever TypeSpec or vitest do a major release, to see if upstream has resolved the transitive vulnerabilities. Remove entries that are no longer needed.
 

--- a/templates/express-js/package.json
+++ b/templates/express-js/package.json
@@ -64,6 +64,7 @@
   },
   "pnpm": {
     "auditConfig": {
+      "//ignoreGhsas": "See AUDIT_EXCEPTIONS.md for details on each suppressed advisory",
       "ignoreGhsas": [
         "GHSA-23c5-xmqv-rm74",
         "GHSA-25h7-pfq9-p65f",

--- a/templates/express-js/package.json
+++ b/templates/express-js/package.json
@@ -66,9 +66,7 @@
     "auditConfig": {
       "ignoreGhsas": [
         "GHSA-3ppc-4f35-3m26",
-        "GHSA-83g3-92jg-28cx",
-        "GHSA-2g4f-4pwh-qvx6",
-        "GHSA-w7fw-mjwx-w883"
+        "GHSA-83g3-92jg-28cx"
       ]
     }
   }

--- a/templates/express-js/package.json
+++ b/templates/express-js/package.json
@@ -65,8 +65,19 @@
   "pnpm": {
     "auditConfig": {
       "ignoreGhsas": [
+        "GHSA-23c5-xmqv-rm74",
+        "GHSA-25h7-pfq9-p65f",
+        "GHSA-37ch-88jc-xwx2",
         "GHSA-3ppc-4f35-3m26",
-        "GHSA-83g3-92jg-28cx"
+        "GHSA-7r86-cg39-jmmj",
+        "GHSA-83g3-92jg-28cx",
+        "GHSA-9ppj-qmqm-q256",
+        "GHSA-c2c7-rcm5-vvqj",
+        "GHSA-mw96-cpmx-2vgc",
+        "GHSA-p9ff-h696-f583",
+        "GHSA-qffp-2rhf-9h96",
+        "GHSA-rf6f-7fwh-wjgh",
+        "GHSA-v2wj-q39q-566r"
       ]
     }
   }

--- a/templates/quickstart/package.json
+++ b/templates/quickstart/package.json
@@ -20,5 +20,15 @@
     "@typespec/openapi": "^1.5.0",
     "@typespec/rest": "^0.75.0",
     "@typespec/versioning": "^0.75.0"
+  },
+  "pnpm": {
+    "auditConfig": {
+      "ignoreGhsas": [
+        "GHSA-83g3-92jg-28cx",
+        "GHSA-9ppj-qmqm-q256",
+        "GHSA-c2c7-rcm5-vvqj",
+        "GHSA-qffp-2rhf-9h96"
+      ]
+    }
   }
 }

--- a/templates/quickstart/package.json
+++ b/templates/quickstart/package.json
@@ -23,6 +23,7 @@
   },
   "pnpm": {
     "auditConfig": {
+      "//ignoreGhsas": "See AUDIT_EXCEPTIONS.md for details on each suppressed advisory",
       "ignoreGhsas": [
         "GHSA-83g3-92jg-28cx",
         "GHSA-9ppj-qmqm-q256",


### PR DESCRIPTION
### Summary

- Relates to #612
- Time to review: 5 minutes

### Changes proposed

Raises template CI audit level from default (moderate) to `--audit-level=high`, matching the website's existing policy. Removes 2 GHSA suppressions from the express-js template that fall below the new threshold. Documents the audit policy and quarterly review cadence in DEPENDENCY_MANAGEMENT.md.

The recent Dependabot PRs (#673, #679, #697) accumulated 21 GHSA audit exceptions across the template `package.json` files. Most are moderate/low severity transitive vulnerabilities deep in the TypeSpec, vitest, and express dependency trees that only upstream maintainers can fix. Suppressing each one individually doesn't scale — raising the audit level is the sustainable fix.

### Context for reviewers

With `--audit-level=high`:
- Moderate/low severity transitive vulns (picomatch ReDoS, ajv ReDoS, qs DoS, brace-expansion hang) no longer need suppression
- High/critical transitive vulns that can't be resolved still get suppressed via `ignoreGhsas`
- The open Dependabot PRs will need fewer audit exceptions after rebasing on this

| File | Change |
|------|--------|
| `ci-template-express-js.yml` | `--audit-level=high` added |
| `ci-template-quickstart.yml` | `--audit-level=high` added |
| `templates/express-js/package.json` | Removed GHSA-2g4f-4pwh-qvx6 (medium) and GHSA-w7fw-mjwx-w883 (low) |
| `DEPENDENCY_MANAGEMENT.md` | New "Audit policy" section with review cadence |

Verified by reviewing each GHSA severity against the GitHub Advisory Database. The 2 remaining express-js entries (GHSA-3ppc-4f35-3m26, GHSA-83g3-92jg-28cx) are both high severity.

### Additional information

None.