### PR TITLE
ci: fix dependabot guard on website preview cleanup

### DIFF
--- a/.github/workflows/ci-website-cleanup.yml
+++ b/.github/workflows/ci-website-cleanup.yml
@@ -14,7 +14,9 @@ jobs:
     name: Cleanup PR preview
     # Previews are not deployed for dependabot PRs (see ci-website-preview.yml),
     # so there's nothing to clean up and `wrangler delete` would 404.
-    if: github.actor != 'dependabot[bot]'
+    # Use pull_request.user.login because github.actor on `closed` events is
+    # the person who closed/merged the PR, not the PR author.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6


### PR DESCRIPTION
### Summary

- Follow-up to #774
- Time to review: 3 minutes

### Changes proposed

Switch the cleanup workflow's dependabot guard from `github.actor` to `github.event.pull_request.user.login`.

### Context for reviewers

The guard added in #774 was supposed to skip preview cleanup on dependabot PRs (since previews aren't deployed for them, so `wrangler delete` 404s). It used `github.actor`, which on `pull_request: closed` events resolves to the person who closed/merged the PR — not the PR author. As a result, the job still ran whenever a maintainer merged a dependabot PR.

Both of today's dependabot merges hit this:

- [run 25008016312](https://github.com/HHS/simpler-grants-protocol/actions/runs/25008016312) on #778
- [run 25007766237](https://github.com/HHS/simpler-grants-protocol/actions/runs/25007766237) on #777

Both failed with `This Worker does not exist on this account. [code: 10090]`.

`pull_request.user.login` is the PR author and is stable across `opened` / `synchronize` / `closed`, so the guard now fires regardless of who clicks merge.

The preview workflow's identical-looking `github.actor != 'dependabot[bot]'` checks are unaffected — that workflow only runs on open/sync, where `github.actor` *is* the dependabot bot.

### Additional information

n/a — verification will come from the next dependabot PR merge producing a skipped cleanup job.