### PR TITLE
ci: fix website PR preview cleanup

### DIFF
--- a/.github/workflows/ci-website-cleanup.yml
+++ b/.github/workflows/ci-website-cleanup.yml
@@ -5,7 +5,8 @@ on:
     types: [closed]
     paths:
       - website/**
-      - .github/workflows/ci-website.yml
+      - .github/workflows/ci-website-preview.yml
+      - .github/workflows/ci-website-cleanup.yml
 
 jobs:
   cleanup-preview:

--- a/.github/workflows/ci-website-cleanup.yml
+++ b/.github/workflows/ci-website-cleanup.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
+        with:
+          version: 10
 
       - name: Delete Worker for PR
         run: |

--- a/.github/workflows/ci-website-preview.yml
+++ b/.github/workflows/ci-website-preview.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
     paths:
       - website/**
-      - .github/workflows/ci-website.yml
+      - .github/workflows/ci-website-preview.yml
+      - .github/workflows/ci-website-cleanup.yml
       - pnpm-lock.yaml
 
 defaults:


### PR DESCRIPTION
### Summary

Fixes failing PR preview workflow due to missing pnpm version.

- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Fixes website CI workflow triggers
- Adds version to pnpm step in cleanup workflow

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

We removed the `version` section from the pnpm setup steps in CI workflows because they conflicted with the version in `package.json` but because the cleanup step doesn't rely on a specific `package.json` for the cleanup, [it currently fails](https://github.com/HHS/simpler-grants-protocol/actions/runs/24846740600/job/72735796660).

<img width="1440" height="900" alt="Screenshot 2026-04-23 at 6 25 59 PM" src="https://github.com/user-attachments/assets/07f089cd-574a-4a01-9a2f-37ebfd4f5bf8" />

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Successfully deleted the preview 🎉 

<img width="1440" height="900" alt="Screenshot 2026-04-23 at 6 30 33 PM" src="https://github.com/user-attachments/assets/8a79497f-fecc-4ac5-b875-c64195494ebb" />