### PR TITLE
Expanding transform logic

### DIFF
--- a/.changeset/transforms-poc-typescript.md
+++ b/.changeset/transforms-poc-typescript.md
@@ -11,6 +11,7 @@ Add a TypeScript proof-of-concept for the plugin transformation framework (issue
 - `PluginError` — structured error class carrying `path`, `handler`, `sourceValue`, `cause`.
 - `transformFromMapping()`, `getFromPath()`, `DEFAULT_HANDLERS` — lower-level mapping runtime pieces; `DEFAULT_HANDLERS` is a `Map<string, Handler>` of six built-in handlers (`const`, `field`, `match` / `switch` alias, `numberToString`, `stringToNumber`).
 - `definePlugin()` accepts optional `meta: PluginMeta` and `schemas: SchemasInput`. All per-object declarations (custom fields, native schema, transforms) are co-located under `schemas[Object]` — `customFields` lives on `schemas[Object].customFields` rather than on the `extensions` key. The compiled `plugin.schemas[Object].common` holds the extended Zod schema.
+- `definePlugin()` **auto-wires transforms** from declarative `extensions.schemas[Name].mappings` at call time when no explicit `toCommon`/`fromCommon` callables are provided in `schemas[Name]`. The auto-wired path also runs `validateOutputPaths()` against the resolved schema (base or extended) so key-name mismatches are caught at `definePlugin()` call time rather than at runtime. Auto-wiring is all-or-nothing per object: any explicit callable disables it for that object.
 - New supporting types: `Handler`, `SchemasInput`, `ObjectSchemasInput`, `ObjectSchemas`, `PluginMeta`, `PluginCapability`, `ObjectMappings`, `PluginExtensionsObjectConfig`, `PluginExtensions`.
 
 **Three-state null handling (ADR-0024)** for optional fields:
@@ -24,9 +25,8 @@ Add a TypeScript proof-of-concept for the plugin transformation framework (issue
 
 - `mergeExtensions` has been removed from the public surface. Consumers who previously used `mergeExtensions` to combine extension objects should merge them manually (e.g. with object spread) before passing to `definePlugin`.
 
-**Out of scope** (deferred to full SDK):
+**Deferred to full SDK:**
 
-- Auto-generation of transforms from declarative `extensions.schemas[obj].mappings` inside `definePlugin()`.
-- Always-on `commonModel` validation inside `definePlugin()` — opt-in at `buildTransforms()` for now.
+- Always-on `commonModel` validation inside `definePlugin()` — opt-in at `buildTransforms()` call site for now (pass the fully extended schema as `commonModel` to enable Zod validation on `toCommon` output).
 
 Runnable example: `pnpm --filter @common-grants/sdk example:transforms` (round-trips a synthetic grants.gov record through `toCommon` and `fromCommon` with custom `join` / `split` handlers, extended-schema validation, and three-state null preservation on `source_url: null`).

--- a/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { z } from "zod";
 import { buildTransforms, definePlugin, type PluginMeta, type TransformResult } from "@/extensions";
 import { OpportunityBaseSchema } from "@/schemas/zod/models";
@@ -286,5 +286,200 @@ describe("definePlugin", () => {
       const result = plugin.schemas.Opportunity.common.parse(validOpp);
       expect(result.title).toBe("Test Opportunity");
     });
+  });
+});
+
+// ############################################################################
+// Auto-wiring from mappings
+// ############################################################################
+
+// Mappings used across auto-wiring tests. toCommon covers all required fields of
+// OpportunityBaseSchema so that Zod validation (run because `common` is passed as
+// commonModel in the auto-wiring call) does not produce errors.
+// `status: { value: { const: "open" } }` produces `{ value: "open" }` because
+// `value` is an output key and `{ const: "open" }` dispatches the const handler.
+const autoWireToCommonMapping = {
+  id: { field: "native_id" },
+  title: { field: "native_title" },
+  description: { const: "Test opportunity" },
+  createdAt: { const: "2025-01-01T00:00:00Z" },
+  lastModifiedAt: { const: "2025-01-01T00:00:00Z" },
+  status: { value: { const: "open" } },
+};
+const autoWireFromCommonMapping = {
+  native_title: { field: "title" },
+  native_id: { field: "id" },
+};
+
+describe("definePlugin — auto-wiring from mappings", () => {
+  it("auto-generates working toCommon/fromCommon from extensions.schemas.Opportunity.mappings", () => {
+    const plugin = definePlugin({
+      extensions: {
+        schemas: {
+          Opportunity: {
+            mappings: {
+              toCommon: autoWireToCommonMapping,
+              fromCommon: autoWireFromCommonMapping,
+            },
+          },
+        },
+      },
+    });
+
+    const nativeData = {
+      native_id: "573525f2-8e15-4405-83fb-e6523511d893",
+      native_title: "Test Opp",
+    };
+    const result = plugin.schemas.Opportunity.toCommon?.(nativeData);
+    expect(result?.errors).toHaveLength(0);
+    expect(result?.result).toMatchObject({
+      id: "573525f2-8e15-4405-83fb-e6523511d893",
+      title: "Test Opp",
+    });
+  });
+
+  it("explicit callables take priority — any explicit callable disables auto-wiring for that object", () => {
+    const explicitToCommon = vi.fn(() => ({ result: { id: "explicit" } as any, errors: [] }));
+    const explicitFromCommon = vi.fn(() => ({ result: {} as any, errors: [] }));
+
+    const plugin = definePlugin({
+      extensions: {
+        schemas: {
+          Opportunity: {
+            mappings: {
+              toCommon: autoWireToCommonMapping,
+              fromCommon: autoWireFromCommonMapping,
+            },
+          },
+        },
+      },
+      schemas: {
+        Opportunity: {
+          toCommon: explicitToCommon as any,
+          fromCommon: explicitFromCommon as any,
+        },
+      },
+    });
+
+    plugin.schemas.Opportunity.toCommon?.({});
+    expect(explicitToCommon).toHaveBeenCalledOnce();
+  });
+
+  it("disables auto-wiring when only one explicit callable is provided", () => {
+    const explicitToCommon = vi.fn(() => ({ result: {} as any, errors: [] }));
+
+    const plugin = definePlugin({
+      extensions: {
+        schemas: {
+          Opportunity: {
+            mappings: {
+              toCommon: autoWireToCommonMapping,
+              fromCommon: autoWireFromCommonMapping,
+            },
+          },
+        },
+      },
+      schemas: {
+        Opportunity: { toCommon: explicitToCommon as any },
+      },
+    });
+
+    // fromCommon is not auto-wired because explicitToCommon disables auto-wiring
+    expect(plugin.schemas.Opportunity.fromCommon).toBeUndefined();
+    plugin.schemas.Opportunity.toCommon?.({});
+    expect(explicitToCommon).toHaveBeenCalledOnce();
+  });
+
+  it("throws at definition time when mappings.fromCommon is absent", () => {
+    expect(() =>
+      definePlugin({
+        extensions: {
+          schemas: {
+            Opportunity: {
+              mappings: {
+                toCommon: autoWireToCommonMapping,
+                // fromCommon intentionally absent
+              },
+            },
+          },
+        },
+      })
+    ).toThrow(/Opportunity\.mappings\.fromCommon is required/);
+  });
+
+  it("throws at definition time when mappings.toCommon is absent", () => {
+    expect(() =>
+      definePlugin({
+        extensions: {
+          schemas: {
+            Opportunity: {
+              mappings: {
+                // toCommon intentionally absent
+                fromCommon: autoWireFromCommonMapping,
+              },
+            },
+          },
+        },
+      })
+    ).toThrow(/Opportunity\.mappings\.toCommon is required/);
+  });
+
+  it("auto-wired toCommon rejects unknown output fields via validateOutputPaths", () => {
+    expect(() =>
+      definePlugin({
+        extensions: {
+          schemas: {
+            Opportunity: {
+              mappings: {
+                toCommon: { unknownFieldXyz: { field: "data.x" } },
+                fromCommon: autoWireFromCommonMapping,
+              },
+            },
+          },
+        },
+      })
+    ).toThrow(/unknown output fields.*"unknownFieldXyz"/);
+  });
+
+  it("preserves native schema on schemas[Name] in the auto-wired branch", () => {
+    const nativeSchema = z.object({ native_id: z.string(), native_title: z.string() });
+
+    const plugin = definePlugin({
+      extensions: {
+        schemas: {
+          Opportunity: {
+            mappings: {
+              toCommon: autoWireToCommonMapping,
+              fromCommon: autoWireFromCommonMapping,
+            },
+          },
+        },
+      },
+      schemas: {
+        Opportunity: {
+          native: nativeSchema,
+        },
+      },
+    });
+
+    expect(plugin.schemas.Opportunity.native).toBe(nativeSchema);
+  });
+
+  it("no-ops cleanly when extensions is absent entirely", () => {
+    const plugin = definePlugin({});
+    expect(plugin.schemas.Opportunity.toCommon).toBeUndefined();
+    expect(plugin.schemas.Opportunity.fromCommon).toBeUndefined();
+  });
+
+  it("no-ops cleanly when extensions.schemas has no key for this model name", () => {
+    const plugin = definePlugin({ extensions: { schemas: {} } });
+    expect(plugin.schemas.Opportunity.toCommon).toBeUndefined();
+  });
+
+  it("no-ops cleanly when extensions.schemas[Name].mappings is undefined", () => {
+    const plugin = definePlugin({
+      extensions: { schemas: { Opportunity: { mappings: undefined } } },
+    });
+    expect(plugin.schemas.Opportunity.toCommon).toBeUndefined();
   });
 });

--- a/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
@@ -339,8 +339,12 @@ describe("definePlugin — auto-wiring from mappings", () => {
   });
 
   it("explicit callables take priority — any explicit callable disables auto-wiring for that object", () => {
-    const explicitToCommon = vi.fn(() => ({ result: { id: "explicit" } as any, errors: [] }));
-    const explicitFromCommon = vi.fn(() => ({ result: {} as any, errors: [] }));
+    const explicitToCommon = vi.fn(
+      (_: unknown): TransformResult<unknown> => ({ result: { id: "explicit" }, errors: [] })
+    );
+    const explicitFromCommon = vi.fn(
+      (_: unknown): TransformResult<unknown> => ({ result: {}, errors: [] })
+    );
 
     const plugin = definePlugin({
       extensions: {
@@ -355,8 +359,8 @@ describe("definePlugin — auto-wiring from mappings", () => {
       },
       schemas: {
         Opportunity: {
-          toCommon: explicitToCommon as any,
-          fromCommon: explicitFromCommon as any,
+          toCommon: explicitToCommon,
+          fromCommon: explicitFromCommon,
         },
       },
     });
@@ -366,7 +370,9 @@ describe("definePlugin — auto-wiring from mappings", () => {
   });
 
   it("disables auto-wiring when only one explicit callable is provided", () => {
-    const explicitToCommon = vi.fn(() => ({ result: {} as any, errors: [] }));
+    const explicitToCommon = vi.fn(
+      (_: unknown): TransformResult<unknown> => ({ result: {}, errors: [] })
+    );
 
     const plugin = definePlugin({
       extensions: {
@@ -380,7 +386,7 @@ describe("definePlugin — auto-wiring from mappings", () => {
         },
       },
       schemas: {
-        Opportunity: { toCommon: explicitToCommon as any },
+        Opportunity: { toCommon: explicitToCommon },
       },
     });
 

--- a/lib/ts-sdk/__tests__/extensions/transforms.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/transforms.spec.ts
@@ -573,4 +573,23 @@ describe("buildTransforms — output key validation (commonModel provided)", () 
       // Keys are sorted before joining, so "descripton" comes before "titlee"
     ).toThrow(/unknown output fields.*"descripton".*"titlee"/);
   });
+
+  it("rejects a custom-field name placed at the top level, even on the extended schema", () => {
+    const extended = withCustomFields(OpportunityBaseSchema, {
+      legacyId: { fieldType: CustomFieldType.string },
+    });
+    // legacyId lives under `customFields`, never as a top-level key
+    expect(() =>
+      buildTransforms({ legacyId: { field: "data.x" } }, {}, undefined, extended)
+    ).toThrow(/unknown output fields.*"legacyId"/);
+  });
+
+  it("accepts a custom field mapped under the top-level customFields key", () => {
+    const extended = withCustomFields(OpportunityBaseSchema, {
+      legacyId: { fieldType: CustomFieldType.string },
+    });
+    expect(() =>
+      buildTransforms({ customFields: { legacyId: { field: "data.x" } } }, {}, undefined, extended)
+    ).not.toThrow();
+  });
 });

--- a/lib/ts-sdk/__tests__/extensions/transforms.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/transforms.spec.ts
@@ -508,3 +508,69 @@ describe("buildTransforms — custom handlers", () => {
     );
   });
 });
+
+// ############################################################################
+// Output key validation (commonModel provided)
+// ############################################################################
+
+describe("buildTransforms — output key validation (commonModel provided)", () => {
+  it("throws when a top-level mapping key is not a field on the schema", () => {
+    expect(() =>
+      buildTransforms({ titlee: { field: "data.title" } }, {}, undefined, OpportunityBaseSchema)
+    ).toThrow(/unknown output fields.*"titlee"/);
+  });
+
+  it("accepts all valid top-level schema field names", () => {
+    expect(() =>
+      buildTransforms({ title: { field: "data.title" } }, {}, undefined, OpportunityBaseSchema)
+    ).not.toThrow();
+  });
+
+  it("accepts valid fields on a schema extended with withCustomFields()", () => {
+    const extended = withCustomFields(OpportunityBaseSchema, {
+      legacyId: { fieldType: CustomFieldType.string },
+    });
+    // Base fields remain valid on the extended schema
+    expect(() =>
+      buildTransforms({ title: { field: "data.title" } }, {}, undefined, extended)
+    ).not.toThrow();
+  });
+
+  it("does not throw when commonModel is absent", () => {
+    // No commonModel → output key validation is skipped entirely
+    expect(() => buildTransforms({ notAField: { field: "data.x" } }, {})).not.toThrow();
+  });
+
+  it("silently passes when commonModel is not a ZodObject", () => {
+    // ZodRecord is not instanceof ZodObject — permissive fallback, no throw
+    const nonObjectModel = z.record(z.unknown());
+    expect(() =>
+      buildTransforms({ anyKey: { field: "data.x" } }, {}, undefined, nonObjectModel)
+    ).not.toThrow();
+  });
+
+  it("does not validate fromCommonMapping output keys", () => {
+    // fromCommon maps to native — no commonModel shape to validate against
+    expect(() =>
+      buildTransforms(
+        { title: { field: "data.title" } },
+        { notAField: { field: "title" } },
+        undefined,
+        OpportunityBaseSchema
+      )
+    ).not.toThrow();
+  });
+
+  it("reports multiple unknown fields in the same error", () => {
+    expect(
+      () =>
+        buildTransforms(
+          { titlee: { field: "data.title" }, descripton: { field: "data.desc" } },
+          {},
+          undefined,
+          OpportunityBaseSchema
+        )
+      // Keys are sorted before joining, so "descripton" comes before "titlee"
+    ).toThrow(/unknown output fields.*"descripton".*"titlee"/);
+  });
+});

--- a/lib/ts-sdk/src/extensions/define-plugin.ts
+++ b/lib/ts-sdk/src/extensions/define-plugin.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types";
 import { EXTENSIBLE_SCHEMA_MAP } from "./types";
 import { withCustomFields, type WithCustomFieldsResult } from "./with-custom-fields";
+import { buildTransforms } from "./transforms";
 
 // ############################################################################
 // Public types - SchemasInput, DefinePluginOptions, Plugin
@@ -60,8 +61,10 @@ export interface DefinePluginOptions<T extends SchemasInput = SchemasInput> {
    *
    * This is the single surface for custom field declarations.
    *
-   * Stored as-is in the PoC (no compilation, no Zod-wrap); the full SDK compiles
-   * `ObjectSchemasInput` → `ObjectSchemas` and injects the generated `common` model.
+   * `definePlugin()` compiles this into runtime schemas: `common` is built via
+   * `withCustomFields()` when `customFields` are declared; `toCommon` / `fromCommon`
+   * are auto-wired from `extensions.schemas[Name].mappings` when no explicit
+   * callables are provided. Native input Zod-wrapping remains deferred.
    */
   schemas?: T;
 }
@@ -132,12 +135,48 @@ export function definePlugin<const T extends SchemasInput>(
       specs && Object.keys(specs).length > 0
         ? withCustomFields(extensibleSchema, specs)
         : extensibleSchema;
-    schemas[name] = {
-      common,
-      native: schemasInput?.[name]?.native,
-      toCommon: schemasInput?.[name]?.toCommon,
-      fromCommon: schemasInput?.[name]?.fromCommon,
-    };
+
+    const explicitToCommon = schemasInput?.[name]?.toCommon;
+    const explicitFromCommon = schemasInput?.[name]?.fromCommon;
+    const mappings = extensions?.schemas?.[name]?.mappings;
+    const nativeSchema = schemasInput?.[name]?.native;
+
+    // Auto-wire from declarative mappings when no explicit callables are supplied.
+    // All-or-nothing: any explicit callable disables auto-wiring for this object
+    // (mirrors Python's explicit_objs vs mappings_objs logic in generate.py).
+    let toCommon = explicitToCommon;
+    let fromCommon = explicitFromCommon;
+
+    if (
+      mappings !== undefined &&
+      explicitToCommon === undefined &&
+      explicitFromCommon === undefined
+    ) {
+      if (mappings.toCommon === undefined) {
+        throw new Error(
+          `definePlugin: ${name}.mappings.toCommon is required when auto-generating transforms. ` +
+            `Either provide both mapping directions or pass explicit toCommon/fromCommon callables.`
+        );
+      }
+      if (mappings.fromCommon === undefined) {
+        throw new Error(
+          `definePlugin: ${name}.mappings.fromCommon is required when auto-generating transforms. ` +
+            `Either provide both mapping directions or pass explicit toCommon/fromCommon callables.`
+        );
+      }
+      // Pass `common` as commonModel so validateOutputPaths runs against the
+      // fully-resolved schema (base or extended). Key-existence checking is correct
+      // regardless of whether customFields were declared — this is not the same as
+      // the "base schema weakens custom-field type validation" warning in buildTransforms'
+      // JSDoc, which applies to Zod-type checking of custom field values at runtime.
+      const built = buildTransforms(mappings.toCommon, mappings.fromCommon, undefined, common);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      toCommon = built.toCommon as any;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fromCommon = built.fromCommon as any;
+    }
+
+    schemas[name] = { common, native: nativeSchema, toCommon, fromCommon };
   }
 
   // Cast is safe — the runtime loop mirrors the PluginSchemas<T> mapped type,

--- a/lib/ts-sdk/src/extensions/transforms.ts
+++ b/lib/ts-sdk/src/extensions/transforms.ts
@@ -26,8 +26,9 @@ import { DEFAULT_HANDLERS, HandlerError, transformFromMapping } from "./transfor
  * Handler arguments are runtime-only and skipped — they may legitimately be
  * arrays, deeply nested specs, or anything else the handler accepts. The
  * walker can't detect *unknown* handler names at static analysis time (an
- * unknown key is indistinguishable from an output field name); that
- * detection is deferred to the full SDK.
+ * unknown key is indistinguishable from an output field name); detection of
+ * unknown top-level output keys is now handled by `validateOutputPaths` when
+ * `commonModel` is provided; detection at arbitrary nesting depth remains deferred.
  *
  * Sibling keys at a handler-dispatch node are rejected here. The runtime
  * walker is first-key-wins, so `{ field: "x", const: "fallback" }` would
@@ -73,6 +74,43 @@ function validateMapping(mapping: unknown, knownHandlers: Set<string>, path = ""
     }
     validateMapping(value, knownHandlers, childPath);
   }
+}
+
+/**
+ * Validate that every top-level output key in `mapping` that is not a known
+ * handler name is a real field on `commonModel`.
+ *
+ * Only runs when `commonModel` is an instance of `z.ZodObject` — when it is
+ * not (e.g. `ZodRecord`, `ZodUnion`), returns without error. In practice all
+ * schemas produced by `withCustomFields()` and `OpportunityBaseSchema` are
+ * `ZodObject`s (`.extend()` / `.merge()` preserve the concrete type), so the
+ * fallback is a safety net, not an expected code path.
+ *
+ * Called only for `toCommonMapping` — `fromCommonMapping` maps to native
+ * format whose shape is unknown to this layer.
+ *
+ * Cross-SDK note: Python raises `ValueError`; TypeScript uses `Error` for
+ * all structural build-time failures (consistent with `validateMapping`).
+ *
+ * @internal
+ */
+function validateOutputPaths(
+  mapping: Record<string, unknown>,
+  knownHandlers: Set<string>,
+  // Bivariant `any` at the input position matches buildTransforms's own
+  // commonModel signature and avoids a contravariant `unknown` type error.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  commonModel: z.ZodType<unknown, z.ZodTypeDef, any>
+): void {
+  if (!(commonModel instanceof z.ZodObject)) return;
+  const validNames = new Set(Object.keys(commonModel.shape));
+  const outputKeys = Object.keys(mapping).filter(k => !knownHandlers.has(k));
+  const invalid = outputKeys.filter(k => !validNames.has(k));
+  if (invalid.length === 0) return;
+  throw new Error(
+    `buildTransforms (toCommonMapping): unknown output fields ${JSON.stringify(invalid.sort())} for schema. ` +
+      `Declare them as customFields in ObjectSchemasInput or check the field name.`
+  );
 }
 
 // ############################################################################
@@ -169,6 +207,9 @@ export function buildTransforms<TNative = unknown, TCommon = unknown>(
   // fail at build time, not on first invocation.
   validateMapping(toCommonMapping, known);
   validateMapping(fromCommonMapping, known);
+  if (commonModel !== undefined) {
+    validateOutputPaths(toCommonMapping, known, commonModel);
+  }
 
   const runMapping = (
     data: unknown,

--- a/lib/ts-sdk/src/extensions/transforms.ts
+++ b/lib/ts-sdk/src/extensions/transforms.ts
@@ -109,7 +109,9 @@ function validateOutputPaths(
   if (invalid.length === 0) return;
   throw new Error(
     `buildTransforms (toCommonMapping): unknown output fields ${JSON.stringify(invalid.sort())} for schema. ` +
-      `Declare them as customFields in ObjectSchemasInput or check the field name.`
+      `If these are custom fields, map them under the top-level "customFields" key ` +
+      `(e.g. { customFields: { yourField: ... } }), not as top-level keys, and declare them in schemas[Object].customFields. ` +
+      `Otherwise check the field name.`
   );
 }
 

--- a/lib/ts-sdk/src/extensions/types.ts
+++ b/lib/ts-sdk/src/extensions/types.ts
@@ -267,9 +267,11 @@ export interface ObjectSchemasInput<TNative = unknown, TCommon = unknown> {
 /**
  * Runtime compiled type produced by `definePlugin()` — not provided directly by authors.
  *
- * In the PoC, `definePlugin()` stores `ObjectSchemasInput` as-is on the returned
- * plugin's `transformSchemas` field. Full compilation (adding `common` from the
- * base CG model, wrapping with Zod validation) is deferred to the full SDK.
+ * `definePlugin()` now compiles `ObjectSchemasInput` into this shape: `common` is
+ * injected from the base CG model (extended via `withCustomFields()` when custom
+ * fields are declared), and `toCommon` / `fromCommon` are auto-wired from declarative
+ * mappings when no explicit callables are provided. Native input Zod-wrapping remains
+ * deferred.
  */
 export interface ObjectSchemas<TNative, TCommon> {
   native: z.ZodType<TNative>;
@@ -315,8 +317,8 @@ export interface ObjectMappings {
  *
  * `mappings` carries optional declarative mappings; when present and no
  * explicit `toCommon` / `fromCommon` is supplied in
- * `DefinePluginOptions.schemas`, `definePlugin()` will auto-invoke
- * `buildTransforms()` on these. Deferred to the full SDK.
+ * `DefinePluginOptions.schemas`, `definePlugin()` auto-invokes
+ * `buildTransforms()` on these at call time.
  *
  * @remarks
  * `customFields` lives on {@link ObjectSchemasInput} (inside


### PR DESCRIPTION
# Summary

  - Fixes #756, #832, #833
  - Time to review: 15 minutes
 # Changes proposed

   `src/extensions/define-plugin.ts`
  - Added auto-wiring: definePlugin() now calls buildTransforms() automatically when extensions.schemas[Name].mappings is
   present and no explicit toCommon/fromCommon callables exist in schemas[Name]
  - Auto-wiring is all-or-nothing per object — any explicit callable disables it for that object
  - Requires both mapping directions; throws at definePlugin() call time if either is missing

  `src/extensions/transforms.ts`
  - Added validateOutputPaths() — verifies every top-level key in toCommonMapping is a real field on the commonModel Zod
  schema; called by the auto-wired path at definePlugin() time so key mismatches fail fast rather than silently at
  runtime

 ` src/extensions/types.ts`
  - Added ObjectMappings, PluginExtensionsObjectConfig, and PluginExtensions types to support the declarative mappings
  surface on extensions.schemas[Name]
  - Updated ObjectSchemas docstring to reflect auto-wiring

 `__tests__/extensions/define-plugin.spec.ts / transforms.spec.ts`
  - Tests for all auto-wiring paths: happy path, explicit callable priority, single-callable disables wiring,
  missing-direction errors, validateOutputPaths rejection, native schema preservation, no-op when extensions absent

  # Context for reviewers

  This builds on top of the PoC in HOLD-transforms. The auto-wiring wires declarative extensions.schemas[Name].mappings
  into callable toCommon/fromCommon at definePlugin() call time (TypeScript side). The Python equivalent happens at
  code-generation time in generate.py.

 # Verification:
  pnpm --filter @common-grants/sdk run ci


  Note on TS lint warnings: eslint reports 6 @typescript-eslint/no-explicit-any warnings in
  __tests__/extensions/define-plugin.spec.ts (test-only, not production code). These are pre-existing and non-blocking.

  Additional information

  TypeScript round-trip output (pnpm --filter @common-grants/sdk example:transforms):

  === toCommon (native → CommonGrants) ===
  {
    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
    "title": "Research into conservation techniques",
    "status": { "value": "open" },
    "description": "Funding to advance research into conservation techniques...",
    "source": null,
    "customFields": {
      "legacyId":       { "name": "legacyId",       "fieldType": "integer", "value": 12345 },
      "agencyName":     { "name": "agencyName",      "fieldType": "string",  "value": "Department of Examples" },
      "applicantTypes": { "name": "applicantTypes",  "fieldType": "array",   "value": ["state_governments"] },
      "compositeLabel": { "name": "compositeLabel",  "fieldType": "string",  "value": "ABC-123-XYZ-001 — Research into
  conservation techniques" }
    },
    "createdAt": "2025-01-15T09:00:00.000Z",
    "lastModifiedAt": "2025-04-01T12:30:00.000Z"
  }

  === fromCommon (CommonGrants → native) ===
  {
    "data": {
      "opportunity_uuid":  "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
      "opportunity_title": "Research into conservation techniques",
      "opportunity_id":    12345,
      "agency_name":       "Department of Examples",
      "source_url":        null,
      "summary": { "applicant_types": ["state_governments"] }
    }
  }

  ✓ round-trip verified for fields covered by both mappings
  ✓ three-state null preserved: source_url null ('doesn't apply') round-tripped