### PR TITLE
Add changeset and fix stale ARRAY default in README

### DIFF
--- a/.changeset/array-default-any.md
+++ b/.changeset/array-default-any.md
@@ -1,0 +1,5 @@
+---
+"common-grants-sdk": patch
+---
+
+Change default ARRAY field type annotation from `list[str]` to `list[Any]` in plugin code generation. This more accurately reflects that an array field with no explicit `value` type should not assume string elements.

--- a/lib/python-sdk/common_grants_sdk/extensions/README.md
+++ b/lib/python-sdk/common_grants_sdk/extensions/README.md
@@ -508,7 +508,7 @@ A plugin should represent a single logical concern (one agency's fields, one int
 
 ### Type safety
 
-- Omitting `value` in `CustomFieldSpec` falls back to a sensible default (`str`, `int`, `float`, `bool`, `list[str]`, or `dict[str, Any]`). Specify it explicitly when you need a more precise type.
+- Omitting `value` in `CustomFieldSpec` falls back to a sensible default (`str`, `int`, `float`, `bool`, `list[Any]`, or `dict[str, Any]`). Specify it explicitly when you need a more precise type.
 - For complex object types, define a Pydantic `BaseModel` subclass and pass it as `value`:
 
   ```python


### PR DESCRIPTION
### Summary

- Supplements #707
- Time to review: 2 minutes

### Changes proposed

1. **Added changeset** for the `list[str]` → `list[Any]` default type change in `FIELD_TYPE_DEFAULT_ANNOTATION`. Since `common-grants-sdk` is published to PyPI and this changes the generated type signature for ARRAY fields without an explicit `value`, it warrants a patch changeset.
2. **Fixed stale documentation** in `lib/python-sdk/common_grants_sdk/extensions/README.md` line 511 — updated `list[str]` reference to `list[Any]` to match the new code behavior.

### Context for reviewers

The Black upgrade portion of #707 is dev-only and doesn't need a changeset. The ARRAY default change does, per the [changeset workflow](../blob/main/lib/README.md#developer-instructions) — `common-grants-sdk` is a tracked published package in `.changeset/config.json`.

### Additional information

N/A