### PR TITLE
fix: Replace pnpm audit with bulk advisory endpoint script

### DIFF
--- a/.github/scripts/audit-deps.js
+++ b/.github/scripts/audit-deps.js
@@ -135,7 +135,15 @@ const req = https.request(
         process.exit(1);
       }
 
-      const advisories = JSON.parse(data);
+      let advisories;
+      try {
+        advisories = JSON.parse(data);
+      } catch {
+        console.error(
+          'Failed to parse registry response:\n' + data.slice(0, 200)
+        );
+        process.exit(1);
+      }
       const affected = Object.keys(advisories);
 
       if (affected.length === 0) {

--- a/.github/scripts/audit-deps.js
+++ b/.github/scripts/audit-deps.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+
+// Workaround for pnpm audit 410 error (pnpm/pnpm#11265).
+//
+// npm retired the legacy audit endpoints on 2026-04-15, returning
+// 410 Gone. pnpm <=10.x (and 11.0.0-rc.0) still uses the old
+// endpoints. This script calls the replacement bulk advisory
+// endpoint directly.
+//
+// Usage:
+//   node audit-deps.js [options]
+//
+// Options:
+//   --level <severity>    Minimum severity to fail on (low|moderate|high|critical). Default: low
+//   --filter <pattern>    pnpm workspace filter (e.g. @common-grants/cli)
+//   --ignore-ghsa <id>    GHSA ID to ignore (can be repeated)
+//
+// Requires pnpm on PATH. Remove this script once pnpm ships
+// native support for the new endpoint.
+
+'use strict';
+
+const { execSync } = require('node:child_process');
+const https = require('node:https');
+
+const BULK_ENDPOINT =
+  'https://registry.npmjs.org/-/npm/v1/security/advisories/bulk';
+
+const SEVERITY_ORDER = ['low', 'moderate', 'high', 'critical'];
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Parse arguments
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+let level = 'low';
+let filter = '';
+const ignoreGhsas = new Set();
+
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
+    case '--level':
+      level = args[++i];
+      break;
+    case '--filter':
+      filter = args[++i];
+      break;
+    case '--ignore-ghsa':
+      ignoreGhsas.add(args[++i]);
+      break;
+    default:
+      console.error('Unknown option: ' + args[i]);
+      process.exit(1);
+  }
+}
+
+const threshold = SEVERITY_ORDER.indexOf(level);
+if (threshold === -1) {
+  console.error(
+    'Unknown severity: ' + level + '. Use: low, moderate, high, or critical'
+  );
+  process.exit(1);
+}
+const severityGate = new Set(SEVERITY_ORDER.slice(threshold));
+
+// ---------------------------------------------------------------------------
+// 1. Collect all transitive dependencies via pnpm
+// ---------------------------------------------------------------------------
+
+const listCmd = filter
+  ? `pnpm list --filter ${filter} --json --depth=Infinity`
+  : 'pnpm list --json --depth=Infinity';
+
+let raw;
+try {
+  raw = execSync(listCmd, {
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+} catch (err) {
+  console.error(
+    'Failed to list dependencies. Is pnpm installed and have you run pnpm install?\n' +
+      (err.stderr || err.message)
+  );
+  process.exit(1);
+}
+
+const projects = JSON.parse(raw);
+const deps = {};
+const seen = new Set();
+
+function walk(tree) {
+  for (const [name, info] of Object.entries(tree || {})) {
+    const key = name + '@' + info.version;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    if (!deps[name]) deps[name] = [];
+    if (!deps[name].includes(info.version)) deps[name].push(info.version);
+    walk(info.dependencies);
+  }
+}
+for (const project of projects) {
+  walk(project.dependencies);
+  walk(project.devDependencies);
+}
+
+const count = Object.keys(deps).length;
+console.log('Auditing ' + count + ' packages\u2026');
+
+// ---------------------------------------------------------------------------
+// 2. POST to the bulk advisory endpoint
+// ---------------------------------------------------------------------------
+
+const body = JSON.stringify(deps);
+
+const req = https.request(
+  BULK_ENDPOINT,
+  {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(body),
+    },
+    timeout: REQUEST_TIMEOUT_MS,
+  },
+  function (res) {
+    let data = '';
+    res.on('data', function (chunk) {
+      data += chunk;
+    });
+    res.on('end', function () {
+      if (res.statusCode !== 200) {
+        console.error('Registry returned ' + res.statusCode + ': ' + data);
+        process.exit(1);
+      }
+
+      const advisories = JSON.parse(data);
+      const affected = Object.keys(advisories);
+
+      if (affected.length === 0) {
+        console.log('No vulnerabilities found.');
+        process.exit(0);
+      }
+
+      let gated = 0;
+      for (const pkg of affected) {
+        for (const advisory of advisories[pkg]) {
+          const ghsaId = (advisory.url || '').split('/').pop() || '';
+          if (ignoreGhsas.has(ghsaId)) continue;
+
+          const sev = advisory.severity;
+          const icon =
+            sev === 'critical'
+              ? '\u{1F534}'
+              : sev === 'high'
+                ? '\u{1F7E0}'
+                : sev === 'moderate'
+                  ? '\u{1F7E1}'
+                  : '\u26AA';
+          console.log(
+            icon +
+              ' ' +
+              sev.padEnd(9) +
+              ' ' +
+              pkg +
+              ' ' +
+              advisory.vulnerable_versions +
+              ' \u2014 ' +
+              advisory.title +
+              (ghsaId ? ' (' + ghsaId + ')' : '')
+          );
+          if (severityGate.has(sev)) gated++;
+        }
+      }
+
+      if (gated > 0) {
+        console.error(
+          '\n' + gated + ' advisory(ies) at or above "' + level + '" severity.'
+        );
+        process.exit(1);
+      }
+      console.log('\nNo advisories at or above "' + level + '" severity.');
+    });
+  }
+);
+
+req.on('timeout', function () {
+  req.destroy();
+  console.error('Request timed out after ' + REQUEST_TIMEOUT_MS + 'ms');
+  process.exit(1);
+});
+
+req.on('error', function (err) {
+  console.error('Request failed: ' + err.message);
+  process.exit(1);
+});
+
+req.write(body);
+req.end();

--- a/.github/workflows/ci-catalog-validation.yml
+++ b/.github/workflows/ci-catalog-validation.yml
@@ -34,9 +34,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Audit dependencies
-        # auditConfig.ignoreGhsas in pnpm-workspace.yaml excludes known advisories;
-        # --audit-level=moderate keeps low-severity findings from blocking CI.
-        run: pnpm audit --audit-level=moderate
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm audit` once pnpm ships native support.
+        run: node .github/scripts/audit-deps.js --level moderate
 
       - name: CI — core
         run: pnpm run ci:core

--- a/.github/workflows/ci-lib-changelog-emitter.yml
+++ b/.github/workflows/ci-lib-changelog-emitter.yml
@@ -40,4 +40,7 @@ jobs:
         run: pnpm --filter typespec-versioning-changelog run test:coverage
 
       - name: Audit dependencies
-        run: pnpm --filter typespec-versioning-changelog run audit
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm --filter typespec-versioning-changelog run audit` once pnpm ships native support.
+        run: node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js --filter typespec-versioning-changelog

--- a/.github/workflows/ci-lib-cli.yml
+++ b/.github/workflows/ci-lib-cli.yml
@@ -45,4 +45,7 @@ jobs:
         run: pnpm --filter @common-grants/cli run build
 
       - name: Audit dependencies
-        run: pnpm --filter @common-grants/cli run audit
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm --filter @common-grants/cli run audit` once pnpm ships native support.
+        run: node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js --filter @common-grants/cli

--- a/.github/workflows/ci-lib-core.yml
+++ b/.github/workflows/ci-lib-core.yml
@@ -42,4 +42,7 @@ jobs:
         run: pnpm --filter @common-grants/core run typespec
 
       - name: Audit dependencies
-        run: pnpm --filter @common-grants/core run audit
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm --filter @common-grants/core run audit` once pnpm ships native support.
+        run: node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js --filter @common-grants/core

--- a/.github/workflows/ci-lib-ts-sdk.yml
+++ b/.github/workflows/ci-lib-ts-sdk.yml
@@ -42,4 +42,7 @@ jobs:
         run: pnpm --filter @common-grants/sdk run test:coverage
 
       - name: Audit dependencies
-        run: pnpm --filter @common-grants/sdk run audit
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm --filter @common-grants/sdk run audit` once pnpm ships native support.
+        run: node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js --filter @common-grants/sdk

--- a/.github/workflows/ci-template-express-js.yml
+++ b/.github/workflows/ci-template-express-js.yml
@@ -45,6 +45,13 @@ jobs:
         # Calls the npm bulk advisory endpoint directly as a workaround for
         # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
         # revert to `pnpm audit --ignore-workspace` once pnpm ships native support.
+        #
+        # Suppressed GHSAs — all are unpatched transitive deps of express v4 / swagger-ui-express.
+        # Remove each once an upstream fix lands or the template migrates to express v5.
+        #   GHSA-3ppc-4f35-3m26  high     minimatch ReDoS (via glob < 9, transitive of express)
+        #   GHSA-83g3-92jg-28cx  high     node-tar symlink escape (transitive of npm/pacote)
+        #   GHSA-2g4f-4pwh-qvx6  moderate ajv ReDoS with $data (transitive of swagger-ui-express)
+        #   GHSA-w7fw-mjwx-w883  low      qs arrayLimit DoS (transitive of express body-parser)
         run: >
           node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js
           --ignore-ghsa GHSA-3ppc-4f35-3m26

--- a/.github/workflows/ci-template-express-js.yml
+++ b/.github/workflows/ci-template-express-js.yml
@@ -42,4 +42,12 @@ jobs:
         run: pnpm run build
 
       - name: Audit dependencies
-        run: pnpm audit --ignore-workspace
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm audit --ignore-workspace` once pnpm ships native support.
+        run: >
+          node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js
+          --ignore-ghsa GHSA-3ppc-4f35-3m26
+          --ignore-ghsa GHSA-83g3-92jg-28cx
+          --ignore-ghsa GHSA-2g4f-4pwh-qvx6
+          --ignore-ghsa GHSA-w7fw-mjwx-w883

--- a/.github/workflows/ci-template-quickstart.yml
+++ b/.github/workflows/ci-template-quickstart.yml
@@ -42,4 +42,7 @@ jobs:
         run: pnpm run typespec
 
       - name: Audit dependencies
-        run: pnpm audit --ignore-workspace
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm audit --ignore-workspace` once pnpm ships native support.
+        run: node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js

--- a/.github/workflows/ci-website-preview.yml
+++ b/.github/workflows/ci-website-preview.yml
@@ -45,7 +45,10 @@ jobs:
         run: pnpm run checks
 
       - name: Audit dependencies
-        run: pnpm run audit:high
+        # Calls the npm bulk advisory endpoint directly as a workaround for
+        # pnpm audit 410 errors (pnpm/pnpm#11265). Remove this script and
+        # revert to `pnpm run audit:high` once pnpm ships native support.
+        run: node ${GITHUB_WORKSPACE}/.github/scripts/audit-deps.js --level high
 
       # Preview deployment (only on PRs)
       - name: Deploy PR preview


### PR DESCRIPTION
### Summary

- Fixes CI failures caused by npm retiring their legacy audit endpoint
- Time to review: 10 minutes

### Changes proposed

Added a new script (`.github/scripts/audit-deps.js`) that calls npm's replacement bulk advisory endpoint directly, bypassing pnpm's broken `pnpm audit` command. All CI workflow audit steps now use this script instead of `pnpm audit`.

**Files changed:**
- New: `.github/scripts/audit-deps.js` — standalone Node.js script that queries the bulk advisory endpoint
- 8 CI workflow files updated to call the new script instead of `pnpm audit`
- 5 package.json files reverted (no longer need `--ignore-registry-errors`)

### Context for reviewers

npm retired their legacy `/v1/security/audits` endpoint on 2026-04-15, returning HTTP 410. pnpm (all v10.x and v11 rc) still uses the old endpoint, breaking `pnpm audit` globally.

This is tracked upstream:
- **Issue:** https://github.com/pnpm/pnpm/issues/11265

Rather than using `--ignore-registry-errors` (which silently skips the audit), this PR adopts a community workaround from the upstream issue ([comment](https://github.com/pnpm/pnpm/issues/11265#issuecomment-4253931245)) that calls the new bulk advisory endpoint directly. This keeps real vulnerability detection active.

The script audits all dependencies (prod + dev) and supports a severity threshold argument matching the existing per-workflow audit levels.

Each workflow file has a comment linking to the upstream issue and documenting what to revert once pnpm ships native support (expected in pnpm v11).

### Additional information

**Dependabot PRs unblocked by this change:**
- #718 — chore(deps-dev): bump the tooling group (typescript-eslint)
- #719 — chore(deps): bump the website-framework group