### PR TITLE
ci(deps-catalog): respect semver and split majors into draft PR

### DIFF
--- a/.github/scripts/update-catalog-deps.sh
+++ b/.github/scripts/update-catalog-deps.sh
@@ -1,14 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Update catalog-managed dependencies to latest versions by modifying
-# pnpm-workspace.yaml version ranges and regenerating the lockfile.
-# These deps are excluded from Dependabot to avoid lockfile corruption
-# (dependabot-core #14339).
+# Update catalog-managed dependencies in pnpm-workspace.yaml and regenerate
+# the lockfile. These deps are excluded from Dependabot to avoid lockfile
+# corruption (dependabot-core #14339).
+#
+# Two modes, controlled by --majors-only:
+#
+#   Default (within-major)
+#     Bumps each dep to the latest version on the same compatibility line.
+#     ^X.Y.Z (X>=1)  stay within major X — e.g. typescript ^5.9.3 -> ^5.x.y
+#     ^0.Y.Z         stay within 0.x line — e.g. @typespec/rest ^0.80.0 -> ^0.81.x
+#                    (lets TypeSpec ecosystem minor bumps through, blocks 0.x -> 1.0)
+#     ~X.Y.Z         stay within minor X.Y
+#     pinned         no auto-bump
+#
+#   --majors-only
+#     Inverts the filter: only proposes bumps that CROSS the boundary above
+#     (typescript 5 -> 6, zod 3 -> 4, @types/node 20 -> 25, etc.). Use this to
+#     surface breaking-change candidates in a separate draft PR. Install runs
+#     with --ignore-scripts because prepare hooks will usually fail under a
+#     major bump; PR CI is the source of truth for whether the bump is viable.
 #
 # Usage:
-#   ./.github/scripts/update-catalog-deps.sh           # Update and regenerate lockfile
-#   ./.github/scripts/update-catalog-deps.sh --dry-run  # Check only, no changes
+#   ./.github/scripts/update-catalog-deps.sh                     # within-major, apply
+#   ./.github/scripts/update-catalog-deps.sh --dry-run           # within-major, check only
+#   ./.github/scripts/update-catalog-deps.sh --majors-only       # majors-only, apply
+#   ./.github/scripts/update-catalog-deps.sh --majors-only --dry-run
 #
 # Exit codes:
 #   0 = updates available (applied unless --dry-run)
@@ -19,11 +37,21 @@ set -euo pipefail
 # `catalogs: <name>:` sections).
 
 DRY_RUN=false
-if [[ "${1:-}" == "--dry-run" ]]; then
-  DRY_RUN=true
-fi
+MAJORS_ONLY=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true ;;
+    --majors-only) MAJORS_ONLY=true ;;
+    *) echo "ERROR: unknown argument: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
 
-echo "=== Checking for catalog dependency updates ==="
+if [[ "$MAJORS_ONLY" == "true" ]]; then
+  echo "=== Checking for MAJOR-VERSION catalog dependency updates ==="
+else
+  echo "=== Checking for catalog dependency updates (within-major) ==="
+fi
 
 WORKSPACE_FILE="pnpm-workspace.yaml"
 if [[ ! -f "$WORKSPACE_FILE" ]]; then
@@ -35,8 +63,10 @@ UPDATED_COUNT=0
 
 # check_and_update_dep <dep_name> <current_range> <catalog_label>
 #
-# Queries npm for the latest version, compares against the current range,
-# and updates pnpm-workspace.yaml if a newer version is available.
+# Picks the newest stable version on the relevant side of the dep's compat
+# boundary (see header) and updates pnpm-workspace.yaml when a newer version
+# is available. In --majors-only mode the boundary filter is inverted so only
+# versions OUTSIDE the current compat line are considered.
 check_and_update_dep() {
   local dep_name="$1"
   local current_range="$2"
@@ -53,20 +83,68 @@ check_and_update_dep() {
     base_version="${current_range:1}"
   fi
 
-  # Query npm registry for latest version
-  local latest
-  latest=$(npm view "$dep_name" version 2>/dev/null) || {
-    echo "  WARNING: Could not fetch latest version for $dep_name, skipping"
+  # Compute the boundary prefix that defines the dep's current compat line.
+  # We filter the published versions list rather than passing a semver range
+  # to npm directly because `npm view <pkg>@<range> version` emits one line
+  # per matching version, which is awkward to parse. Filtering also lets us
+  # exclude prereleases uniformly.
+  local major="${base_version%%.*}"
+  local rest="${base_version#*.}"
+  local minor="${rest%%.*}"
+  local boundary_prefix
+  if [[ "$prefix" == "~" ]]; then
+    # ~X.Y.Z -> X.Y.* is the compat line
+    boundary_prefix="${major}.${minor}."
+  elif [[ "$prefix" == "^" ]]; then
+    # ^X.Y.Z -> X.* is the compat line (this also captures 0.x minor bumps,
+    # which the TypeSpec ecosystem treats as in-band)
+    boundary_prefix="${major}."
+  else
+    # pinned: compat line is the exact version
+    boundary_prefix="${base_version}"
+  fi
+
+  local raw_versions
+  raw_versions=$(npm view "$dep_name" versions --json 2>/dev/null) || {
+    echo "  WARNING: Could not fetch versions for $dep_name, skipping"
     return
   }
 
-  # Compare versions: is latest newer than base_version?
+  # Default mode: pick highest stable version WITHIN the compat boundary.
+  # --majors-only: pick highest stable version OUTSIDE it (cross-boundary bump).
+  local jq_filter
+  if [[ "$MAJORS_ONLY" == "true" ]]; then
+    jq_filter='select((startswith($p) | not) and (test("[-+]") | not))'
+  else
+    jq_filter='select(startswith($p) and (test("[-+]") | not))'
+  fi
+
+  local latest
+  latest=$(printf '%s' "$raw_versions" \
+    | jq -r --arg p "$boundary_prefix" "
+        (if type == \"array\" then . else [.] end) | .[] | ${jq_filter}
+      " \
+    | sort -V \
+    | tail -n1)
+
+  if [[ -z "$latest" ]]; then
+    if [[ "$MAJORS_ONLY" == "false" ]]; then
+      echo "  WARNING: No matching version for $dep_name within ${boundary_prefix}*, skipping"
+    fi
+    # In majors-only mode, "no out-of-boundary versions" is the common case
+    # (most deps don't have a major waiting) and not worth logging per-dep.
+    return
+  fi
+
+  # Is the latest strictly newer than base_version?
   local newer
   newer=$(printf '%s\n%s\n' "$base_version" "$latest" | sort -V | tail -1)
 
   if [[ "$latest" != "$base_version" && "$newer" == "$latest" ]]; then
     local new_range="${prefix}${latest}"
-    echo "  UPDATE ($catalog_label): $dep_name $current_range -> $new_range"
+    local label="$catalog_label"
+    [[ "$MAJORS_ONLY" == "true" ]] && label="major:${catalog_label}"
+    echo "  UPDATE (${label}): $dep_name $current_range -> $new_range"
 
     if [[ "$DRY_RUN" == "false" ]]; then
       # Build sed pattern that matches both quoted and unquoted dep names.
@@ -77,8 +155,8 @@ check_and_update_dep() {
     fi
 
     UPDATED_COUNT=$((UPDATED_COUNT + 1))
-  else
-    echo "  OK ($catalog_label): $dep_name ${current_range} (latest: $latest)"
+  elif [[ "$MAJORS_ONLY" == "false" ]]; then
+    echo "  OK ($catalog_label): $dep_name ${current_range} (latest in range: $latest)"
   fi
 }
 
@@ -125,7 +203,11 @@ rm -f "${WORKSPACE_FILE}.bak"
 
 echo ""
 if [[ $UPDATED_COUNT -eq 0 ]]; then
-  echo "All catalog dependencies are up to date."
+  if [[ "$MAJORS_ONLY" == "true" ]]; then
+    echo "No major-version updates available."
+  else
+    echo "All catalog dependencies are up to date."
+  fi
   exit 2
 fi
 
@@ -138,8 +220,15 @@ fi
 
 echo ""
 echo "--- Regenerating lockfile ---"
-# Catalog edits above changed pnpm-workspace.yaml; override CI's frozen default to update the lockfile.
-pnpm install --no-frozen-lockfile
+# Catalog edits above changed pnpm-workspace.yaml; override CI's frozen
+# default to update the lockfile. In --majors-only mode skip the workspace
+# `prepare` scripts: tsc et al. will fail under a major bump, and that's
+# expected — the resulting draft PR's CI is where we want that signal.
+install_flags=(--no-frozen-lockfile)
+if [[ "$MAJORS_ONLY" == "true" ]]; then
+  install_flags+=(--ignore-scripts)
+fi
+pnpm install "${install_flags[@]}"
 
 echo ""
 echo "--- Summary of changes ---"

--- a/.github/workflows/deps-catalog-check-majors.yml
+++ b/.github/workflows/deps-catalog-check-majors.yml
@@ -1,0 +1,89 @@
+name: "Deps: Check Catalog Major Updates"
+
+on:
+  schedule:
+    # Weekly Monday at ~7-8am PT (15:00 UTC = 8am PDT / 7am PST)
+    - cron: "0 15 * * 1"
+  workflow_call:
+  workflow_dispatch:
+  # Smoke-test the script end-to-end on changes here (e.g. dependabot action bumps).
+  pull_request:
+    paths:
+      - .github/scripts/update-catalog-deps.sh
+      - .github/workflows/deps-catalog-check-majors.yml
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-catalog-majors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22.x"
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Check for major-version updates
+        id: check
+        run: |
+          set +e
+          ./.github/scripts/update-catalog-deps.sh --majors-only --dry-run
+          EXIT_CODE=$?
+          set -e
+          if [[ "$EXIT_CODE" -eq 2 ]]; then
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+          elif [[ "$EXIT_CODE" -eq 0 ]]; then
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Catalog dep check (majors-only) failed with exit code $EXIT_CODE"
+            exit 1
+          fi
+
+      - name: Apply major-version updates
+        if: steps.check.outputs.has_updates == 'true'
+        run: ./.github/scripts/update-catalog-deps.sh --majors-only
+
+      - name: Open major-version draft PR
+        if: steps.check.outputs.has_updates == 'true' && github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-catalog-deps-majors
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          draft: true
+          title: "chore(deps-major): catalog major-version bumps — REQUIRES MANUAL REVIEW"
+          body: |
+            ## ⚠️ Major-version catalog bumps — manual review required
+
+            This is a **draft** PR opened by the weekly `deps-catalog-check-majors` workflow to surface available cross-major dependency bumps. Each one is presumed to contain breaking changes (see recent history: zod 3→4 renamed `ZodError.errors`, typescript 5→6 deprecated `baseUrl`, etc.).
+
+            ### How to handle this PR
+            1. Look at the diff to see which majors are now available.
+            2. **Cherry-pick** the major(s) you want to adopt into their own focused PR with the corresponding migration work, OR
+            3. Pull this branch locally and chip away at the migrations, then mark ready for review.
+            4. If you don't want a particular major right now, drop it from the workspace diff before merging.
+
+            CI on this PR is **expected to fail** until migration work is done. The script regenerated the lockfile with `--ignore-scripts` so the lockfile is internally consistent even though `tsc`/build steps would currently break.
+
+            ### Why this PR exists
+            The within-major auto-update PR (`chore/update-catalog-deps`) intentionally holds these back because they break the build. This draft PR exists so they don't get silently forgotten — but they need a human to drive the migration.
+
+            ### Workflow
+            This PR is re-pushed every Monday with the latest majors. Don't worry about it going stale; merge or close it on your own cadence.
+          labels: |
+            dependencies
+            DO NOT MERGE
+          commit-message: "chore(deps-major): catalog major-version bumps"
+          delete-branch: true

--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -34,8 +34,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Check for outdated catalog deps
-        id: check
+      # ── Pass 1: within-major bumps ────────────────────────────────────────
+      # Safe updates that almost always work. Auto-mergeable after CI passes.
+
+      - name: Check for within-major updates
+        id: check_minor
         run: |
           set +e
           ./.github/scripts/update-catalog-deps.sh --dry-run
@@ -46,16 +49,16 @@ jobs:
           elif [[ "$EXIT_CODE" -eq 0 ]]; then
             echo "has_updates=true" >> $GITHUB_OUTPUT
           else
-            echo "::error::Catalog dep check failed with exit code $EXIT_CODE"
+            echo "::error::Catalog dep check (within-major) failed with exit code $EXIT_CODE"
             exit 1
           fi
 
-      - name: Run catalog update script
-        if: steps.check.outputs.has_updates == 'true'
+      - name: Apply within-major updates
+        if: steps.check_minor.outputs.has_updates == 'true'
         run: ./.github/scripts/update-catalog-deps.sh
 
-      - name: Create pull request
-        if: steps.check.outputs.has_updates == 'true' && github.event_name != 'pull_request'
+      - name: Open within-major PR
+        if: steps.check_minor.outputs.has_updates == 'true' && github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -67,6 +70,9 @@ jobs:
             ## Automated catalog dependency update
 
             This PR was created by the weekly `deps-catalog-check` workflow.
+
+            ### Scope
+            **Within-major bumps only.** Each dep moves to the newest version on its current compatibility line (same major for `^X.Y.Z`, same `0.x` line for `^0.Y.Z`, same minor for `~X.Y.Z`). Major-version bumps are handled by a separate draft PR (`chore/update-catalog-deps-majors`) that lands alongside this one when applicable.
 
             ### What changed
             Updates to dependencies managed via `pnpm-workspace.yaml` catalog:
@@ -82,9 +88,70 @@ jobs:
             - [ ] If TypeSpec packages updated: verify `pnpm run typespec` output is sensible
             - [ ] If website deps updated: spot-check key pages render correctly
             - [ ] If SDK-affecting deps updated: verify SDK examples still work
-            - [ ] If this is a **major** version bump: review changelog of updated packages
             - [ ] Add changeset if peerDep ranges changed for `@common-grants/core`
           labels: |
             dependencies
           commit-message: "chore(deps): update catalog dependencies"
+          delete-branch: true
+
+      # ── Pass 2: cross-major bumps (manual review) ─────────────────────────
+      # Drafts a separate PR for major bumps so they're visible but obviously
+      # not auto-mergeable. Reset the working tree first so pass 2 sees the
+      # original committed workspace + lockfile, not pass 1's modifications.
+
+      - name: Reset working tree for major pass
+        run: git checkout HEAD -- pnpm-workspace.yaml pnpm-lock.yaml
+
+      - name: Check for major-version updates
+        id: check_major
+        run: |
+          set +e
+          ./.github/scripts/update-catalog-deps.sh --majors-only --dry-run
+          EXIT_CODE=$?
+          set -e
+          if [[ "$EXIT_CODE" -eq 2 ]]; then
+            echo "has_updates=false" >> $GITHUB_OUTPUT
+          elif [[ "$EXIT_CODE" -eq 0 ]]; then
+            echo "has_updates=true" >> $GITHUB_OUTPUT
+          else
+            echo "::error::Catalog dep check (majors-only) failed with exit code $EXIT_CODE"
+            exit 1
+          fi
+
+      - name: Apply major-version updates
+        if: steps.check_major.outputs.has_updates == 'true'
+        run: ./.github/scripts/update-catalog-deps.sh --majors-only
+
+      - name: Open major-version draft PR
+        if: steps.check_major.outputs.has_updates == 'true' && github.event_name != 'pull_request'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/update-catalog-deps-majors
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          draft: true
+          title: "chore(deps-major): catalog major-version bumps — REQUIRES MANUAL REVIEW"
+          body: |
+            ## ⚠️ Major-version catalog bumps — manual review required
+
+            This is a **draft** PR opened by the weekly `deps-catalog-check` workflow to surface available cross-major dependency bumps. Each one is presumed to contain breaking changes (see recent history: zod 3→4 renamed `ZodError.errors`, typescript 5→6 deprecated `baseUrl`, etc.).
+
+            ### How to handle this PR
+            1. Look at the diff to see which majors are now available.
+            2. **Cherry-pick** the major(s) you want to adopt into their own focused PR with the corresponding migration work, OR
+            3. Pull this branch locally and chip away at the migrations, then mark ready for review.
+            4. If you don't want a particular major right now, drop it from the workspace diff before merging.
+
+            CI on this PR is **expected to fail** until migration work is done. The script regenerated the lockfile with `--ignore-scripts` so the lockfile is internally consistent even though `tsc`/build steps would currently break.
+
+            ### Why this PR exists
+            The within-major auto-update PR (`chore/update-catalog-deps`) intentionally holds these back because they break the build. This draft PR exists so they don't get silently forgotten — but they need a human to drive the migration.
+
+            ### Workflow
+            This PR is re-pushed every Monday with the latest majors. Don't worry about it going stale; merge or close it on your own cadence.
+          labels: |
+            dependencies
+            DO NOT MERGE
+          commit-message: "chore(deps-major): catalog major-version bumps"
           delete-branch: true

--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -34,11 +34,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      # ── Pass 1: within-major bumps ────────────────────────────────────────
-      # Safe updates that almost always work. Auto-mergeable after CI passes.
-
-      - name: Check for within-major updates
-        id: check_minor
+      - name: Check for outdated catalog deps
+        id: check
         run: |
           set +e
           ./.github/scripts/update-catalog-deps.sh --dry-run
@@ -49,16 +46,16 @@ jobs:
           elif [[ "$EXIT_CODE" -eq 0 ]]; then
             echo "has_updates=true" >> $GITHUB_OUTPUT
           else
-            echo "::error::Catalog dep check (within-major) failed with exit code $EXIT_CODE"
+            echo "::error::Catalog dep check failed with exit code $EXIT_CODE"
             exit 1
           fi
 
-      - name: Apply within-major updates
-        if: steps.check_minor.outputs.has_updates == 'true'
+      - name: Run catalog update script
+        if: steps.check.outputs.has_updates == 'true'
         run: ./.github/scripts/update-catalog-deps.sh
 
-      - name: Open within-major PR
-        if: steps.check_minor.outputs.has_updates == 'true' && github.event_name != 'pull_request'
+      - name: Create pull request
+        if: steps.check.outputs.has_updates == 'true' && github.event_name != 'pull_request'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -72,7 +69,7 @@ jobs:
             This PR was created by the weekly `deps-catalog-check` workflow.
 
             ### Scope
-            **Within-major bumps only.** Each dep moves to the newest version on its current compatibility line (same major for `^X.Y.Z`, same `0.x` line for `^0.Y.Z`, same minor for `~X.Y.Z`). Major-version bumps are handled by a separate draft PR (`chore/update-catalog-deps-majors`) that lands alongside this one when applicable.
+            **Within-major bumps only.** Each dep moves to the newest version on its current compatibility line (same major for `^X.Y.Z`, same `0.x` line for `^0.Y.Z`, same minor for `~X.Y.Z`). Major-version bumps are handled by a separate draft PR (`chore/update-catalog-deps-majors`) opened by the `deps-catalog-check-majors` workflow.
 
             ### What changed
             Updates to dependencies managed via `pnpm-workspace.yaml` catalog:
@@ -92,66 +89,4 @@ jobs:
           labels: |
             dependencies
           commit-message: "chore(deps): update catalog dependencies"
-          delete-branch: true
-
-      # ── Pass 2: cross-major bumps (manual review) ─────────────────────────
-      # Drafts a separate PR for major bumps so they're visible but obviously
-      # not auto-mergeable. Reset the working tree first so pass 2 sees the
-      # original committed workspace + lockfile, not pass 1's modifications.
-
-      - name: Reset working tree for major pass
-        run: git checkout HEAD -- pnpm-workspace.yaml pnpm-lock.yaml
-
-      - name: Check for major-version updates
-        id: check_major
-        run: |
-          set +e
-          ./.github/scripts/update-catalog-deps.sh --majors-only --dry-run
-          EXIT_CODE=$?
-          set -e
-          if [[ "$EXIT_CODE" -eq 2 ]]; then
-            echo "has_updates=false" >> $GITHUB_OUTPUT
-          elif [[ "$EXIT_CODE" -eq 0 ]]; then
-            echo "has_updates=true" >> $GITHUB_OUTPUT
-          else
-            echo "::error::Catalog dep check (majors-only) failed with exit code $EXIT_CODE"
-            exit 1
-          fi
-
-      - name: Apply major-version updates
-        if: steps.check_major.outputs.has_updates == 'true'
-        run: ./.github/scripts/update-catalog-deps.sh --majors-only
-
-      - name: Open major-version draft PR
-        if: steps.check_major.outputs.has_updates == 'true' && github.event_name != 'pull_request'
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: chore/update-catalog-deps-majors
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          draft: true
-          title: "chore(deps-major): catalog major-version bumps — REQUIRES MANUAL REVIEW"
-          body: |
-            ## ⚠️ Major-version catalog bumps — manual review required
-
-            This is a **draft** PR opened by the weekly `deps-catalog-check` workflow to surface available cross-major dependency bumps. Each one is presumed to contain breaking changes (see recent history: zod 3→4 renamed `ZodError.errors`, typescript 5→6 deprecated `baseUrl`, etc.).
-
-            ### How to handle this PR
-            1. Look at the diff to see which majors are now available.
-            2. **Cherry-pick** the major(s) you want to adopt into their own focused PR with the corresponding migration work, OR
-            3. Pull this branch locally and chip away at the migrations, then mark ready for review.
-            4. If you don't want a particular major right now, drop it from the workspace diff before merging.
-
-            CI on this PR is **expected to fail** until migration work is done. The script regenerated the lockfile with `--ignore-scripts` so the lockfile is internally consistent even though `tsc`/build steps would currently break.
-
-            ### Why this PR exists
-            The within-major auto-update PR (`chore/update-catalog-deps`) intentionally holds these back because they break the build. This draft PR exists so they don't get silently forgotten — but they need a human to drive the migration.
-
-            ### Workflow
-            This PR is re-pushed every Monday with the latest majors. Don't worry about it going stale; merge or close it on your own cadence.
-          labels: |
-            dependencies
-            DO NOT MERGE
-          commit-message: "chore(deps-major): catalog major-version bumps"
           delete-branch: true


### PR DESCRIPTION
### Summary

Stop the weekly catalog-check workflow from bumping past major-version boundaries (which has broken `main` four of the last five weeks via zod 3→4, typescript 5→6, `@types/node` 20→25, etc.). Within-major bumps continue to flow into the existing auto-PR; cross-major bumps now go to a separate draft PR labeled `DO NOT MERGE` so they stay visible without blocking the safe updates.

- Time to review: 8 minutes

### Changes proposed

- `.github/scripts/update-catalog-deps.sh`: bumps now stay within a dep's compatibility boundary by default — `^X.Y.Z` (X≥1) within major X, `^0.Y.Z` within the 0.x line, `~X.Y.Z` within minor X.Y. A new `--majors-only` flag inverts the filter to surface cross-boundary bumps. Majors-only install uses `--ignore-scripts` so the lockfile regenerates cleanly even when the workspace `prepare` step would fail under the major bump.
- `.github/workflows/deps-catalog-check.yml`: trimmed to the within-major pass. Continues to produce the existing ready-for-review PR on `chore/update-catalog-deps`.
- `.github/workflows/deps-catalog-check-majors.yml` (new): majors-only pass. Produces a **draft** PR on `chore/update-catalog-deps-majors` labeled `DO NOT MERGE` that surfaces available majors for human-led migration. Runs on its own runner, so a failure here can't block the within-major pass.

### Context for reviewers

**Why.** The scheduled catalog-check has failed 4 of the last 5 weekly runs. Each failure looked the same: the script bumped a dep to a new major (zod 3→4 renamed `ZodError.errors`, typescript 5→6 deprecated `baseUrl`, `@types/node` 20→25, etc.), the workspace `prepare` step then broke during `pnpm install`, and the workflow exited non-zero before reaching `peter-evans/create-pull-request`. Collateral damage: every safe within-major update that week (typespec minors, prettier patches, typescript-eslint patches) got dropped along with the broken major.

**New behavior.**

1. Within-major bumps flow through to the existing ready-for-review PR with no breaking-change risk.
2. Cross-major bumps go to a separate draft PR. CI on that PR is expected to fail until a human drives the migration — that failing CI is the signal it needs attention. Reviewers cherry-pick a single major into a focused migration PR, or pull the draft branch and chip through it. Closing the draft just defers the work — it re-appears on the next Monday's run with whatever majors are still pending.
3. Each Monday both branches force-update against `main` with the current state, so neither goes stale.

**Residual risk we're accepting.** `^0.Y.Z` minor bumps (typespec `^0.80.0 → ^0.81.0`) flow into the within-major PR. If a future typespec minor breaks the build, the within-major PR's CI fails visibly — same bounded outcome as the majors draft, no `main` impact. No past failures from this path. Not worth pre-emptive per-dep machinery.

**Verification.**

- Within-major dry-run identifies 11 in-range bumps; typescript ^5, zod ^3, eslint ^9, vitest ^3 correctly held.
- Within-major full-apply: `pnpm install` plus all four workspace `prepare` steps complete successfully.
- Majors-only dry-run identifies 9 cross-boundary candidates. Full-apply with `--ignore-scripts` regenerates the lockfile cleanly. Peer-dep warnings (e.g. eslint-plugin-vitest 0.5.4 vs eslint 10) correctly surface the work a reviewer will need to do.
- `pull_request` trigger smoke-tests the updated script end-to-end against itself in both workflow files (each lists the shared script in its `paths:` filter).