### PR TITLE
docs(adr): #759 resolve drift in mergeExtensions, getClient, filters

### DIFF
--- a/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
+++ b/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
@@ -32,7 +32,7 @@ We decided to:
 
 1. **Keep "plugin" as the unified term** for both the published npm/PyPI packages in the website catalog and the runtime SDK object. No change to `PluginSourceEntry` or `src/content/plugins/index.json`. The existing `definePlugin()` function is expanded to accept the full set of top-level fields described below.
 
-2. **Use functional grouping at the top level** with four keys — `meta`, `client`, `schemas`, and `extensions` — rather than grouping by object name at the root.
+2. **Use functional grouping at the top level** with four keys — `meta`, `client`, `schemas`, and `extensions` — rather than grouping by object name at the root. Custom filters (`filters`) are an authoring-time input on `DefinePluginOptions` / `define_plugin()` and surface through the `Client` returned by `getClient()`, so they don't add a fifth top-level key on the runtime `Plugin` shape.
 
 3. **Use per-object grouping inside `schemas`** where it reflects real coupling: each object's native schema, CommonGrants schema, and bidirectional transforms are tightly coupled and change together.
 
@@ -142,16 +142,16 @@ interface ClientConfig {
   [key: string]: unknown;
 }
 
-// Client is a placeholder for the SDK's runtime client type (not shown here)
+// Client is a placeholder for the SDK's runtime client type (not shown here).
+// Per Decision #2: the runtime Plugin shape stays at four keys. Custom filters
+// declared on DefinePluginOptions are handled by the Client returned by getClient(),
+// so `filters` does not appear on Plugin itself.
 interface Plugin {
   meta?: PluginMeta;
   getClient?: (config: ClientConfig) => Client;
   extensions?: PluginExtensions; // serializable
   schemas?: Partial<
     Record<ExtensibleSchemaName, ObjectSchemas<unknown, unknown>>
-  >;
-  filters?: Partial<
-    Record<ExtensibleSchemaName, Record<string, CustomFilterSpec>>
   >;
 }
 
@@ -190,10 +190,13 @@ interface DefinePluginOptions {
 // to the errors array rather than throwing (see Decision #7).
 function definePlugin(options: DefinePluginOptions): Plugin;
 
-// Combine multiple extension objects (e.g. from separate packages)
+// Combine multiple extension objects (e.g. from separate packages).
+// Exact signature is provisional pending SDK implementation (#744) — the SDK PR
+// will pin the final shape, including the `error` default that preserves detailed
+// type inference for plugins.
 function mergeExtensions(
-  ...extensions: PluginExtensions[],
-  onConflict: "firstWins" = "firstWins",
+  extensions: PluginExtensions[],
+  options?: { onConflict?: "firstWins" | "lastWins" | "error" }, // default: "error"
 ): PluginExtensions;
 
 // Handler signature matches ADR-0017 runtime conventions.
@@ -319,13 +322,15 @@ class PluginExtensions(BaseModel):
 
 ClientConfig = dict[str, Any]  # plugin authors define their own keys (auth, base_url, timeout, etc.)
 
+# Per Decision #2: the runtime Plugin shape stays at four keys. Custom filters
+# declared on define_plugin(filters=...) are handled by the Client returned by
+# get_client(), so `filters` does not appear on Plugin itself.
 @dataclass
 class Plugin:
     meta: PluginMeta | None = None
     get_client: Callable[[ClientConfig], Client] | None = None
     extensions: PluginExtensions | None = None
     schemas: dict[ExtensibleSchemaName, ObjectSchemas[Any, Any]] | None = None
-    filters: dict[ExtensibleSchemaName, dict[str, CustomFilterSpec]] | None = None
 
 # All params are optional — adopters can start with only what they need and expand
 # incrementally. Unlike TypeScript, Python supports named optional params at the
@@ -352,7 +357,12 @@ def define_plugin(
     schemas: dict[ExtensibleSchemaName, ObjectSchemasInput[Any, Any]] | None = None,
     filters: dict[ExtensibleSchemaName, dict[str, CustomFilterSpec]] | None = None,
 ) -> Plugin: ...
-def merge_extensions(*extensions: PluginExtensions, on_conflict: Literal["first_wins"] = "first_wins") -> PluginExtensions: ...
+# Exact signature is provisional pending SDK implementation (#744) — the SDK PR
+# will pin the final shape.
+def merge_extensions(
+    *extensions: PluginExtensions,
+    on_conflict: Literal["firstWins", "lastWins", "error"] = "firstWins",
+) -> PluginExtensions: ...
 
 # Handler signature matches ADR-0017 runtime conventions.
 Handler = Callable[[Any, Any], Any]
@@ -460,7 +470,7 @@ const plugin = definePlugin({
 });
 
 // Combine extensions from multiple packages before constructing the plugin
-const merged = mergeExtensions(baseExtensions, grantsGovExtensions);
+const merged = mergeExtensions([baseExtensions, grantsGovExtensions]);
 const mergedPlugin = definePlugin({ extensions: merged });
 
 // Calling getClient() with a config object — memoized, so repeated calls return the same instance
@@ -767,7 +777,7 @@ Top-level keys are functional (`meta`, `client`, `schemas`, `extensions`). Per-o
 ```ts
 interface Plugin {
   meta?: PluginMeta;
-  client?: Client;
+  getClient?: (config: ClientConfig) => Client;
   extensions?: PluginExtensions;
   schemas?: Partial<Record<ExtensibleSchemaName, ObjectSchemas>>; // per-object grouping only here
 }

--- a/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
+++ b/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
@@ -143,6 +143,7 @@ interface ClientConfig {
 }
 
 // Client is a placeholder for the SDK's runtime client type (not shown here).
+//
 // Per Decision #2: the runtime Plugin shape stays at four keys. Custom filters
 // declared on DefinePluginOptions are handled by the Client returned by getClient(),
 // so `filters` does not appear on Plugin itself.
@@ -192,8 +193,7 @@ function definePlugin(options: DefinePluginOptions): Plugin;
 
 // Combine multiple extension objects (e.g. from separate packages).
 // Exact signature is provisional pending SDK implementation (#744) — the SDK PR
-// will pin the final shape, including the `error` default that preserves detailed
-// type inference for plugins.
+// will pin the final shape, including the conflict-resolution default.
 function mergeExtensions(
   extensions: PluginExtensions[],
   options?: { onConflict?: "firstWins" | "lastWins" | "error" }, // default: "error"
@@ -324,7 +324,7 @@ ClientConfig = dict[str, Any]  # plugin authors define their own keys (auth, bas
 
 # Per Decision #2: the runtime Plugin shape stays at four keys. Custom filters
 # declared on define_plugin(filters=...) are handled by the Client returned by
-# get_client(), so `filters` does not appear on Plugin itself.
+# getClient(), so `filters` does not appear on Plugin itself.
 @dataclass
 class Plugin:
     meta: PluginMeta | None = None
@@ -357,8 +357,9 @@ def define_plugin(
     schemas: dict[ExtensibleSchemaName, ObjectSchemasInput[Any, Any]] | None = None,
     filters: dict[ExtensibleSchemaName, dict[str, CustomFilterSpec]] | None = None,
 ) -> Plugin: ...
+
 # Exact signature is provisional pending SDK implementation (#744) — the SDK PR
-# will pin the final shape.
+# will pin the final shape, including the conflict-resolution default.
 def merge_extensions(
     *extensions: PluginExtensions,
     on_conflict: Literal["firstWins", "lastWins", "error"] = "firstWins",

--- a/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
+++ b/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
@@ -189,11 +189,10 @@ interface DefinePluginOptions {
 function definePlugin(options: DefinePluginOptions): Plugin;
 
 // Combine multiple extension objects (e.g. from separate packages).
-// Exact signature is provisional pending SDK implementation (#744) — the SDK PR
-// will pin the final shape, including the conflict-resolution default.
+// Exact signature shape (overloads, param structure) is provisional pending SDK pin in #744.
 function mergeExtensions(
   extensions: PluginExtensions[],
-  options?: { onConflict?: "firstWins" | "lastWins" | "error" },
+  options?: { onConflict?: "error" | "firstWins" | "lastWins" }, // defaults to "error"
 ): PluginExtensions;
 
 // Handler signature matches ADR-0017 runtime conventions.
@@ -353,11 +352,10 @@ def define_plugin(
     filters: dict[ExtensibleSchemaName, dict[str, CustomFilterSpec]] | None = None,
 ) -> Plugin: ...
 
-# Exact signature is provisional pending SDK implementation (#744) — the SDK PR
-# will pin the final shape, including the conflict-resolution default.
+# Exact signature shape is provisional pending SDK pin in #744.
 def merge_extensions(
     *extensions: PluginExtensions,
-    on_conflict: Literal["firstWins", "lastWins", "error"] = "firstWins",
+    on_conflict: Literal["error", "firstWins", "lastWins"] = "error",
 ) -> PluginExtensions: ...
 
 # Handler signature matches ADR-0017 runtime conventions.

--- a/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
+++ b/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
@@ -196,7 +196,7 @@ function definePlugin(options: DefinePluginOptions): Plugin;
 // will pin the final shape, including the conflict-resolution default.
 function mergeExtensions(
   extensions: PluginExtensions[],
-  options?: { onConflict?: "firstWins" | "lastWins" | "error" }, // default: "error"
+  options?: { onConflict?: "firstWins" | "lastWins" | "error" },
 ): PluginExtensions;
 
 // Handler signature matches ADR-0017 runtime conventions.

--- a/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
+++ b/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
@@ -143,10 +143,7 @@ interface ClientConfig {
 }
 
 // Client is a placeholder for the SDK's runtime client type (not shown here).
-//
-// Per Decision #2: the runtime Plugin shape stays at four keys. Custom filters
-// declared on DefinePluginOptions are handled by the Client returned by getClient(),
-// so `filters` does not appear on Plugin itself.
+// No `filters` key on Plugin — handled by the Client returned by getClient() (see Decision #2).
 interface Plugin {
   meta?: PluginMeta;
   getClient?: (config: ClientConfig) => Client;
@@ -322,9 +319,7 @@ class PluginExtensions(BaseModel):
 
 ClientConfig = dict[str, Any]  # plugin authors define their own keys (auth, base_url, timeout, etc.)
 
-# Per Decision #2: the runtime Plugin shape stays at four keys. Custom filters
-# declared on define_plugin(filters=...) are handled by the Client returned by
-# getClient(), so `filters` does not appear on Plugin itself.
+# No `filters` field on Plugin — handled by the Client returned by get_client() (see Decision #2).
 @dataclass
 class Plugin:
     meta: PluginMeta | None = None


### PR DESCRIPTION
### Summary

- Fixes #759
- Time to review: 5 minutes

### Changes proposed

Three spec-internal drift items in [ADR-0022 plugin framework](https://commongrants.org/governance/adr/0022-plugin-framework/), flagged during [#740](https://github.com/HHS/simpler-grants-protocol/pull/740) review and deferred to land alongside the SDK sub-issues. All three resolved in one .mdx file:

1. **`mergeExtensions` / `merge_extensions` signatures.** Replace the single-literal `onConflict: "firstWins" = "firstWins"` (which can only ever hold one value) with the three-value union `"firstWins" | "lastWins" | "error"` per [Billy's reply on #740](https://github.com/HHS/simpler-grants-protocol/pull/740#discussion_r3127086113). TS switches from `...rest, options` to `extensions: PluginExtensions[], options?: { onConflict? }` to satisfy TS1014 (rest parameter must be last); the example call site at line 473 updates to the new array-arg form. Both signatures carry an inline `// provisional pending SDK implementation (#744)` marker — exact syntax will be pinned by the SDK PR per Billy's deferral framing.

2. **`client` vs `getClient` drift in the Option 3 sketch.** The chosen-option `interface Plugin` (line 149), the plugin-shape prose (line 56), and the Option 3 pros all already use `getClient`. Only the Option 3 sketch (now line 780) lagged with `client?: Client`. Updated for consistency.

3. **Orphan `filters` top-level key.** Decision #2 enumerates four top-level keys (`meta`, `client`, `schemas`, `extensions`), but the runtime `Plugin` types tacked on a fifth `filters` key. Per [Billy's resolution](https://github.com/HHS/simpler-grants-protocol/pull/740#discussion_r3127172197): `filters` belongs on `DefinePluginOptions` / `define_plugin()` as an authoring-time input but does not surface on the runtime `Plugin` shape, because filter handling is encapsulated in the `Client` returned by `getClient()`. Removed `filters?:` from the TS `interface Plugin` and the Python `Plugin` dataclass; left `DefinePluginOptions` / `define_plugin(... filters=...)` untouched. Decision #2 footnote and inline comments above each `Plugin` type document the intentional asymmetry.

### Context for reviewers

- Per acceptance criteria on #759, this lands as a single follow-up PR tagged `adr` + `documentation`. No SDK code changes; the implementer tickets ([#744](https://github.com/HHS/simpler-grants-protocol/issues/744) / [#745](https://github.com/HHS/simpler-grants-protocol/issues/745) / [#756](https://github.com/HHS/simpler-grants-protocol/issues/756) / [#757](https://github.com/HHS/simpler-grants-protocol/issues/757)) own those.
- Verification (run inside `website/`):
  - `pnpm check:format` — all matched files use Prettier code style
  - `pnpm check:astro` — 0 errors, 0 warnings, 0 hints
  - `pnpm check:spelling` — 768 files, 0 issues
- **Item 1 framing.** Per [Billy's reply on the deferral thread](https://github.com/HHS/simpler-grants-protocol/pull/740#discussion_r3127086113), exact signature syntax "will likely need to change as we start actually implementing these decisions." But the current ADR snippet was TS1014-invalid as written, so leaving it would mean shipping uncompilable code in the doc. This PR fixes the obvious bugs (single-literal type, rest-parameter ordering, filters orphan) and adds an inline `provisional pending #744` marker on each signature so future readers know not to over-index on the exact form. The SDK PR pins the final shape.
- **Item 3 framing.** The "filters live on Client" design lines up with the prior `leaning client-side` position from the long-running adapter/transformation architecture exploration. Open spike [#646](https://github.com/HHS/simpler-grants-protocol/issues/646) (custom filter design) goes further — it proposes renaming `filters` → `customFilters` and moving it under `extensions.schemas.<Object>.customFilters`. That's deliberately out of scope here: this PR only resolves the existing drift against ADR-0022's current shape; the rename and placement decisions belong to #646.
- **`mergeExtensions` / `merge_extensions` default.** Pinned to `error` in both signatures. The existing Python SDK ([specs.py:67-68](https://github.com/HHS/simpler-grants-protocol/blob/main/lib/python-sdk/common_grants_sdk/extensions/specs.py#L67-L68)) defaults to `error`, and the existing TS SDK does too via overloads ([merge-extensions.ts:67-86](https://github.com/HHS/simpler-grants-protocol/blob/main/lib/ts-sdk/src/extensions/merge-extensions.ts#L67-L86)) with the runtime fallback at [L96](https://github.com/HHS/simpler-grants-protocol/blob/main/lib/ts-sdk/src/extensions/merge-extensions.ts#L96). My initial draft kept Python at `firstWins` and left TS unpinned on the deferral framing — [Jeff flagged the mismatch](https://github.com/HHS/simpler-grants-protocol/pull/803#discussion_r3204039182), and the ADR now matches both implementations. The `provisional pending #744` marker still covers the broader signature shape but no longer covers the default.

### Additional information

N/A — documentation-only diff (+22/-12 in one file plus a small follow-up commit applying review feedback).
