### PR TITLE
[Issue #612] Disable Dependabot for templates and examples

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # Automated dependency updates for the CommonGrants monorepo.
 #
 # Split strategy:
-#   - Dependabot handles non-catalog deps (templates, examples, Python, Actions, non-catalog workspace deps)
+#   - Dependabot handles non-catalog deps (Python SDK, Actions, non-catalog workspace deps)
 #   - A scheduled GitHub Action (deps-catalog-check.yml) handles catalog-managed deps
 #     (avoids dependabot-core pnpm catalog bugs: #14339, #13347, #12244, #12445, #13000)
 #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,43 +52,7 @@ updates:
       - "dependencies"
     open-pull-requests-limit: 10
 
-  # ── World B: Isolated lockfile directories ──
-
-  # templates/express-js (npm, weekly)
-  - package-ecosystem: "npm"
-    directory: "/templates/express-js"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-    groups:
-      all-deps:
-        patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@common-grants/*"
-    labels: ["dependencies"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # templates/quickstart (npm, weekly)
-  - package-ecosystem: "npm"
-    directory: "/templates/quickstart"
-    schedule:
-      interval: "weekly"
-      day: "tuesday"
-    groups:
-      all-deps:
-        patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@common-grants/*"
-    labels: ["dependencies"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
+  # ── World B: Python SDK (pip, isolated lockfile) ──
 
   # lib/python-sdk (pip/Poetry, weekly)
   - package-ecosystem: "pip"
@@ -102,57 +66,6 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-    labels: ["dependencies", "python"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # templates/fast-api (pip/Poetry, monthly)
-  - package-ecosystem: "pip"
-    directory: "/templates/fast-api"
-    schedule:
-      interval: "monthly"
-    groups:
-      all-deps:
-        patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "common-grants-sdk"
-    labels: ["dependencies", "python"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # examples/pa-opportunity-example (pip/Poetry, monthly)
-  - package-ecosystem: "pip"
-    directory: "/examples/pa-opportunity-example"
-    schedule:
-      interval: "monthly"
-    groups:
-      all-deps:
-        patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "common-grants-sdk"
-    labels: ["dependencies", "python"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # examples/ca-opportunity-example (pip/Poetry, monthly)
-  - package-ecosystem: "pip"
-    directory: "/examples/ca-opportunity-example"
-    schedule:
-      interval: "monthly"
-    groups:
-      all-deps:
-        patterns: ["*"]
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "common-grants-sdk"
     labels: ["dependencies", "python"]
     commit-message:
       prefix: "chore"

--- a/DEPENDENCY_MANAGEMENT.md
+++ b/DEPENDENCY_MANAGEMENT.md
@@ -45,7 +45,7 @@ Dependabot runs on three "worlds":
 - Major version bumps are ignored (handled manually)
 - Ignores `@common-grants/*` (internal workspace deps) and all catalog-managed deps
 
-**World B: Isolated lockfile directories** (weekly or monthly)
+**World B: Isolated lockfile directories** (weekly)
 
 | Directory | Schedule | Notes |
 |-----------|----------|-------|

--- a/DEPENDENCY_MANAGEMENT.md
+++ b/DEPENDENCY_MANAGEMENT.md
@@ -17,10 +17,22 @@ Dependabot has [multiple open bugs](https://github.com/dependabot/dependabot-cor
 
 | Tier | Tool | What it covers |
 |------|------|----------------|
-| Tier 1 | Dependabot | Templates, examples, Python SDK, GitHub Actions, non-catalog workspace deps |
+| Tier 1 | Dependabot | Python SDK, GitHub Actions, non-catalog workspace deps |
 | Tier 2 | `deps-catalog-check` workflow | Catalog-managed deps: `@typespec/*`, `vitest`, `@vitest/*`, `eslint-plugin-vitest`, `@types/node` |
 
 Config lives in `.github/dependabot.yml` and `.github/workflows/deps-catalog-check.yml`.
+
+---
+
+## Maintenance tiers
+
+Dependencies are maintained at different cadences depending on whether they are core tooling or supporting assets.
+
+| Tier | Scope | Cadence |
+|------|-------|---------|
+| **Core** | `lib/*`, `website`, root workspace | Automated — Dependabot + catalog workflow. Merge promptly. |
+| **Templates and examples** | `templates/*`, `examples/*` | Manual — no automated PRs. Refreshed deliberately when a maintainer chooses to. |
+| **GitHub Actions** | `.github/workflows` | Automated — Dependabot weekly. Merge when green. |
 
 ## Dependabot scope
 
@@ -37,12 +49,9 @@ Dependabot runs on three "worlds":
 
 | Directory | Schedule | Notes |
 |-----------|----------|-------|
-| `templates/express-js` | Weekly, Tuesdays | All deps grouped |
-| `templates/quickstart` | Weekly, Tuesdays | All deps grouped |
 | `lib/python-sdk` | Weekly, Wednesdays | pip/Poetry, all deps grouped |
-| `templates/fast-api` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
-| `examples/pa-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
-| `examples/ca-opportunity-example` | Monthly | pip/Poetry, ignores `common-grants-sdk` |
+
+Templates and examples are now manually maintained and do not have Dependabot entries.
 
 **World C: GitHub Actions** (weekly, Mondays)
 - All Actions grouped into a single PR
@@ -105,7 +114,8 @@ This catches breakage that individual package CI workflows would miss, since a T
 1. Add the package directory to `pnpm-workspace.yaml` under `packages:`
 2. If the package uses catalog deps, no extra steps needed — it inherits from the catalog automatically
 3. If the package has non-catalog deps that Dependabot should track, they'll be picked up automatically by the root workspace entry
-4. If the package has its own isolated lockfile (like templates), add a new entry to `.github/dependabot.yml` under World B
+4. If the package has its own isolated lockfile (like `lib/python-sdk`), add a new entry to `.github/dependabot.yml` under World B
+5. New templates and examples should not be added to Dependabot; they follow the manual maintenance tier
 
 ## Adding a new catalog dep
 


### PR DESCRIPTION
### Summary

- Relates to #612
- Relates to #611
- Time to review: 5 minutes

Follow-up to #647 and #691 — removes Dependabot automation for all template and example directories and documents a tiered maintenance policy.

### Changes proposed

**`.github/dependabot.yml`**
- Removed all 5 template/example Dependabot entries: `/templates/express-js`, `/templates/quickstart`, `/templates/fast-api`, `/examples/pa-opportunity-example`, `/examples/ca-opportunity-example`
- Updated the World B section header to reflect that only `lib/python-sdk` remains
- Updated the top-level split strategy comment to remove stale template/example references

**`DEPENDENCY_MANAGEMENT.md`**
- Added a new **Maintenance tiers** section documenting three tiers: core (automated), templates/examples (manual), GitHub Actions (automated)
- Updated the Architecture table — Tier 1 no longer lists templates or examples
- Trimmed the World B table to `lib/python-sdk` only, with a note that templates/examples are manually maintained
- Updated "Adding a new workspace package" guidance — new templates/examples should not be added to Dependabot

### Context for reviewers

Templates and examples generate transitive alert noise (24+ npm and Poetry alerts) from pinned starter-code lockfiles. The team decided full manual maintenance is the right operating model — no Dependabot, no cadence, refreshed deliberately when a maintainer chooses to.

`lib/python-sdk` is preserved in Dependabot — it's a published core PyPI package, not a template.

**Side effects on merge:**
- Open Dependabot PRs should auto-close: #697 (templates/express-js), #695 (examples/ca-opportunity-example), #694 (templates/fast-api)
- If they don't close automatically within a day, close them manually ([known Dependabot reliability issue](https://github.com/dependabot/dependabot-core/issues/6845))
- PR #696 (`lib/python-sdk`) is **not affected** and should stay open

**Verification:**
- YAML validated with `js-yaml`
- Confirmed exactly 3 `package-ecosystem` entries remain
- Confirmed zero `templates/` or `examples/` directory references in `dependabot.yml`
- `lib/python-sdk` entry is byte-identical to `main`

### Additional information

The broader dependency management direction is tracked in #612. Repo separation for templates/examples is being discussed with product owners separately.