### PR TITLE
chore: upgrade pnpm from 10.18.3 to 10.33.0

### DIFF
--- a/.github/workflows/cd-deploy-lib-cli.yml
+++ b/.github/workflows/cd-deploy-lib-cli.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-lib-core.yml
+++ b/.github/workflows/cd-deploy-lib-core.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/cd-deploy-lib-ts-sdk.yml
+++ b/.github/workflows/cd-deploy-lib-ts-sdk.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-bump-version.yml
+++ b/.github/workflows/ci-bump-version.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-catalog-validation.yml
+++ b/.github/workflows/ci-catalog-validation.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Validate catalog deps in Dependabot ignore list
         run: ./.github/scripts/validate-catalog-deps.sh

--- a/.github/workflows/ci-lib-changelog-emitter.yml
+++ b/.github/workflows/ci-lib-changelog-emitter.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-lib-cli-publish.yml
+++ b/.github/workflows/ci-lib-cli-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-lib-cli.yml
+++ b/.github/workflows/ci-lib-cli.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-lib-core-publish.yml
+++ b/.github/workflows/ci-lib-core-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-lib-core.yml
+++ b/.github/workflows/ci-lib-core.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-lib-ts-sdk-publish.yml
+++ b/.github/workflows/ci-lib-ts-sdk-publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci-lib-ts-sdk.yml
+++ b/.github/workflows/ci-lib-ts-sdk.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v5
         with:
-          version: 10.18.3
+          version: 10.33.0
 
       - name: Install dependencies
         run: pnpm install

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.18.3",
+  "packageManager": "pnpm@10.33.0",
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.30.0"

--- a/templates/express-js/package.json
+++ b/templates/express-js/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "Agile Six",
   "license": "MIT",
-  "packageManager": "pnpm@10.18.3",
+  "packageManager": "pnpm@10.33.0",
   "dependencies": {
     "@common-grants/core": "^0.3.2",
     "cors": "^2.8.6",

--- a/templates/quickstart/package.json
+++ b/templates/quickstart/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "private": true,
   "description": "CommonGrants quickstart template",
-  "packageManager": "pnpm@10.18.3",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "typespec": "tsp compile main.tsp",
     "format": "tsp format .",


### PR DESCRIPTION
### Summary

- Unblocks #720
- Time to review: 5 minutes

### Changes proposed

Upgrade pnpm from 10.18.3 to 10.33.0 across all `packageManager` fields (3 package.json files) and all CI workflow version pins (13 workflow files).

### Context for reviewers

PR #720 (Dependabot GitHub Actions bump) bumps `pnpm/action-setup` from v4 to v6. v6 writes a second YAML document into `pnpm-lock.yaml` for version resolution metadata. pnpm 10.18.3 cannot parse multi-document lockfiles, causing `ERR_PNPM_BROKEN_LOCKFILE` in every CI job that runs `pnpm install --frozen-lockfile`.

pnpm 10.33.0 handles multi-document lockfiles correctly. This is a known upstream issue:
- pnpm/action-setup#226
- pnpm/action-setup#228

No lockfile changes were needed — the dependency tree is identical between 10.18.3 and 10.33.0.

Verified locally: `pnpm install --frozen-lockfile` passes for root, `templates/express-js`, and `templates/quickstart`.

### Additional information

N/A