### PR TITLE
[Stack 3/4] feat(website): Add /forms-new catalog and detail pages

### DIFF
--- a/website/src/components/forms-new/FormCard.astro
+++ b/website/src/components/forms-new/FormCard.astro
@@ -1,0 +1,88 @@
+---
+import type { FormItem } from "@/lib/forms";
+import CatalogCard from "@/components/catalog/CatalogCard.astro";
+
+interface Props {
+  item: FormItem;
+}
+
+const { item } = Astro.props;
+const detailHref = `/forms-new/${item.id}`;
+---
+
+<CatalogCard
+  href={detailHref}
+  title={item.label}
+  description={item.description}
+  dataAttributes={{
+    name: item.name,
+    description: item.description,
+    tags: item.tags.join(","),
+  }}
+>
+  <div class="card-schema">
+    <span class="sr-only">Schema</span>
+    <span class="schema-pill">{item.schema}</span>
+  </div>
+  {
+    item.tags.length > 0 && (
+      <div class="card-tags">
+        <span class="sr-only">Tags</span>
+        <div class="tag-pill-list">
+          {item.tags.map((tag) => (
+            <span class="tag-pill">{tag}</span>
+          ))}
+        </div>
+      </div>
+    )
+  }
+</CatalogCard>
+
+<style>
+  .card-schema {
+    margin-bottom: 0.5rem;
+  }
+
+  .schema-pill {
+    display: inline-block;
+    padding: 0.375rem 0.75rem;
+    background: var(--sl-color-accent-low);
+    color: var(--sl-color-accent-high);
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    font-family: monospace;
+    font-weight: 500;
+  }
+
+  .card-tags {
+    margin-bottom: 0.375rem;
+  }
+
+  .tag-pill-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .tag-pill {
+    padding: 0.375rem 0.75rem;
+    background: var(--sl-color-blue-low);
+    color: var(--sl-color-blue-high);
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    font-family: monospace;
+    font-weight: 500;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/website/src/components/forms-new/FormDetails.astro
+++ b/website/src/components/forms-new/FormDetails.astro
@@ -1,0 +1,127 @@
+---
+import type { FormItem } from "@/lib/forms";
+import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
+import { JsonFormRenderer } from "@/components/forms/JsonFormRenderer";
+import type { JsonSchema, VerticalLayout } from "@jsonforms/core";
+import type { FormData, JsonValue } from "@/lib/types";
+import { transformWithMapping } from "@/lib/transformation";
+import { generateSchemaExample } from "@/lib/schema/example-generator";
+import { Paths } from "@/lib/schema/paths";
+import { extensionsAjv } from "@/lib/validation";
+import * as yaml from "js-yaml";
+
+interface Props {
+  item: FormItem;
+}
+
+const { item } = Astro.props;
+
+const toJson = (data: Record<string, unknown>) =>
+  JSON.stringify(data, null, 2) as string;
+
+const toYaml = (data: Record<string, unknown>) =>
+  yaml.dump(data, { noRefs: true, lineWidth: -1 }) as string;
+
+// Generate example data from the schema using openapi-sampler, which
+// composes examples from nested $ref schemas automatically. Mirrors the
+// approach used by QuestionDetails.astro so form authors can rely on
+// @example decorators in their TypeSpec the same way.
+const schemaRelPath = `${Paths.EXTENSION_SCHEMAS_PATH_PREFIX}/${item.schema}.yaml`;
+const exampleJson = await generateSchemaExample(schemaRelPath, {
+  validator: extensionsAjv,
+});
+const exampleData = JSON.parse(exampleJson) as FormData;
+
+// Transform example data to CommonGrants format using the mapping
+const commonGrantsData = transformWithMapping(
+  exampleData as Record<string, JsonValue>,
+  item.mappingToCg as Record<string, JsonValue>,
+);
+
+const hasOverrides =
+  Object.keys(item.overrides.uiSchema ?? {}).length > 0 ||
+  Object.keys(item.overrides.mappingFromCg ?? {}).length > 0 ||
+  Object.keys(item.overrides.mappingToCg ?? {}).length > 0;
+---
+
+<h2 class="details-title">Details</h2>
+
+<Tabs>
+  <TabItem label="Form">
+    <p>Sample version of the rendered form.</p>
+    <JsonFormRenderer
+      client:load
+      schema={item.rawSchema as JsonSchema}
+      uischema={item.uiSchema as unknown as VerticalLayout}
+      data={exampleData}
+    />
+  </TabItem>
+  <TabItem label="Data">
+    <details open>
+      <summary>Form Data</summary>
+      <p>What the form data looks like when it is submitted.</p>
+      <Code lang="json" code={toJson(exampleData)} />
+    </details>
+    <details>
+      <summary>CommonGrants Data</summary>
+      <p>
+        What the data looks like translated to the CommonGrants data model using
+        the mapping-to-cg.
+      </p>
+      <Code lang="json" code={toJson(commonGrantsData)} />
+    </details>
+  </TabItem>
+  <TabItem label="Schemas">
+    <details>
+      <summary>JSON Schema</summary>
+      <p>Provides the structure and data validation for this form.</p>
+      <Code lang="yaml" code={toYaml(item.rawSchema)} />
+    </details>
+    <details>
+      <summary>UI Schema (merged)</summary>
+      <p>
+        Describes how to present the form. Reflects any per-form
+        <code>x-overrides.uiSchema</code> patches applied on top of the inherited
+        question-bank UI schemas.
+      </p>
+      <Code lang="json" code={toJson(item.uiSchema)} />
+    </details>
+  </TabItem>
+  <TabItem label="Mappings">
+    <details>
+      <summary>Mapping to CommonGrants</summary>
+      <p>How to translate this form into the CommonGrants data model.</p>
+      <Code lang="json" code={toJson(item.mappingToCg)} />
+    </details>
+    <details>
+      <summary>Mapping from CommonGrants</summary>
+      <p>
+        How to pre-fill this form with data from the CommonGrants data model.
+      </p>
+      <Code lang="json" code={toJson(item.mappingFromCg)} />
+    </details>
+    {
+      hasOverrides && (
+        <details>
+          <summary>Per-form overrides (x-overrides)</summary>
+          <p>
+            The raw <code>x-overrides</code> block declared on the form spec.
+            Already merged into the UI schema and mappings shown above.
+          </p>
+          <Code
+            lang="json"
+            code={toJson(item.overrides as unknown as Record<string, unknown>)}
+          />
+        </details>
+      )
+    }
+  </TabItem>
+</Tabs>
+
+<style>
+  .details-title {
+    font-size: 1.75rem !important;
+    margin-top: 0.25rem;
+    margin-bottom: 0.5rem;
+  }
+</style>

--- a/website/src/pages/forms-new/[slug].astro
+++ b/website/src/pages/forms-new/[slug].astro
@@ -1,0 +1,52 @@
+---
+import { loadAllFormItems, getFormIds } from "@/lib/forms";
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+import FormDetails from "@/components/forms-new/FormDetails.astro";
+import type { GetStaticPaths } from "astro";
+
+export interface Props {
+  itemId: string;
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const itemIds = getFormIds();
+  const paths = itemIds.map((itemId) => ({
+    params: { slug: itemId },
+    props: { itemId },
+  }));
+  return paths;
+};
+
+const { itemId } = Astro.props;
+const forms = await loadAllFormItems();
+const item = forms[itemId];
+
+if (!item) {
+  throw new Error(`Form "${itemId}" not found`);
+}
+---
+
+<StarlightPage
+  frontmatter={{
+    title: item.label,
+    description: item.description,
+    tableOfContents: false,
+  }}
+>
+  <a href="/forms-new" class="back-link">&larr; Back to Form library</a>
+  <FormDetails item={item} />
+</StarlightPage>
+
+<style>
+  .back-link {
+    display: inline-block;
+    margin-bottom: 1rem;
+    font-size: 0.9375rem;
+    color: var(--sl-color-accent);
+    text-decoration: none;
+  }
+
+  .back-link:hover {
+    text-decoration: underline;
+  }
+</style>

--- a/website/src/pages/forms-new/index.astro
+++ b/website/src/pages/forms-new/index.astro
@@ -1,0 +1,37 @@
+---
+import { loadAllFormItems } from "@/lib/forms";
+import CatalogPage from "@/layouts/CatalogPage.astro";
+import FormCard from "@/components/forms-new/FormCard.astro";
+
+const forms = await loadAllFormItems();
+---
+
+<CatalogPage
+  title="Form library (TypeSpec)"
+  description="Forms composed from question-bank questions and compiled from TypeSpec specs"
+  searchLabel="Search forms"
+  searchPlaceholder="Search by name, description, or tags..."
+  filters={[]}
+  noResultsMessage="No forms match your search criteria."
+  stats={[{ count: Object.keys(forms).length, label: "forms" }]}
+>
+  <p slot="intro" class="intro">
+    A parallel form library that renders forms compiled from TypeSpec specs in
+    <code>website/src/specs/forms/</code>. Each form is composed from
+    question-bank questions and may apply per-field UI / mapping overrides via
+    the <code>x-overrides</code> extension. The legacy hand-written forms remain available
+    at <a href="/forms">/forms</a> until the migration completes.
+  </p>
+  {
+    Object.entries(forms)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([, item]) => <FormCard item={item} />)
+  }
+</CatalogPage>
+
+<style>
+  .intro {
+    margin-bottom: 2rem;
+    color: var(--sl-color-gray-2);
+  }
+</style>


### PR DESCRIPTION
### Summary

Adds a new `/forms-new/` index and details page, following the pattern of `/question-bank/` and `/custom-fields/`

- Part 3 of 4 in a stacked diff
- Time to review: 10 minutes

> [!NOTE]
> I added this in parallel to the existing `/forms/` page because we're not ready to do a full replacement of the existing form library code. But it's not linked to the nav bar or side bar.

### Changes proposed

- Adds`pages/forms-new/index.astro` (catalog page modeled on `pages/custom-fields/index.astro`)
- Adds `pages/forms-new/[slug].astro` (detail page modeled on `pages/question-bank/[slug].astro`)
- Adds `components/forms-new/FormCard.astro` and `components/forms-new/FormDetails.astro` building against the new `FormItem` shape
- Reuses the existing `JsonFormRenderer` (already source-agnostic)

### Context for reviewers

**Review instructions: (Preview)**
1. Go to https://cg-pr-712.billy-daly.workers.dev/forms-new/
2. Click on "Canary Form": https://cg-pr-712.billy-daly.workers.dev/forms-new/form-canary/
3. Click into the various tabs

**Implementation notes:**
- The two pipelines (legacy hand-written forms vs TypeSpec forms) stay structurally isolated. A future cleanup PR will atomically delete `pages/forms/` + `lib/schemas.ts` and rename `pages/forms-new/` to `pages/forms/`
- `FormDetails.astro` was built fresh against `FormItem` rather than importing from the legacy `FormDetails.astro` to avoid coupling the two pipelines
- Catalog page passes empty `filters` for now since the canary has no `x-tags`; real forms with tags will surface filter dropdowns automatically

### Additional information

<img width="1440" height="900" alt="Screenshot 2026-04-14 at 9 52 35 AM" src="https://github.com/user-attachments/assets/3a05b3f8-4602-4314-a7da-6f89a3a58711" />
<img width="1440" height="900" alt="Screenshot 2026-04-14 at 9 52 47 AM" src="https://github.com/user-attachments/assets/8e2d51ce-1517-42d7-838a-a1c7726ec393" />
<img width="1440" height="900" alt="Screenshot 2026-04-14 at 9 52 55 AM" src="https://github.com/user-attachments/assets/4463467e-fb9b-4240-9dc9-0983fbadcded" />
<img width="1440" height="900" alt="Screenshot 2026-04-14 at 9 53 04 AM" src="https://github.com/user-attachments/assets/17a55d73-bf4e-4515-8c3f-b1de0ca411e3" />


### Stack

> This PR is part of a stacked diff. Please review only the changes in this PR, not the cumulative diff.

| # | Branch | Targets | PR | Status |
|---|--------|---------|----|--------|
| 1 | `stack/593-generate-forms-from-question-bank/01-audit-cleanup` | `593-generate-forms-from-question-bank` | #710 | ⏳ Open |
| 2 | `stack/593-generate-forms-from-question-bank/02-forms-loader` | PR 1 | #711 | ⏳ Open |
| 3 | `stack/593-generate-forms-from-question-bank/03-forms-new-pages` | PR 2 | #712 | 🎯 Current |
| 4 | `stack/593-generate-forms-from-question-bank/04-key-contact-form` | PR 3 | #713 | ⏳ Queued |

**Review order**: Start from PR 1 and work down.
**Merge strategy**: Squash and merge each PR in order. After merging, rebase the next PR onto the parent feature branch (`593-generate-forms-from-question-bank`) and update its base accordingly. Once all four merge into the parent, an umbrella PR will merge `593-generate-forms-from-question-bank` into `main`.
