### PR TITLE
[Issue #612] Set catalog update PR author to github-actions bot

### DIFF
--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: chore/update-catalog-deps
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           title: "chore(deps): update catalog dependencies"
           body: |
             ## Automated catalog dependency update


### PR DESCRIPTION
### Summary

- Related #612
- Time to review: 5 minutes

### Changes proposed
Set the `deps-catalog-check` workflow to pass explicit `author` and `committer` values to `peter-evans/create-pull-request`, both using `github-actions[bot]`, so catalog dependency update commits are no longer attributed to the workflow triggerer.

### Context for reviewers
- Verified against the action docs that `create-pull-request` defaults `author` to `${{ github.actor }}` while `committer` defaults to `github-actions[bot]`, which explains the current attribution split.
- Verified locally that the diff is limited to the two new workflow inputs in `.github/workflows/deps-catalog-check.yml`.
- No code or runtime behavior changed; `lsp_diagnostics` on the workflow file is clean.

### Additional information
N/A