### PR TITLE
[Issue #714] Fix ajv errors in website for form library

### DIFF
--- a/website/__tests__/lib/schema/ref-resolver.spec.ts
+++ b/website/__tests__/lib/schema/ref-resolver.spec.ts
@@ -40,7 +40,7 @@ describe("dereferenceSchema — multi-composite AJV safety", () => {
   it("fully dereferenced output (without stripping $id) throws — pins the underlying bug", async () => {
     // Baseline: $RefParser deep-clones each resolved $ref, so a schema
     // with three $refs to Event.yaml produces a tree with three distinct
-    // subschemas all carrying the same $id. AJV walks the tree on
+    // sub-schemas all carrying the same $id. AJV walks the tree on
     // addSchema, sees duplicates, and throws.
     //
     // If this test ever stops throwing, $RefParser changed its semantics

--- a/website/__tests__/lib/schema/ref-resolver.spec.ts
+++ b/website/__tests__/lib/schema/ref-resolver.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import Ajv2020 from "ajv/dist/2020";
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+import {
+  resolveSchemaRefs,
+  dereferenceSchema,
+} from "@/lib/schema/ref-resolver";
+import { Paths } from "@/lib/schema/paths";
+
+/**
+ * Regression tests for the multi-composite shared-$ref AJV failure.
+ *
+ * Uses OppTimeline.yaml as the fixture: it references Event.yaml three
+ * times (postDate, closeDate, otherDates), which transitively pulls in
+ * isoDate.yaml multiple times. This is the same structural pattern that
+ * multi-composite forms produce (e.g. SF424Mandatory composing three QB
+ * questions that each include QuestionAddress).
+ *
+ * The pair of tests below isolates the root cause: the failure is not
+ * about having multiple $refs to the same schema — it's about what
+ * happens when those refs are fully resolved before being handed to AJV.
+ */
+describe("dereferenceSchema — multi-composite AJV safety", () => {
+  const schemaPath = path.join(Paths.SCHEMAS_DIR, "OppTimeline.yaml");
+
+  it("raw YAML (unresolved $refs) is accepted by AJV — multiple $refs are fine", () => {
+    // Contrast case: the same schema shape, but $refs are strings pointing
+    // to other files rather than inlined subtrees. AJV registers the top-
+    // level schema by $id and lazily resolves references to other
+    // registered schemas. No duplicate $id conflict.
+    const raw = yaml.load(fs.readFileSync(schemaPath, "utf-8")) as {
+      $id: string;
+    };
+    const ajv = new Ajv2020({ strict: false });
+    expect(() => ajv.addSchema(raw, raw.$id)).not.toThrow();
+  });
+
+  it("fully dereferenced output (without stripping $id) throws — pins the underlying bug", async () => {
+    // Baseline: $RefParser deep-clones each resolved $ref, so a schema
+    // with three $refs to Event.yaml produces a tree with three distinct
+    // subschemas all carrying the same $id. AJV walks the tree on
+    // addSchema, sees duplicates, and throws.
+    //
+    // If this test ever stops throwing, $RefParser changed its semantics
+    // and the stripIds step in dereferenceSchema may no longer be needed.
+    const resolved = (await resolveSchemaRefs(schemaPath)) as {
+      $id: string;
+    };
+    const ajv = new Ajv2020({ strict: false });
+    expect(() => ajv.addSchema(resolved, resolved.$id)).toThrow(
+      /resolves to more than one schema/,
+    );
+  });
+
+  it("dereferenceSchema output is accepted by AJV — the fix", async () => {
+    // dereferenceSchema strips $ids from the tree after inlining, so every
+    // downstream AJV consumer (JsonFormRenderer's internal AJV, direct
+    // ajv.addSchema, etc.) is safe regardless of how many shared sub-
+    // schemas a form composes.
+    const schema = (await dereferenceSchema(schemaPath)) as {
+      $id?: string;
+    };
+    const ajv = new Ajv2020({ strict: false });
+    expect(() => ajv.addSchema(schema, schema.$id ?? "test")).not.toThrow();
+  });
+});

--- a/website/__tests__/lib/schema/strip-ids.spec.ts
+++ b/website/__tests__/lib/schema/strip-ids.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { stripIds } from "@/lib/schema/strip-ids";
+
+describe("stripIds", () => {
+  it("removes a top-level $id field", () => {
+    const result = stripIds({ $id: "Foo.yaml", type: "object" });
+    expect(result).not.toHaveProperty("$id");
+    expect(result).toHaveProperty("type", "object");
+  });
+
+  it("removes $id fields nested inside properties", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        address: { $id: "QuestionAddress.yaml", type: "object" },
+      },
+    };
+    const result = stripIds(schema) as typeof schema;
+    expect(result.properties.address).not.toHaveProperty("$id");
+    expect(result.properties.address.type).toBe("object");
+  });
+
+  it("removes duplicate $id values at multiple levels (the multi-composite case)", () => {
+    const schema = {
+      $id: "SF424Mandatory.yaml",
+      properties: {
+        org: { $id: "QuestionAddress.yaml", type: "object" },
+        aor: { $id: "QuestionAddress.yaml", type: "object" },
+      },
+    };
+    const result = stripIds(schema) as typeof schema;
+    expect(result).not.toHaveProperty("$id");
+    expect(result.properties.org).not.toHaveProperty("$id");
+    expect(result.properties.aor).not.toHaveProperty("$id");
+  });
+
+  it("does not remove non-string $id values", () => {
+    // $id is always a string per JSON Schema spec, but guard the edge case
+    const schema = { $id: 42, type: "string" };
+    const result = stripIds(schema) as typeof schema;
+    expect(result.$id).toBe(42);
+  });
+
+  it("leaves schemas with no $id unchanged", () => {
+    const schema = { type: "object", properties: { name: { type: "string" } } };
+    const result = stripIds(schema);
+    expect(result).toEqual(schema);
+  });
+});

--- a/website/src/content/forms/typespec-index.json
+++ b/website/src/content/forms/typespec-index.json
@@ -2,5 +2,9 @@
   "key-contact": {
     "schema": "KeyContact",
     "label": "Key Contact"
+  },
+  "sf424-mandatory": {
+    "schema": "SF424Mandatory",
+    "label": "SF-424 Mandatory Contacts"
   }
 }

--- a/website/src/lib/schema/ref-resolver.ts
+++ b/website/src/lib/schema/ref-resolver.ts
@@ -1,5 +1,6 @@
 import $RefParser from "@apidevtools/json-schema-ref-parser";
 import mergeAllOf from "json-schema-merge-allof";
+import { stripIds } from "./strip-ids";
 
 /**
  * Loads a schema by file path, resolves all $ref references, and returns
@@ -13,8 +14,22 @@ export async function resolveSchemaRefs(
 
 /**
  * Fully dereferences a schema file: resolves all $ref references, merges
- * allOf entries (from TypeSpec "extends" patterns), and strips $schema
- * (which can confuse downstream AJV consumers like JSON Forms).
+ * allOf entries (from TypeSpec "extends" patterns), strips $schema (which
+ * can confuse downstream AJV consumers like JSON Forms), and strips all
+ * $id fields from the inlined tree.
+ *
+ * Why strip $ids: $RefParser.dereference() deep-clones each resolved $ref,
+ * so a schema that pulls in the same sub-schema through multiple paths
+ * (e.g. a form composing three QB questions that each include
+ * QuestionAddress) produces a tree with N distinct subschemas all
+ * carrying the same $id. Any AJV consumer that walks that tree via
+ * addSchema / compile throws "reference X resolves to more than one
+ * schema". Stripping $ids at this boundary makes the result safe for
+ * every downstream consumer — JsonFormRenderer's internal AJV,
+ * openapi-sampler validation, direct ajv.addSchema, etc.
+ *
+ * See __tests__/lib/schema/ref-resolver.spec.ts for the regression test
+ * that pins this behavior.
  *
  * This is the main entry point for preparing a schema for rendering.
  */
@@ -31,5 +46,5 @@ export async function dereferenceSchema(
     },
   }) as Record<string, unknown>;
   delete merged.$schema;
-  return merged;
+  return stripIds(merged);
 }

--- a/website/src/lib/schema/ref-resolver.ts
+++ b/website/src/lib/schema/ref-resolver.ts
@@ -21,7 +21,7 @@ export async function resolveSchemaRefs(
  * Why strip $ids: $RefParser.dereference() deep-clones each resolved $ref,
  * so a schema that pulls in the same sub-schema through multiple paths
  * (e.g. a form composing three QB questions that each include
- * QuestionAddress) produces a tree with N distinct subschemas all
+ * QuestionAddress) produces a tree with N distinct sub-schemas all
  * carrying the same $id. Any AJV consumer that walks that tree via
  * addSchema / compile throws "reference X resolves to more than one
  * schema". Stripping $ids at this boundary makes the result safe for

--- a/website/src/lib/schema/strip-ids.ts
+++ b/website/src/lib/schema/strip-ids.ts
@@ -1,0 +1,16 @@
+/**
+ * Recursively removes all `$id` fields from a schema object.
+ *
+ * After full $ref inlining, the same $id (e.g. "QuestionAddress.yaml") can
+ * appear multiple times in the schema tree — once per composite that references
+ * it. AJV (used internally by JsonForms) throws "resolves to more than one
+ * schema" when it encounters duplicate $id values. Stripping them prevents
+ * that error while leaving the structural schema intact.
+ */
+export function stripIds<T>(schema: T): T {
+  return JSON.parse(
+    JSON.stringify(schema, (key, value) =>
+      key === "$id" && typeof value === "string" ? undefined : value,
+    ),
+  ) as T;
+}

--- a/website/src/specs/forms/index.tsp
+++ b/website/src/specs/forms/index.tsp
@@ -2,6 +2,7 @@ import "@common-grants/core";
 import "@typespec/json-schema";
 
 import "./key-contact.tsp";
+import "./sf424-mandatory.tsp";
 
 using JsonSchema;
 

--- a/website/src/specs/forms/sf424-mandatory.tsp
+++ b/website/src/specs/forms/sf424-mandatory.tsp
@@ -1,0 +1,28 @@
+import "@typespec/json-schema";
+import "../question-bank/primary-org/org-details.tsp";
+import "../question-bank/poc/poc-details.tsp";
+import "../question-bank/aor/aor-details.tsp";
+
+using JsonSchema;
+using QuestionBank.OrgDetails;
+using QuestionBank.PocDetails;
+using QuestionBank.AorDetails;
+
+namespace Forms.SF424Mandatory;
+
+/**
+ * SF-424 mandatory contact information section.
+ * Composes org + contact + AOR — all three include QuestionAddress,
+ * which is the multi-composite case that triggers the AJV shared-refs error.
+ */
+@extension("x-tags", #["sf424-mandatory", "application"])
+model SF424Mandatory {
+  /** Primary applicant organization */
+  org: QuestionOrgDetails;
+
+  /** Primary point of contact */
+  contact: QuestionPocDetails;
+
+  /** Authorized Organization Representative */
+  aor: QuestionAorDetails;
+}


### PR DESCRIPTION
### Summary

Alternate minimal fix for #714 / #737. Strips `$id` fields inside `dereferenceSchema` so every downstream AJV consumer is safe from the "resolves to more than one schema" throw when a dereferenced tree contains shared-`$id` duplicates.

- Fixes #714 
- Time to review: 15 minutes.

### Root cause

`$RefParser.dereference()` deep-clones each resolved `$ref`, so a schema that pulls in the same sub-schema through multiple paths produces a tree with N distinct subschemas all carrying the same `$id`. Any AJV consumer that walks that tree via `addSchema` / `compile` throws `reference X resolves to more than one schema`. Forms are the first place this bites because they're the composition layer that brings together multiple QB questions sharing transitive deps like `QuestionAddress`.

### Changes proposed

One-line change: `dereferenceSchema()` now calls `stripIds()` on the merged output. New regression test (`__tests__/lib/schema/ref-resolver.spec.ts`) pins the behavior with three cases:

1. Raw YAML (unresolved `$refs`) is accepted by AJV — proves multiple `$refs` are not the problem
2. Full `$RefParser` output without stripping throws — pins the underlying bug; if it ever stops throwing, `$RefParser` changed and we can revisit
3. `dereferenceSchema` output is accepted — proves the fix

Uses `OppTimeline.yaml` as the fixture (three `$ref: Event.yaml`, transitively pulling `isoDate.yaml`) so the regression test doesn't depend on any specific form being present.

### Context

See #737 for the full root-cause investigation. @jcrichlake identified `$id` duplication as the real culprit and wrote the `stripIds` utility — both commits are cherry-picked here to preserve authorship. This PR moves the `stripIds` call site from `FormDetails.astro` to `dereferenceSchema`, which turns out to be sufficient on its own: the per-call AJV refactor, `.form-schemas/` directory split, and `extensionsAjv` removal in #737 aren't needed.

### Test plan

1. Checkout the PR and go to `website/`
2. Run `pnpm build` and all pages should build correctly (including `/forms-new/s424Mandatory`
3. Go to https://cg-pr-739.billy-daly.workers.dev/forms-new/ and explore the forms

### Additional info

<img width="1512" height="982" alt="Screenshot 2026-04-18 at 12 48 19 PM" src="https://github.com/user-attachments/assets/a9f2c19b-b26b-4f4a-9bc8-22cb001e69c5" />
<img width="1512" height="982" alt="Screenshot 2026-04-18 at 1 03 41 PM" src="https://github.com/user-attachments/assets/a1ef45f1-9461-4ab9-877d-1ac384f7b9c5" />
