### PR TITLE
[Issue #593] Add key-contact form composed from question bank items

### DIFF
--- a/website/__tests__/lib/forms/loader.spec.ts
+++ b/website/__tests__/lib/forms/loader.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
+import type { FormItem } from "@/lib/forms";
 import { loadFormItem, loadAllFormItems, getFormIds } from "@/lib/forms";
 
 /**
@@ -9,94 +10,113 @@ import { loadFormItem, loadAllFormItems, getFormIds } from "@/lib/forms";
  */
 
 describe("forms loader", () => {
+  // =============================================================================
+  // getFormIds
+  // =============================================================================
+
   describe("getFormIds", () => {
     it("returns the slugs in typespec-index.json", () => {
       expect(getFormIds()).toContain("key-contact");
     });
   });
 
+  // =============================================================================
+  // loadFormItem
+  // =============================================================================
+
   describe("loadFormItem", () => {
-    it("loads the key-contact form by id with all metadata fields populated", async () => {
-      const item = await loadFormItem("key-contact");
+    // =============================================================================
+    // key-contact form
+    // =============================================================================
 
-      expect(item).not.toBeNull();
-      expect(item?.id).toBe("key-contact");
-      expect(item?.schema).toBe("KeyContact");
-      expect(item?.label).toBe("Key Contact");
-      expect(item?.description).toContain("Key Contacts");
-      expect(item?.tags).toEqual(
-        expect.arrayContaining(["key-contact", "application"]),
-      );
-      expect(item?.properties).toHaveProperty("org");
-      expect(item?.properties).toHaveProperty("contact");
-      expect(item?.properties).toHaveProperty("projectRole");
-    });
+    describe("key-contact form", () => {
+      let item: FormItem | null;
 
-    it("composes a VerticalLayout UI schema from the form's properties", async () => {
-      const item = await loadFormItem("key-contact");
-      expect(item?.uiSchema.type).toBe("VerticalLayout");
-      const elements = item?.uiSchema.elements as Record<string, unknown>[];
-      expect(elements).toHaveLength(3);
-    });
-
-    it("re-scopes inherited Control scopes under the property name", async () => {
-      const item = await loadFormItem("key-contact");
-      const json = JSON.stringify(item?.uiSchema);
-      expect(json).toContain('"scope":"#/properties/org/properties/name"');
-      expect(json).toContain(
-        '"scope":"#/properties/contact/properties/name/properties/firstName"',
-      );
-    });
-
-    it("generates a default Control for atomic form-only fields", async () => {
-      const item = await loadFormItem("key-contact");
-      const elements = item?.uiSchema.elements as Record<string, unknown>[];
-      const projectRoleEl = elements[elements.length - 1];
-      expect(projectRoleEl).toEqual({
-        type: "Control",
-        scope: "#/properties/projectRole",
+      beforeAll(async () => {
+        item = await loadFormItem("key-contact");
       });
-    });
 
-    it("applies the field-level x-overrides label", async () => {
-      const item = await loadFormItem("key-contact");
-      const json = JSON.stringify(item?.uiSchema);
-      expect(json).toContain('"label":"Applicant Organization Name"');
-    });
-
-    it("aggregates field-level overrides under the property name", async () => {
-      const item = await loadFormItem("key-contact");
-      expect(item?.overrides.uiSchema).toEqual({
-        "org.name": { label: "Applicant Organization Name" },
+      it("loads the key-contact form by id with all metadata fields populated", async () => {
+        expect(item).not.toBeNull();
+        expect(item?.id).toBe("key-contact");
+        expect(item?.schema).toBe("KeyContact");
+        expect(item?.label).toBe("Key Contact");
+        expect(item?.description).toContain("Key Contacts");
+        expect(item?.tags).toEqual(
+          expect.arrayContaining(["key-contact", "application"]),
+        );
+        expect(item?.properties).toHaveProperty("org");
+        expect(item?.properties).toHaveProperty("contact");
+        expect(item?.properties).toHaveProperty("projectRole");
       });
-    });
 
-    it("composes mappingFromCg by nesting child mappings under the property name", async () => {
-      const item = await loadFormItem("key-contact");
-      expect(item?.mappingFromCg).toMatchObject({
-        org: { name: { field: "organizations.primary.name" } },
-        contact: {
-          name: {
-            firstName: { field: "contacts.primary.name.firstName" },
+      it("composes a VerticalLayout UI schema from the form's properties", async () => {
+        expect(item?.uiSchema.type).toBe("VerticalLayout");
+        const elements = item?.uiSchema.elements as Record<string, unknown>[];
+        expect(elements).toHaveLength(3);
+      });
+
+      it("re-scopes inherited Control scopes under the property name", async () => {
+        const json = JSON.stringify(item?.uiSchema);
+        expect(json).toContain('"scope":"#/properties/org/properties/name"');
+        expect(json).toContain(
+          '"scope":"#/properties/contact/properties/name/properties/firstName"',
+        );
+      });
+
+      it("generates a default Control for atomic form-only fields", async () => {
+        const elements = item?.uiSchema.elements as Record<string, unknown>[];
+        const projectRoleEl = elements[elements.length - 1];
+        expect(projectRoleEl).toEqual({
+          type: "Control",
+          scope: "#/properties/projectRole",
+        });
+      });
+
+      it("applies the field-level x-overrides label", async () => {
+        const json = JSON.stringify(item?.uiSchema);
+        expect(json).toContain('"label":"Applicant Organization Name"');
+      });
+
+      it("aggregates field-level overrides under the property name", async () => {
+        expect(item?.overrides.uiSchema).toEqual({
+          "org.name": { label: "Applicant Organization Name" },
+        });
+      });
+
+      it("composes mappingFromCg by nesting child mappings under the property name", async () => {
+        expect(item?.mappingFromCg).toMatchObject({
+          org: { name: { field: "organizations.primary.name" } },
+          contact: {
+            name: {
+              firstName: { field: "contacts.primary.name.firstName" },
+            },
           },
-        },
+        });
+      });
+
+      it("composes mappingToCg by rewriting field references with the property name prefix", async () => {
+        const orgPath = (
+          (item?.mappingToCg.organizations as Record<string, unknown>)
+            ?.primary as Record<string, unknown>
+        )?.name as { field: string };
+        expect(orgPath.field).toBe("org.name");
       });
     });
 
-    it("composes mappingToCg by rewriting field references with the property name prefix", async () => {
-      const item = await loadFormItem("key-contact");
-      const orgPath = (
-        (item?.mappingToCg.organizations as Record<string, unknown>)
-          ?.primary as Record<string, unknown>
-      )?.name as { field: string };
-      expect(orgPath.field).toBe("org.name");
-    });
+    // =============================================================================
+    // unknown form id
+    // =============================================================================
 
     it("returns null for an unknown form id", async () => {
       const item = await loadFormItem("does-not-exist");
       expect(item).toBeNull();
     });
   });
+
+  // =============================================================================
+  // loadAllFormItems
+  // =============================================================================
 
   describe("loadAllFormItems", () => {
     it("returns a map keyed by form id", async () => {

--- a/website/__tests__/lib/forms/loader.spec.ts
+++ b/website/__tests__/lib/forms/loader.spec.ts
@@ -2,54 +2,94 @@ import { describe, it, expect } from "vitest";
 import { loadFormItem, loadAllFormItems, getFormIds } from "@/lib/forms";
 
 /**
- * These tests exercise the end-to-end loader against the FormCanary schema.
- * The canary YAML must exist at website/.extension-schemas/FormCanary.yaml,
- * which the typespec emit step produces. CI runs `pnpm build` (which runs
- * typespec first) before `pnpm test`; locally, run `pnpm typespec` once.
+ * End-to-end loader tests against the KeyContact form. The compiled YAML
+ * must exist at website/.extension-schemas/KeyContact.yaml, which the
+ * typespec emit step produces. CI runs `pnpm build` (which runs typespec
+ * first) before `pnpm test`; locally, run `pnpm typespec` once.
  */
 
 describe("forms loader", () => {
   describe("getFormIds", () => {
     it("returns the slugs in typespec-index.json", () => {
-      const ids = getFormIds();
-      expect(ids).toContain("form-canary");
+      expect(getFormIds()).toContain("key-contact");
     });
   });
 
   describe("loadFormItem", () => {
-    it("loads the canary form by id with all fields populated", async () => {
-      const item = await loadFormItem("form-canary");
+    it("loads the key-contact form by id with all metadata fields populated", async () => {
+      const item = await loadFormItem("key-contact");
 
       expect(item).not.toBeNull();
-      expect(item?.id).toBe("form-canary");
-      expect(item?.schema).toBe("FormCanary");
-      expect(item?.label).toBe("Canary");
-      expect(item?.description).toContain("Canary form");
-      expect(item?.tags).toEqual([]);
-      expect(item?.properties).toHaveProperty("note");
+      expect(item?.id).toBe("key-contact");
+      expect(item?.schema).toBe("KeyContact");
+      expect(item?.label).toBe("Key Contact");
+      expect(item?.description).toContain("Key Contacts");
+      expect(item?.tags).toEqual(
+        expect.arrayContaining(["key-contact", "application"]),
+      );
+      expect(item?.properties).toHaveProperty("org");
+      expect(item?.properties).toHaveProperty("contact");
+      expect(item?.properties).toHaveProperty("projectRole");
     });
 
-    it("extracts the canary's x-ui-schema verbatim", async () => {
-      const item = await loadFormItem("form-canary");
+    it("composes a VerticalLayout UI schema from the form's properties", async () => {
+      const item = await loadFormItem("key-contact");
+      expect(item?.uiSchema.type).toBe("VerticalLayout");
+      const elements = item?.uiSchema.elements as Record<string, unknown>[];
+      expect(elements).toHaveLength(3);
+    });
 
-      expect(item?.uiSchema).toEqual({
-        type: "Group",
-        label: "Canary",
-        elements: [
-          { type: "Control", scope: "#/properties/note", label: "Note" },
-        ],
+    it("re-scopes inherited Control scopes under the property name", async () => {
+      const item = await loadFormItem("key-contact");
+      const json = JSON.stringify(item?.uiSchema);
+      expect(json).toContain('"scope":"#/properties/org/properties/name"');
+      expect(json).toContain(
+        '"scope":"#/properties/contact/properties/name/properties/firstName"',
+      );
+    });
+
+    it("generates a default Control for atomic form-only fields", async () => {
+      const item = await loadFormItem("key-contact");
+      const elements = item?.uiSchema.elements as Record<string, unknown>[];
+      const projectRoleEl = elements[elements.length - 1];
+      expect(projectRoleEl).toEqual({
+        type: "Control",
+        scope: "#/properties/projectRole",
       });
     });
 
-    it("extracts both x-mapping-from-cg and x-mapping-to-cg", async () => {
-      const item = await loadFormItem("form-canary");
+    it("applies the field-level x-overrides label", async () => {
+      const item = await loadFormItem("key-contact");
+      const json = JSON.stringify(item?.uiSchema);
+      expect(json).toContain('"label":"Applicant Organization Name"');
+    });
 
-      expect(item?.mappingFromCg).toEqual({
-        note: { field: "customFields.canary.note" },
+    it("aggregates field-level overrides under the property name", async () => {
+      const item = await loadFormItem("key-contact");
+      expect(item?.overrides.uiSchema).toEqual({
+        "org.name": { label: "Applicant Organization Name" },
       });
-      expect(item?.mappingToCg).toEqual({
-        note: { field: "customFields.canary.note" },
+    });
+
+    it("composes mappingFromCg by nesting child mappings under the property name", async () => {
+      const item = await loadFormItem("key-contact");
+      expect(item?.mappingFromCg).toMatchObject({
+        org: { name: { field: "organizations.primary.name" } },
+        contact: {
+          name: {
+            firstName: { field: "contacts.primary.name.firstName" },
+          },
+        },
       });
+    });
+
+    it("composes mappingToCg by rewriting field references with the property name prefix", async () => {
+      const item = await loadFormItem("key-contact");
+      const orgPath = (
+        (item?.mappingToCg.organizations as Record<string, unknown>)
+          ?.primary as Record<string, unknown>
+      )?.name as { field: string };
+      expect(orgPath.field).toBe("org.name");
     });
 
     it("returns null for an unknown form id", async () => {
@@ -61,8 +101,8 @@ describe("forms loader", () => {
   describe("loadAllFormItems", () => {
     it("returns a map keyed by form id", async () => {
       const all = await loadAllFormItems();
-      expect(all["form-canary"]).toBeDefined();
-      expect(all["form-canary"].label).toBe("Canary");
+      expect(all["key-contact"]).toBeDefined();
+      expect(all["key-contact"].label).toBe("Key Contact");
     });
 
     it("caches across calls (same reference returned)", async () => {

--- a/website/src/content/forms/typespec-index.json
+++ b/website/src/content/forms/typespec-index.json
@@ -1,6 +1,6 @@
 {
-  "form-canary": {
-    "schema": "FormCanary",
-    "label": "Canary"
+  "key-contact": {
+    "schema": "KeyContact",
+    "label": "Key Contact"
   }
 }

--- a/website/src/specs/forms/index.tsp
+++ b/website/src/specs/forms/index.tsp
@@ -1,34 +1,9 @@
 import "@common-grants/core";
 import "@typespec/json-schema";
 
+import "./key-contact.tsp";
+
 using JsonSchema;
 
 @JsonSchema.jsonSchema
 namespace Forms;
-
-/**
- * Canary form used to exercise the forms pipeline before any real form
- * is composed. Provides one property and a minimal x-ui-schema so the
- * loader has a non-empty schema to dereference and extract from.
- *
- * Removed in the PR that introduces the first real form (key-contact).
- */
-@extension(
-  "x-ui-schema",
-  #{
-    type: "Group",
-    label: "Canary",
-    elements: #[
-      #{ type: "Control", scope: "#/properties/note", label: "Note" }
-    ],
-  }
-)
-@extension(
-  "x-mapping-from-cg",
-  #{ note: #{ field: "customFields.canary.note" } }
-)
-@extension("x-mapping-to-cg", #{ note: #{ field: "customFields.canary.note" } })
-model FormCanary {
-  /** Free-text note used only for canary verification */
-  note?: string;
-}

--- a/website/src/specs/forms/key-contact.tsp
+++ b/website/src/specs/forms/key-contact.tsp
@@ -1,0 +1,37 @@
+import "@typespec/json-schema";
+import "../question-bank/primary-org/org-name.tsp";
+import "../question-bank/poc/poc-details.tsp";
+
+using JsonSchema;
+using QuestionBank.OrgName;
+using QuestionBank.PocDetails;
+
+namespace Forms.KeyContact;
+
+/**
+ * Grants.gov "Key Contacts" form (FID 683).
+ *
+ * Captures the primary point of contact for a grant application along
+ * with their role on the project. The applicant organization name doubles
+ * as the link to ApplicantInfo on full applications.
+ *
+ * The legacy hand-written version (no longer the source of truth) lives
+ * at website/src/content/forms/key-contact/. Reviewers compare the two
+ * via /forms-new/key-contact vs /forms/key-contact during migration.
+ */
+@extension("x-tags", #["key-contact", "application"])
+model KeyContact {
+  /** Applicant organization */
+  @extension(
+    "x-overrides",
+    #{ uiSchema: #{ name: #{ label: "Applicant Organization Name" } } }
+  )
+  org: QuestionOrgName;
+
+  /** Primary point of contact for the project */
+  contact: QuestionPocDetails;
+
+  /** This contact's role on the project (e.g. Project Director, Fiscal Contact) */
+  @example("Project Director")
+  projectRole: string;
+}


### PR DESCRIPTION
### Summary

Demonstrates the new form library layout using a sample form from the existing form library

- Part 4 of 4 in a stacked diff
- Fixes #593 
- Time to review: 10 minutes

### Changes proposed

- Added `website/src/specs/forms/key-contact.tsp`, the first real TypeSpec-built form (Grants.gov Key Contacts, FID 683)
- Composes `QuestionOrgName` + `QuestionPocDetails` plus an atomic `projectRole` field (the unique key-contact-only field surfaced by the form-to-question-bank gap analysis)
- Field-level `x-overrides` relabels the org name to "Applicant Organization Name" to match the PDF section heading
- Removed the placeholder `FormCanary` model and its `typespec-index.json` entry now that a real form exists
- Updated the loader integration test from canary assertions to key-contact assertions (+5 new tests for composition + override merging end-to-end)

### Context for reviewers

**Review instructions: (PR preview)**
- Go to https://cg-pr-713.billy-daly.workers.dev/forms-new/
- Click on "Key Contact" or go to: https://cg-pr-713.billy-daly.workers.dev/forms-new/key-contact/
- Review the various tabs on the form details page

**Implementation notes:**
- `projectRole` is the only field that exists on the legacy form but has no QB question (surfaced by the cross-form gap analysis from earlier in this issue). Modeled as a plain `string` with `@example("Project Director")` so the example generator still produces realistic seed data
- The `org.name` label override is the only intentional textual change; everything else is inherited verbatim from the composed QB types

> [!IMPORTANT]
> This PR is meant to serve as a proof of concept for the new question-bank-driven form library. To add the remaining forms from the existing form library, though, we'll need to make a few changes to how the `ajv` instance is rendered because several forms reference the same schema (Address) in multiple places, which raises an `ajv` error. The work to fix this blocker and finish migrating the rest of the forms are captured in the following tickets:
> - #714 
> - #715 
> - #716 

### Additional information

<img width="1440" height="900" alt="Screenshot 2026-04-14 at 10 15 42 AM" src="https://github.com/user-attachments/assets/8a7a92fb-51d2-4d7a-aa92-da87a3f7fb5f" />
<img width="1440" height="900" alt="Screenshot 2026-04-14 at 10 15 11 AM" src="https://github.com/user-attachments/assets/fe990afa-d176-4b5a-83e2-a6b0b0ebe81d" />
<img width="1440" height="900" alt="Screenshot 2026-04-14 at 10 15 20 AM" src="https://github.com/user-attachments/assets/7be9fe18-7ff1-4fb9-bd47-b8a51de7eef5" />
<img width="1440" height="900" alt="Screenshot 2026-04-14 at 10 15 33 AM" src="https://github.com/user-attachments/assets/db250b37-51d7-4e6b-9838-d00439c44fd1" />


### Stack

> This PR is part of a stacked diff. Please review only the changes in this PR, not the cumulative diff.

| # | Branch | Targets | PR | Status |
|---|--------|---------|----|--------|
| 1 | `stack/593-generate-forms-from-question-bank/01-audit-cleanup` | `593-generate-forms-from-question-bank` | #710 | ⏳ Open |
| 2 | `stack/593-generate-forms-from-question-bank/02-forms-loader` | PR 1 | #711 | ⏳ Open |
| 3 | `stack/593-generate-forms-from-question-bank/03-forms-new-pages` | PR 2 | #712 | ⏳ Open |
| 4 | `stack/593-generate-forms-from-question-bank/04-key-contact-form` | PR 3 | #713 | 🎯 Current |

**Review order**: Start from PR 1 and work down.
**Merge strategy**: Squash and merge each PR in order. After merging, rebase the next PR onto the parent feature branch (`593-generate-forms-from-question-bank`) and update its base accordingly. Once all four merge into the parent, an umbrella PR will merge `593-generate-forms-from-question-bank` into `main`.
