### PR TITLE
ci: skip website preview cleanup for dependabot PRs

### DIFF
--- a/.github/workflows/ci-website-cleanup.yml
+++ b/.github/workflows/ci-website-cleanup.yml
@@ -12,6 +12,9 @@ jobs:
   cleanup-preview:
     runs-on: ubuntu-latest
     name: Cleanup PR preview
+    # Previews are not deployed for dependabot PRs (see ci-website-preview.yml),
+    # so there's nothing to clean up and `wrangler delete` would 404.
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
### Summary

- Fixes failing `CI - Website: Cleanup PR Preview` on dependabot PR merges (e.g. [#772](https://github.com/HHS/simpler-grants-protocol/pull/772), [#773](https://github.com/HHS/simpler-grants-protocol/pull/773))
- Time to review: 2 minutes

### Changes proposed

- Gate the cleanup job on `github.actor != 'dependabot[bot]'`, mirroring the condition already used on the deploy step in `ci-website-preview.yml`.

### Context for reviewers

Preview deploys already skip dependabot: [ci-website-preview.yml L56](https://github.com/HHS/simpler-grants-protocol/blob/main/.github/workflows/ci-website-preview.yml#L56). So `cg-pr-<n>` never exists for a dependabot PR, and when cleanup runs on close it fails with:

```
A request to the Cloudflare API (/accounts/***/workers/services/cg-pr-772) failed.
This Worker does not exist on this account. [code: 10090]
```

Example failed run: https://github.com/HHS/simpler-grants-protocol/actions/runs/24897539582/job/72906310636

This change skips the whole job for dependabot so there's no spurious red X on the merge commit. Non-dependabot PRs are unaffected.

### Additional information

N/A