### PR TITLE
ci(deps): stop back-referencing the upstream pnpm-catalog bug in auto-PR bodies

### DIFF
--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -78,7 +78,7 @@ jobs:
             - Type definitions (`@types/node`)
 
             ### Why a separate workflow?
-            Dependabot's pnpm workspace-catalog support has known bugs that corrupt the lockfile. This workflow runs `pnpm update` + `pnpm install` to produce a clean, valid lockfile. See [`DEPENDENCY_MANAGEMENT.md`](./DEPENDENCY_MANAGEMENT.md) for the upstream bug references and full rationale.
+            Dependabot's pnpm workspace-catalog support has known bugs that corrupt the lockfile. This workflow runs `pnpm update` + `pnpm install` to produce a clean, valid lockfile. See [`DEPENDENCY_MANAGEMENT.md`](https://github.com/HHS/simpler-grants-protocol/blob/main/DEPENDENCY_MANAGEMENT.md) for the upstream bug references and full rationale.
 
             ### Reviewer checklist
             - [ ] CI passes (catalog validation runs all workspace package checks)

--- a/.github/workflows/deps-catalog-check.yml
+++ b/.github/workflows/deps-catalog-check.yml
@@ -78,7 +78,7 @@ jobs:
             - Type definitions (`@types/node`)
 
             ### Why a separate workflow?
-            Dependabot has [known bugs](https://github.com/dependabot/dependabot-core/issues/14339) with pnpm workspace catalogs that corrupt the lockfile. This workflow runs `pnpm update` + `pnpm install` to produce a clean, valid lockfile.
+            Dependabot's pnpm workspace-catalog support has known bugs that corrupt the lockfile. This workflow runs `pnpm update` + `pnpm install` to produce a clean, valid lockfile. See [`DEPENDENCY_MANAGEMENT.md`](./DEPENDENCY_MANAGEMENT.md) for the upstream bug references and full rationale.
 
             ### Reviewer checklist
             - [ ] CI passes (catalog validation runs all workspace package checks)


### PR DESCRIPTION
### Summary

- Time to review: 3 minutes

### Changes proposed

`.github/workflows/deps-catalog-check.yml`: replace the inline upstream-bug link in the auto-generated PR body with a same-repo link to `DEPENDENCY_MANAGEMENT.md`, which already documents the upstream bugs and the rationale.

### Context for reviewers

GitHub's cross-repo back-reference indexer fires on issue URLs and `owner/repo#NNN` shorthand in PR/issue **bodies and comments**. It does **not** fire on URLs that live in committed files (config comments, scripts, docs). The auto-PR body produced by the `Deps: Check Catalog Updates` workflow inlines an upstream issue URL, so every auto-PR creation adds a "mentioned in" entry on the upstream issue. Several of our PRs show up on that issue right now, and the recurring noise prompted this fix.

The reviewer-facing explanation ("why a separate workflow exists instead of Dependabot") still matters, so this routes readers to `DEPENDENCY_MANAGEMENT.md` — same-repo file links don't trigger cross-repo references. Comments inside `dependabot.yml`, `.github/scripts/update-catalog-deps.sh`, and `.github/scripts/validate-catalog-deps.sh` keep their inline references — those live in committed files the indexer doesn't crawl.

The sibling majors workflow (`deps-catalog-check-majors.yml`) doesn't link the upstream issue in its PR body, so nothing to change there.

#### Verified

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deps-catalog-check.yml'))"` parses clean
- Diff is one line in the PR-body string

### Additional information

Before / after of the PR body section:

**Before:**

> Dependabot has [known bugs](URL_REDACTED) with pnpm workspace catalogs that corrupt the lockfile. This workflow runs `pnpm update` + `pnpm install` to produce a clean, valid lockfile.

**After:**

> Dependabot's pnpm workspace-catalog support has known bugs that corrupt the lockfile. This workflow runs `pnpm update` + `pnpm install` to produce a clean, valid lockfile. See [`DEPENDENCY_MANAGEMENT.md`](./DEPENDENCY_MANAGEMENT.md) for the upstream bug references and full rationale.

(URLs in this PR description are deliberately redacted to avoid creating fresh cross-references on the upstream issue — that's the very thing this PR fixes.)