### PR TITLE
ci: fix catalog update script under frozen-lockfile default

### DIFF
--- a/.github/scripts/update-catalog-deps.sh
+++ b/.github/scripts/update-catalog-deps.sh
@@ -138,7 +138,8 @@ fi
 
 echo ""
 echo "--- Regenerating lockfile ---"
-pnpm install
+# Catalog edits above changed pnpm-workspace.yaml; override CI's frozen default to update the lockfile.
+pnpm install --no-frozen-lockfile
 
 echo ""
 echo "--- Summary of changes ---"

--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -6,6 +6,11 @@ on:
     - cron: "0 15 * * 1"
   workflow_call:
   workflow_dispatch:
+  # Smoke-test the script end-to-end on changes here (e.g. dependabot action bumps).
+  pull_request:
+    paths:
+      - .github/scripts/update-catalog-deps.sh
+      - .github/workflows/deps-catalog-check.yml
 
 permissions:
   contents: write
@@ -50,7 +55,7 @@ jobs:
         run: ./.github/scripts/update-catalog-deps.sh
 
       - name: Create pull request
-        if: steps.check.outputs.has_updates == 'true'
+        if: steps.check.outputs.has_updates == 'true' && github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

- Fixes the weekly `Deps: Check Catalog Updates` workflow, which has been failing since run [25004220287](https://github.com/HHS/simpler-grants-protocol/actions/runs/25004220287).
- Refs #612 (original automated dependency update tracking issue).
- Time to review: 5 minutes

### Changes proposed

- `.github/scripts/update-catalog-deps.sh`: pass `--no-frozen-lockfile` to the lockfile regeneration step. After the script edits catalog versions in `pnpm-workspace.yaml`, pnpm 10's CI default of `--frozen-lockfile` aborts with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` because the catalog config has drifted. Refreshing the lockfile is the script's whole purpose at that point.
- `.github/workflows/deps-catalog-check.yml`: add a `pull_request` trigger filtered to the script and the workflow file itself, and gate the create-pull-request step on `github.event_name != 'pull_request'`. Future edits (including dependabot action bumps that touch this workflow, like #720) get smoke-tested in PR CI rather than waiting up to a week for the next scheduled run.

### Context for reviewers

**Root cause.** [#720](https://github.com/HHS/simpler-grants-protocol/pull/720) bumped `pnpm/action-setup` from v4 to v6 on 2026-04-22, which ships pnpm 10.33. Last green run was 2026-04-13 on v5. The next two scheduled runs (04-20 and 04-27) failed in the same place — the `pnpm install` after the catalog edits.

**Verification.** Reproduced the failure and verified the fix locally:

```
$ CI=true ./.github/scripts/update-catalog-deps.sh
... 13 catalog dep(s) have updates.
--- Regenerating lockfile ---
... Done in 8.5s using pnpm v10.33.0
--- Summary of changes ---
 pnpm-lock.yaml      | 1527 +++++++++++++++------------------------------------
 pnpm-workspace.yaml |   26 +-
 2 files changed, 468 insertions(+), 1085 deletions(-)
```

(Reverted the workspace/lockfile edits after verifying — only the script and workflow changes are in this PR.)

**Smoke-test loop closes on this PR.** Both filtered paths are touched here, so the new `pull_request` trigger fires on this PR's CI and exercises the fix end-to-end before merge.

### Additional information

Failure log excerpt from run [25004220287](https://github.com/HHS/simpler-grants-protocol/actions/runs/25004220287):

```
--- Regenerating lockfile ---
Scope: all 7 workspace projects
 ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "catalogs" configuration doesn't match the value found in the lockfile

Update your lockfile using "pnpm install --no-frozen-lockfile"
```