### PR TITLE
Custom filters Python PoC (#869)

### DIFF
--- a/lib/python-sdk/common_grants_sdk/extensions/__init__.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/__init__.py
@@ -1,6 +1,6 @@
 """Public extension APIs for the CommonGrants Python SDK."""
 
-from .filters import classify_filters, f, validate_routes
+from .filters import classify_filters, f, validate_filter_call, validate_routes
 from .plugin import Plugin, PluginConfig, define_plugin, inject_transforms
 from .specs import (
     ConflictStrategy,
@@ -54,5 +54,6 @@ __all__ = [
     "CustomFilterType",
     "f",
     "PluginRoutes",
+    "validate_filter_call",
     "validate_routes",
 ]

--- a/lib/python-sdk/common_grants_sdk/extensions/__init__.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/__init__.py
@@ -48,7 +48,7 @@ __all__ = [
     "PluginExtensionsMeta",
     "PluginExtensionsSchema",
     "TransformResult",
-    # New: custom filters (plan 03)
+    # Custom filters
     "classify_filters",
     "CustomFilterSpec",
     "CustomFilterType",

--- a/lib/python-sdk/common_grants_sdk/extensions/__init__.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/__init__.py
@@ -1,7 +1,15 @@
 """Public extension APIs for the CommonGrants Python SDK."""
 
+from .filters import classify_filters, f, validate_routes
 from .plugin import Plugin, PluginConfig, define_plugin, inject_transforms
-from .specs import ConflictStrategy, CustomFieldSpec, SchemaExtensions, merge_extensions
+from .specs import (
+    ConflictStrategy,
+    CustomFieldSpec,
+    CustomFilterSpec,
+    CustomFilterType,
+    SchemaExtensions,
+    merge_extensions,
+)
 from .transforms import build_transforms
 from .types import (
     Handler,
@@ -13,6 +21,7 @@ from .types import (
     PluginExtensions,
     PluginExtensionsMeta,
     PluginExtensionsSchema,
+    PluginRoutes,
     TransformResult,
 )
 
@@ -39,4 +48,11 @@ __all__ = [
     "PluginExtensionsMeta",
     "PluginExtensionsSchema",
     "TransformResult",
+    # New: custom filters (plan 03)
+    "classify_filters",
+    "CustomFilterSpec",
+    "CustomFilterType",
+    "f",
+    "PluginRoutes",
+    "validate_routes",
 ]

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -38,6 +38,7 @@ from common_grants_sdk.schemas.pydantic.filters.money import (
     MoneyRangeFilter,
 )
 from common_grants_sdk.schemas.pydantic.filters.numeric import (
+    IntegerComparisonFilter,
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRangeFilter,
@@ -135,17 +136,16 @@ f = _FHelpers()
 # ---------------------------------------------------------------------------
 
 #: Maps each CustomFilterType to the Pydantic model used to validate operator/value shape.
-#: ``integerComparison`` reuses ``NumberComparisonFilter`` — a dedicated integer schema
-#: with int-only validation is deferred (mirrors the TS SDK, where
-#: ``integerComparison`` reuses ``NumberComparisonFilterSchema``).
-#: ``booleanComparison`` uses the SDK-level ``BooleanComparisonFilter``.
+#: ``integerComparison`` and ``booleanComparison`` use the SDK-level
+#: ``IntegerComparisonFilter`` / ``BooleanComparisonFilter`` models (parallel to the
+#: TS SDK's ``IntegerComparisonFilterSchema`` / ``BooleanComparisonFilterSchema``).
 FILTER_TYPE_SCHEMAS: dict[CustomFilterType, type[BaseModel]] = {
     CustomFilterType.STRING_COMPARISON: StringComparisonFilter,
     CustomFilterType.STRING_ARRAY: StringArrayFilter,
     CustomFilterType.NUMBER_COMPARISON: NumberComparisonFilter,
     CustomFilterType.NUMBER_ARRAY: NumberArrayFilter,
     CustomFilterType.NUMBER_RANGE: NumberRangeFilter,
-    CustomFilterType.INTEGER_COMPARISON: NumberComparisonFilter,  # reuse — see note above
+    CustomFilterType.INTEGER_COMPARISON: IntegerComparisonFilter,
     CustomFilterType.BOOLEAN_COMPARISON: BooleanComparisonFilter,
     CustomFilterType.DATE_COMPARISON: DateComparisonFilter,
     CustomFilterType.DATE_RANGE: DateRangeFilter,

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -17,6 +17,8 @@ SDK's ``as const`` literal narrowing).
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from types import MappingProxyType
 from typing import Any, Optional
 
 from pydantic import BaseModel, ValidationError
@@ -140,19 +142,23 @@ f = _FHelpers()
 #: ``integerComparison`` and ``booleanComparison`` use the SDK-level
 #: ``IntegerComparisonFilter`` / ``BooleanComparisonFilter`` models (parallel to the
 #: TS SDK's ``IntegerComparisonFilterSchema`` / ``BooleanComparisonFilterSchema``).
-FILTER_TYPE_SCHEMAS: dict[CustomFilterType, type[BaseModel]] = {
-    CustomFilterType.STRING_COMPARISON: StringComparisonFilter,
-    CustomFilterType.STRING_ARRAY: StringArrayFilter,
-    CustomFilterType.NUMBER_COMPARISON: NumberComparisonFilter,
-    CustomFilterType.NUMBER_ARRAY: NumberArrayFilter,
-    CustomFilterType.NUMBER_RANGE: NumberRangeFilter,
-    CustomFilterType.INTEGER_COMPARISON: IntegerComparisonFilter,
-    CustomFilterType.BOOLEAN_COMPARISON: BooleanComparisonFilter,
-    CustomFilterType.DATE_COMPARISON: DateComparisonFilter,
-    CustomFilterType.DATE_RANGE: DateRangeFilter,
-    CustomFilterType.MONEY_COMPARISON: MoneyComparisonFilter,
-    CustomFilterType.MONEY_RANGE: MoneyRangeFilter,
-}
+#: Read-only: the catalog is closed — registering new filter types is a spec/SDK
+#: change (extend CustomFilterType + this map together), not a runtime extension point.
+FILTER_TYPE_SCHEMAS: Mapping[CustomFilterType, type[BaseModel]] = MappingProxyType(
+    {
+        CustomFilterType.STRING_COMPARISON: StringComparisonFilter,
+        CustomFilterType.STRING_ARRAY: StringArrayFilter,
+        CustomFilterType.NUMBER_COMPARISON: NumberComparisonFilter,
+        CustomFilterType.NUMBER_ARRAY: NumberArrayFilter,
+        CustomFilterType.NUMBER_RANGE: NumberRangeFilter,
+        CustomFilterType.INTEGER_COMPARISON: IntegerComparisonFilter,
+        CustomFilterType.BOOLEAN_COMPARISON: BooleanComparisonFilter,
+        CustomFilterType.DATE_COMPARISON: DateComparisonFilter,
+        CustomFilterType.DATE_RANGE: DateRangeFilter,
+        CustomFilterType.MONEY_COMPARISON: MoneyComparisonFilter,
+        CustomFilterType.MONEY_RANGE: MoneyRangeFilter,
+    }
+)
 
 # ---------------------------------------------------------------------------
 # DEFAULT_FILTER_NAMES — must include BOTH snake_case field names AND camelCase aliases
@@ -334,7 +340,7 @@ def classify_filters(
     routes: PluginRoutes,
     resource: str,
     method: str,
-    consumer_filters: dict[str, Any],
+    consumer_filters: Mapping[str, DefaultFilter | dict[str, Any]],
 ) -> OppFilters:
     """Classify consumer filter dict into the ADR-0012 OppFilters request body.
 
@@ -366,7 +372,8 @@ def classify_filters(
         routes: Plugin route declarations (used to identify registered custom filters).
         resource: Resource name (e.g. ``"opportunities"``).
         method: Method name (e.g. ``"search"``).
-        consumer_filters: Flat ``{name: DefaultFilter}`` dict from the consumer call site.
+        consumer_filters: Flat ``{name: DefaultFilter}`` mapping from the consumer
+            call site (raw ``{"operator": ..., "value": ...}`` dicts also accepted).
 
     Returns:
         ``OppFilters`` request body.  Call

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -235,6 +235,18 @@ def validate_routes(routes: PluginRoutes) -> None:
                     )
 
 
+def _first_error_detail(exc: ValidationError) -> str:
+    """One-line summary of the first pydantic error, for PluginError messages.
+
+    The full ValidationError stays on ``cause`` for programmatic access; this
+    puts the most useful line in ``str(exc)`` so a logged message says what
+    failed, not just how many things did.
+    """
+    first = exc.errors()[0]
+    loc = ".".join(str(part) for part in first["loc"]) or "<root>"
+    return f"{first['msg']} (at {loc})"
+
+
 # ---------------------------------------------------------------------------
 # validate_filter_call — call-time validator
 # ---------------------------------------------------------------------------
@@ -290,7 +302,8 @@ def validate_filter_call(
             validated = model_cls.model_validate(payload)
         except ValidationError as exc:
             raise PluginError(
-                f'Filter "{filter_name}" failed validation: {exc.error_count()} error(s)',
+                f'Filter "{filter_name}" failed validation: '
+                f"{exc.error_count()} error(s); first: {_first_error_detail(exc)}",
                 path=f"filters.{filter_name}",
                 source_value=value,
                 cause=exc,
@@ -305,7 +318,7 @@ def validate_filter_call(
     except ValidationError as exc:
         raise PluginError(
             f'Ad-hoc filter "{filter_name}" has an invalid DefaultFilter shape: '
-            f"{exc.error_count()} error(s)",
+            f"{exc.error_count()} error(s); first: {_first_error_detail(exc)}",
             path=f"filters.{filter_name}",
             source_value=value,
             cause=exc,
@@ -421,22 +434,13 @@ def classify_filters(
     except ValidationError as exc:
         # Name the failing field(s) so bucket-1 errors are as pinpointed as the
         # filters.<name> paths raised for buckets 2/3. The loc values are the
-        # alias keys used at construction (e.g. "closeDateRange"); a loc nested
-        # under "customFilters" names the custom filter itself, not the wrapper.
-        failed = sorted(
-            {
-                (
-                    str(err["loc"][1])
-                    if len(err["loc"]) > 1 and err["loc"][0] == "customFilters"
-                    else str(err["loc"][0])
-                )
-                for err in exc.errors()
-                if err.get("loc")
-            }
-        )
+        # alias keys used at construction (e.g. "closeDateRange"); customFilters
+        # values were already validated above, so only default fields fail here.
+        failed = sorted({str(err["loc"][0]) for err in exc.errors() if err.get("loc")})
         field_list = ", ".join(failed) if failed else "<unknown>"
         raise PluginError(
-            f"Filter(s) {field_list} failed validation: {exc.error_count()} error(s)",
+            f"Filter(s) {field_list} failed validation: "
+            f"{exc.error_count()} error(s); first: {_first_error_detail(exc)}",
             path=f"filters.{failed[0]}" if len(failed) == 1 else "filters",
             source_value=default_fields,
             cause=exc,

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -275,7 +275,7 @@ def validate_filter_call(
         except ValidationError as exc:
             raise PluginError(
                 f'Filter "{filter_name}" failed validation: {exc.error_count()} error(s)',
-                path=filter_name,
+                path=f"filters.{filter_name}",
                 source_value=value,
                 cause=exc,
             ) from exc
@@ -289,7 +289,7 @@ def validate_filter_call(
         except ValidationError as exc:
             raise PluginError(
                 f'Ad-hoc filter "{filter_name}" has an invalid DefaultFilter shape: {exc}',
-                path=filter_name,
+                path=f"filters.{filter_name}",
                 source_value=value,
                 cause=exc,
             ) from exc
@@ -332,8 +332,11 @@ def classify_filters(
         consumer_filters: Flat ``{name: DefaultFilter}`` dict from the consumer call site.
 
     Returns:
-        ``OppFilters`` request body.  Call ``.model_dump(by_alias=True, exclude_none=True)``
-        for the JSON body of the ADR-0012 search request.
+        ``OppFilters`` request body.  Call
+        ``.model_dump(by_alias=True, exclude_none=True, mode="json")`` for the JSON
+        body of the ADR-0012 search request — ``mode="json"`` is required because
+        coerced ``date`` objects and operator enums are not JSON-serializable in
+        the default python mode.
 
     Raises:
         PluginError: When any filter value fails validation — registered and ad-hoc
@@ -386,9 +389,15 @@ def classify_filters(
             customFilters=custom_buckets if custom_buckets else None,
         )
     except ValidationError as exc:
+        # Name the failing field(s) so bucket-1 errors are as pinpointed as the
+        # filters.<name> paths raised for buckets 2/3. The loc values are the
+        # alias keys used at construction (e.g. "closeDateRange").
+        failed = sorted({str(err["loc"][0]) for err in exc.errors() if err.get("loc")})
+        field_list = ", ".join(failed) if failed else "<unknown>"
         raise PluginError(
-            f"Default filter failed validation: {exc.error_count()} error(s)",
-            path=f"routes.{resource}.{method}",
+            f"Default filter(s) {field_list} failed validation: "
+            f"{exc.error_count()} error(s)",
+            path=f"filters.{failed[0]}" if len(failed) == 1 else "filters",
             source_value=default_fields,
             cause=exc,
         ) from exc

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -9,8 +9,9 @@ Provides:
 - ``classify_filters(routes, resource, method, consumer_filters)`` — three-bucket ADR-0012
   classifier that returns an OppFilters wire body.
 
-No generate.py / codegen dependency (DP-05). Correctness is enforced at runtime by Pydantic v2
-(DP-02/DP-04); there is no compile-time key/value narrowing claim.
+No generate.py / codegen dependency. Correctness is enforced at runtime by Pydantic v2;
+there is no compile-time key/value narrowing claim (Python has no equivalent of the TS
+SDK's ``as const`` literal narrowing).
 """
 
 from __future__ import annotations
@@ -54,7 +55,7 @@ from .specs import CustomFilterSpec, CustomFilterType
 from .types import PluginError, PluginRoutes
 
 # ---------------------------------------------------------------------------
-# f.* helpers (CFP-03, DP-10)
+# f.* helpers
 # ---------------------------------------------------------------------------
 
 
@@ -64,7 +65,7 @@ class _FHelpers:
     Import as ``from common_grants_sdk.extensions import f`` and use as
     ``f.eq("open")``, ``f.in_([...])``, etc.
 
-    ``in_`` and ``not_in`` use the reserved-word workaround (DP-10):
+    ``in_`` and ``not_in`` use the reserved-word workaround:
     the Python methods are ``f.in_`` / ``f.not_in`` while the wire operator
     values are ``"in"`` / ``"notIn"`` (matching the TS SDK's ``F.in`` / ``F.notIn``).
     """
@@ -130,19 +131,21 @@ class _FHelpers:
 f = _FHelpers()
 
 # ---------------------------------------------------------------------------
-# FILTER_TYPE_SCHEMAS — call-time validation map (CFP-04)
+# FILTER_TYPE_SCHEMAS — call-time validation map
 # ---------------------------------------------------------------------------
 
 #: Maps each CustomFilterType to the Pydantic model used to validate operator/value shape.
-#: ``integerComparison`` reuses ``NumberComparisonFilter`` (CFPV-03 deferred).
-#: ``booleanComparison`` uses the new ``BooleanComparisonFilter`` from plan 01.
+#: ``integerComparison`` reuses ``NumberComparisonFilter`` — a dedicated integer schema
+#: with int-only validation is deferred (mirrors the TS SDK, where
+#: ``integerComparison`` reuses ``NumberComparisonFilterSchema``).
+#: ``booleanComparison`` uses the SDK-level ``BooleanComparisonFilter``.
 FILTER_TYPE_SCHEMAS: dict[CustomFilterType, type[BaseModel]] = {
     CustomFilterType.STRING_COMPARISON: StringComparisonFilter,
     CustomFilterType.STRING_ARRAY: StringArrayFilter,
     CustomFilterType.NUMBER_COMPARISON: NumberComparisonFilter,
     CustomFilterType.NUMBER_ARRAY: NumberArrayFilter,
     CustomFilterType.NUMBER_RANGE: NumberRangeFilter,
-    CustomFilterType.INTEGER_COMPARISON: NumberComparisonFilter,  # CFPV-03: reuse
+    CustomFilterType.INTEGER_COMPARISON: NumberComparisonFilter,  # reuse — see note above
     CustomFilterType.BOOLEAN_COMPARISON: BooleanComparisonFilter,
     CustomFilterType.DATE_COMPARISON: DateComparisonFilter,
     CustomFilterType.DATE_RANGE: DateRangeFilter,
@@ -152,28 +155,26 @@ FILTER_TYPE_SCHEMAS: dict[CustomFilterType, type[BaseModel]] = {
 
 # ---------------------------------------------------------------------------
 # DEFAULT_FILTER_NAMES — must include BOTH snake_case field names AND camelCase aliases
-# (RESEARCH Pitfall 1 / DP-15: the "landmine" for camelCase alias lookup)
 # ---------------------------------------------------------------------------
 
 #: All core default-filter names from OppDefaultFilters: snake_case field names PLUS their
 #: camelCase ``alias`` values.  Both forms are needed so that ``validate_routes`` can catch
-#: a plugin author registering a custom filter whose name shadows either form (DP-15).
+#: a plugin author registering a custom filter whose name shadows either form.
 DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
     list(OppDefaultFilters.model_fields.keys())
     + [v.alias for v in OppDefaultFilters.model_fields.values() if v.alias]
 )
 
 # ---------------------------------------------------------------------------
-# Strategy A: normalization maps for classify_filters
-# (RESEARCH A4 / Pitfall 6 — PINNED as the required construction path)
+# Alias-normalization maps for classify_filters
 #
 # OppDefaultFilters uses snake_case field names with camelCase aliases but does NOT
 # set populate_by_name=True.  Pydantic v2 therefore requires the alias form when
 # constructing OppFilters via **kwargs — passing the snake_case field name silently
 # results in None (the alias is the required construction key).
 #
-# Strategy A normalizes consumer keys to the alias (or field-name for fields without
-# an alias) before passing them to OppFilters(**...):
+# classify_filters normalizes consumer keys to the alias (or field-name for fields
+# without an alias) before passing them to OppFilters(**...):
 #   - snake_case keys with a camelCase alias → converted to the alias (closeDateRange)
 #   - camelCase alias keys → kept as-is (already the alias)
 #   - keys with no alias (e.g. "status") → kept as-is (snake == wire key)
@@ -196,7 +197,7 @@ _SNAKE_TO_ALIAS: dict[str, str] = {
 }
 
 # ---------------------------------------------------------------------------
-# validate_routes — registration-time validator (CFP-05, DP-08, DP-15)
+# validate_routes — registration-time validator
 # ---------------------------------------------------------------------------
 
 
@@ -206,7 +207,8 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
     Iterates every filter spec in ``routes`` and raises ``PluginError`` on:
     1. Unknown ``filter_type`` (not in ``FILTER_TYPE_SCHEMAS``).
     2. Filter name that collides with a core default-filter name in
-       ``DEFAULT_FILTER_NAMES`` (the DP-15 escape-hatch collision check).
+       ``DEFAULT_FILTER_NAMES`` (the escape-hatch collision check — core-shadowing
+       names must use the ``gov.<system>@<filterName>`` namespace instead).
 
     The ``seen`` guard below is a defensive forward-looking comment only:
     a Python ``dict[str, CustomFilterSpec]`` literal cannot hold duplicate keys,
@@ -250,7 +252,7 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
 
 
 # ---------------------------------------------------------------------------
-# validate_filter_call — call-time validator (CFP-04, CFP-05, DP-08)
+# validate_filter_call — call-time validator
 # ---------------------------------------------------------------------------
 
 
@@ -265,8 +267,8 @@ def validate_filter_call(
     ``spec`` is provided (registered filter), or against ``DefaultFilter`` when
     ``spec`` is ``None`` (ad-hoc / escape-hatch filter).
 
-    Correctness is enforced at runtime by Pydantic v2 — the marquee finding (DP-04).
-    No compile-time key/value narrowing is claimed.
+    Correctness is enforced at runtime by Pydantic v2; no compile-time key/value
+    narrowing is claimed (Python has no equivalent of TS ``as const`` narrowing).
 
     Args:
         spec: The registered ``CustomFilterSpec`` for this filter, or ``None`` for ad-hoc.
@@ -308,7 +310,7 @@ def validate_filter_call(
 
 
 # ---------------------------------------------------------------------------
-# classify_filters — three-bucket ADR-0012 classifier (CFP-06, DP-05)
+# classify_filters — three-bucket ADR-0012 classifier
 # ---------------------------------------------------------------------------
 
 
@@ -327,15 +329,15 @@ def classify_filters(
       given resource/method → land in ``custom_filters``.
     - Bucket 3 (ad-hoc): any other key → land in ``custom_filters`` passthrough.
 
-    OppFilters is constructed via **Strategy A** (RESEARCH A4, PINNED):
-    All default consumer keys are normalized to the form that ``OppFilters(**kwargs)``
-    accepts.  Because ``OppDefaultFilters`` does NOT set ``populate_by_name=True``,
-    Pydantic v2 requires the alias form (e.g. ``closeDateRange``) for aliased fields.
-    Snake_case keys (e.g. ``close_date_range``) are therefore mapped to their alias via
-    ``_SNAKE_TO_ALIAS`` before construction.  Fields without aliases (e.g. ``status``)
-    pass through unchanged.
-    Strategy B (``model_validate`` with ``populate_by_name=True``) is **forbidden** —
-    it requires modifying ``OppFilters.model_config``, which is out of scope for the PoC.
+    Construction normalizes all default consumer keys to the form that
+    ``OppFilters(**kwargs)`` accepts.  Because ``OppDefaultFilters`` does NOT set
+    ``populate_by_name=True``, Pydantic v2 requires the alias form (e.g.
+    ``closeDateRange``) for aliased fields.  Snake_case keys (e.g.
+    ``close_date_range``) are therefore mapped to their alias via ``_SNAKE_TO_ALIAS``
+    before construction.  Fields without aliases (e.g. ``status``) pass through
+    unchanged.  The alternative — enabling ``populate_by_name=True`` on
+    ``OppFilters.model_config`` — is deliberately avoided: the classifier must not
+    modify core schema model config.
 
     Args:
         routes: Plugin route declarations (used to identify registered custom filters).
@@ -361,7 +363,7 @@ def classify_filters(
 
     for key, value in consumer_filters.items():
         if key in DEFAULT_FILTER_NAMES:
-            # Bucket 1: core default filter — Strategy A (RESEARCH A4, PINNED).
+            # Bucket 1: core default filter.
             # OppFilters requires the alias form (e.g. "closeDateRange") when constructing
             # via **kwargs because populate_by_name is not set on OppDefaultFilters.
             # Normalize: camelCase aliases stay as-is; snake_case keys are mapped to their

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -357,6 +357,11 @@ def classify_filters(
       given resource/method → land in ``custom_filters``.
     - Bucket 3 (ad-hoc): any other key → land in ``custom_filters`` passthrough.
 
+    The classifier is opportunity-bound today: default names come from
+    ``OppDefaultFilters`` and the wire body is ``OppFilters``. Deriving both
+    from the declared resource is tracked in
+    https://github.com/HHS/simpler-grants-protocol/issues/896.
+
     Registered specs are looked up by the exact ``(resource, method)`` strings
     declared in ``routes``. A non-matching pair (e.g. a pluralization typo in
     ``resource``) yields no registered bucket at all: every non-default filter is
@@ -414,18 +419,18 @@ def classify_filters(
             # OppFilters construction below, against the named field's REAL type (e.g.
             # status → StringArrayFilter) — stricter than the permissive DefaultFilter
             # check, and the single validation point for this bucket.
-            opp_key = _SNAKE_TO_ALIAS.get(key, key)
-            if opp_key in default_fields:
+            alias_key = _SNAKE_TO_ALIAS.get(key, key)
+            if alias_key in default_fields:
                 # Snake and camel forms of the same field normalize to one key;
                 # without this guard, plain dict assignment would silently drop
                 # whichever form the consumer's dict ordered first.
                 raise PluginError(
-                    f'Default filter "{opp_key}" was supplied more than once '
+                    f'Default filter "{alias_key}" was supplied more than once '
                     "(snake_case and camelCase forms of the same filter)",
-                    path=f"filters.{opp_key}",
+                    path=f"filters.{alias_key}",
                     source_value=value,
                 )
-            default_fields[opp_key] = value
+            default_fields[alias_key] = value
         elif key in registered_specs:
             # Bucket 2: registered custom filter — ship the validated value,
             # never the raw input (see validate_filter_call)

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -1,11 +1,12 @@
 """Pure-runtime filter engine for the CommonGrants Python SDK.
 
 Provides:
-- ``f.*`` helper module for building DefaultFilter instances.
+- ``f`` helper singleton for building DefaultFilter instances.
 - ``FILTER_TYPE_SCHEMAS`` — map from CustomFilterType to the Pydantic validation model.
 - ``DEFAULT_FILTER_NAMES`` — frozenset of all core default-filter field names (snake + alias).
 - ``validate_routes(routes)`` — registration-time validator; raises PluginError.
-- ``validate_filter_call(spec, filter_name, value)`` — call-time validator; raises PluginError.
+- ``validate_filter_call(spec, filter_name, value)`` — call-time validator; returns the
+  wire-ready DefaultFilter; raises PluginError.
 - ``classify_filters(routes, resource, method, consumer_filters)`` — three-bucket ADR-0012
   classifier that returns an OppFilters request body.
 
@@ -158,8 +159,10 @@ FILTER_TYPE_SCHEMAS: dict[CustomFilterType, type[BaseModel]] = {
 # ---------------------------------------------------------------------------
 
 #: All core default-filter names from OppDefaultFilters: snake_case field names PLUS their
-#: camelCase ``alias`` values.  Both forms are needed so that ``validate_routes`` can catch
-#: a plugin author registering a custom filter whose name shadows either form.
+#: camelCase ``alias`` values.  Both forms are needed by BOTH consumers of this set:
+#: ``validate_routes`` must catch a custom filter whose name shadows either form, and the
+#: bucket-1 membership test in ``classify_filters`` must route either key form to a named
+#: field (an alias-only set would silently drop camelCase keys into ``customFilters``).
 DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
     list(OppDefaultFilters.model_fields.keys())
     + [v.alias for v in OppDefaultFilters.model_fields.values() if v.alias]
@@ -180,7 +183,8 @@ DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
 #   - keys with no alias (e.g. "status") → kept as-is (snake == request key)
 # ---------------------------------------------------------------------------
 
-# Map from camelCase alias → snake_case field name (used for DEFAULT_FILTER_NAMES check).
+# Alias-form detection for bucket-1 normalization: only key MEMBERSHIP is used
+# ("is this key already the camelCase alias?"); the snake_case values are unused.
 _ALIAS_TO_SNAKE: dict[str, str] = {
     field_info.alias: field_name
     for field_name, field_info in OppDefaultFilters.model_fields.items()
@@ -211,7 +215,8 @@ def validate_routes(routes: PluginRoutes) -> None:
        names must use the ``gov.<system>@<filterName>`` namespace instead).
 
     Duplicate custom-filter names need no check: ``routes`` is dict-keyed, so a
-    duplicate name cannot exist by construction.
+    duplicate name cannot reach this validator (a duplicated literal key collapses
+    silently to its last occurrence at dict construction, before this runs).
 
     Args:
         routes: Route-keyed filter declarations as ``PluginRoutes``.
@@ -354,8 +359,8 @@ def classify_filters(
         ``OppFilters`` request body.  Call
         ``.model_dump(by_alias=True, exclude_none=True, mode="json")`` for the JSON
         body of the ADR-0012 search request — ``mode="json"`` is required because
-        coerced ``date`` objects and operator enums are not JSON-serializable in
-        the default python mode.
+        coerced ``date`` objects are not JSON-serializable in the default python
+        mode (operator enums are ``StrEnum`` and serialize fine either way).
 
     Raises:
         PluginError: When any filter value fails validation — registered and ad-hoc
@@ -413,9 +418,11 @@ def classify_filters(
         # under "customFilters" names the custom filter itself, not the wrapper.
         failed = sorted(
             {
-                str(err["loc"][1])
-                if len(err["loc"]) > 1 and err["loc"][0] == "customFilters"
-                else str(err["loc"][0])
+                (
+                    str(err["loc"][1])
+                    if len(err["loc"]) > 1 and err["loc"][0] == "customFilters"
+                    else str(err["loc"][0])
+                )
                 for err in exc.errors()
                 if err.get("loc")
             }

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -183,17 +183,10 @@ DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
 #   - keys with no alias (e.g. "status") → kept as-is (snake == request key)
 # ---------------------------------------------------------------------------
 
-# Alias-form detection for bucket-1 normalization: only key MEMBERSHIP is used
-# ("is this key already the camelCase alias?"); the snake_case values are unused.
-_ALIAS_TO_SNAKE: dict[str, str] = {
-    field_info.alias: field_name
-    for field_name, field_info in OppDefaultFilters.model_fields.items()
-    if field_info.alias
-}
-
 # Map from snake_case field name → camelCase alias (used for OppFilters construction).
-# Only fields that declare an alias are included; fields without aliases use their
-# snake_case name directly as the OppFilters constructor key (no alias needed).
+# Only fields that declare an alias are included; alias-form keys and fields without
+# aliases fall through ``_SNAKE_TO_ALIAS.get(key, key)`` unchanged — one lookup
+# normalizes all three key classes.
 _SNAKE_TO_ALIAS: dict[str, str] = {
     field_name: field_info.alias
     for field_name, field_info in OppDefaultFilters.model_fields.items()
@@ -339,6 +332,13 @@ def classify_filters(
       given resource/method → land in ``custom_filters``.
     - Bucket 3 (ad-hoc): any other key → land in ``custom_filters`` passthrough.
 
+    Registered specs are looked up by the exact ``(resource, method)`` strings
+    declared in ``routes``. A non-matching pair (e.g. a pluralization typo in
+    ``resource``) yields no registered bucket at all: every non-default filter is
+    then validated only against the permissive ``DefaultFilter`` shape, exactly
+    like ad-hoc input, with no error raised. Call sites must pass the same
+    resource/method strings the plugin declared.
+
     Construction normalizes all default consumer keys to the form that
     ``OppFilters(**kwargs)`` accepts.  Because ``OppDefaultFilters`` does NOT set
     ``populate_by_name=True``, Pydantic v2 requires the alias form (e.g.
@@ -365,7 +365,9 @@ def classify_filters(
     Raises:
         PluginError: When any filter value fails validation — registered and ad-hoc
             values at classification time, default values at ``OppFilters``
-            construction. The error surface is uniform across all three buckets.
+            construction — or when the snake_case and camelCase forms of the same
+            default filter are both supplied. The error surface is uniform across
+            all three buckets.
     """
     registered_specs: dict[str, CustomFilterSpec] = routes.get(resource, {}).get(
         method, {}
@@ -385,12 +387,17 @@ def classify_filters(
             # OppFilters construction below, against the named field's REAL type (e.g.
             # status → StringArrayFilter) — stricter than the permissive DefaultFilter
             # check, and the single validation point for this bucket.
-            if key in _ALIAS_TO_SNAKE:
-                # key is already the camelCase alias → use it directly
-                opp_key = key
-            else:
-                # key is snake_case → convert to alias if one exists, else keep as-is
-                opp_key = _SNAKE_TO_ALIAS.get(key, key)
+            opp_key = _SNAKE_TO_ALIAS.get(key, key)
+            if opp_key in default_fields:
+                # Snake and camel forms of the same field normalize to one key;
+                # without this guard, plain dict assignment would silently drop
+                # whichever form the consumer's dict ordered first.
+                raise PluginError(
+                    f'Default filter "{opp_key}" was supplied more than once '
+                    "(snake_case and camelCase forms of the same filter)",
+                    path=f"filters.{opp_key}",
+                    source_value=value,
+                )
             default_fields[opp_key] = value
         elif key in registered_specs:
             # Bucket 2: registered custom filter — ship the validated value,

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -41,7 +41,6 @@ from common_grants_sdk.schemas.pydantic.filters.money import (
     MoneyRangeFilter,
 )
 from common_grants_sdk.schemas.pydantic.filters.numeric import (
-    IntegerComparisonFilter,
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRangeFilter,
@@ -139,9 +138,8 @@ f = _FHelpers()
 # ---------------------------------------------------------------------------
 
 #: Maps each CustomFilterType to the Pydantic model used to validate operator/value shape.
-#: ``integerComparison`` and ``booleanComparison`` use the SDK-level
-#: ``IntegerComparisonFilter`` / ``BooleanComparisonFilter`` models (designed to stay
-#: parallel to the schema surface planned for the TS custom-filters PoC).
+#: ``booleanComparison`` uses the SDK-level ``BooleanComparisonFilter`` model (the spec
+#: defines no boolean filter; the TS SDK carries the same SDK-level schema).
 #: Read-only: the catalog is closed — registering new filter types is a spec/SDK
 #: change (extend CustomFilterType + this map together), not a runtime extension point.
 FILTER_TYPE_SCHEMAS: Mapping[CustomFilterType, type[BaseModel]] = MappingProxyType(
@@ -151,7 +149,9 @@ FILTER_TYPE_SCHEMAS: Mapping[CustomFilterType, type[BaseModel]] = MappingProxyTy
         CustomFilterType.NUMBER_COMPARISON: NumberComparisonFilter,
         CustomFilterType.NUMBER_ARRAY: NumberArrayFilter,
         CustomFilterType.NUMBER_RANGE: NumberRangeFilter,
-        CustomFilterType.INTEGER_COMPARISON: IntegerComparisonFilter,
+        # integerComparison reuses NumberComparisonFilter — the spec defines no
+        # integer filter model, so the int constraint is not schema-enforced
+        CustomFilterType.INTEGER_COMPARISON: NumberComparisonFilter,
         CustomFilterType.BOOLEAN_COMPARISON: BooleanComparisonFilter,
         CustomFilterType.DATE_COMPARISON: DateComparisonFilter,
         CustomFilterType.DATE_RANGE: DateRangeFilter,

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -217,6 +217,9 @@ def validate_routes(routes: PluginRoutes) -> None:
     duplicate name cannot reach this validator (a duplicated literal key collapses
     silently to its last occurrence at dict construction, before this runs).
 
+    Methods whose ``RouteDeclarations`` carry no ``filters`` key are skipped —
+    declaring a method with no filters is valid.
+
     Args:
         routes: Route-keyed filter declarations as ``PluginRoutes``.
 
@@ -224,9 +227,12 @@ def validate_routes(routes: PluginRoutes) -> None:
         PluginError: On the first invalid declaration found.
     """
     for resource, methods in routes.items():
-        for method, filter_specs in methods.items():
+        for method, declarations in methods.items():
+            filter_specs = declarations.get("filters")
+            if not filter_specs:
+                continue
             for filter_name, spec in filter_specs.items():
-                path = f"routes.{resource}.{method}.{filter_name}"
+                path = f"routes.{resource}.{method}.filters.{filter_name}"
                 if spec.filter_type not in FILTER_TYPE_SCHEMAS:
                     raise PluginError(
                         f'Unknown filter_type "{spec.filter_type}" for filter "{filter_name}"',
@@ -389,8 +395,9 @@ def classify_filters(
             default filter are both supplied. The error surface is uniform across
             all three buckets.
     """
-    registered_specs: dict[str, CustomFilterSpec] = routes.get(resource, {}).get(
-        method, {}
+    route_declarations = routes.get(resource, {}).get(method, {})
+    registered_specs: dict[str, CustomFilterSpec] = route_declarations.get(
+        "filters", {}
     )
 
     default_fields: dict[str, Any] = {}

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -201,7 +201,7 @@ _SNAKE_TO_ALIAS: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 
-def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
+def validate_routes(routes: PluginRoutes) -> None:
     """Registration-time validator for a plugin's route filter declarations.
 
     Iterates every filter spec in ``routes`` and raises ``PluginError`` on:
@@ -210,10 +210,8 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
        ``DEFAULT_FILTER_NAMES`` (the escape-hatch collision check — core-shadowing
        names must use the ``gov.<system>@<filterName>`` namespace instead).
 
-    The ``seen`` guard below is a defensive forward-looking comment only:
-    a Python ``dict[str, CustomFilterSpec]`` literal cannot hold duplicate keys,
-    so iterating ``.items()`` yields each key exactly once.  The guard is retained
-    for a future list-of-pairs API and will never fire with current dict semantics.
+    Duplicate custom-filter names need no check: ``routes`` is dict-keyed, so a
+    duplicate name cannot exist by construction.
 
     Args:
         routes: Route-keyed filter declarations as ``PluginRoutes``.
@@ -223,9 +221,6 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
     """
     for resource, methods in routes.items():
         for method, filter_specs in methods.items():
-            seen: set[str] = (
-                set()
-            )  # unreachable with dict semantics; retained for a future list-of-pairs API
             for filter_name, spec in filter_specs.items():
                 path = f"routes.{resource}.{method}.{filter_name}"
                 if spec.filter_type not in FILTER_TYPE_SCHEMAS:
@@ -240,15 +235,6 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
                         path=path,
                         source_value=filter_name,
                     )
-                if (
-                    filter_name in seen
-                ):  # forward-looking guard; unreachable with dict semantics
-                    raise PluginError(
-                        f'Duplicate filter name "{filter_name}" in {resource}.{method}',
-                        path=path,
-                        source_value=filter_name,
-                    )
-                seen.add(filter_name)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -1,0 +1,356 @@
+"""Pure-runtime filter engine for the CommonGrants Python SDK.
+
+Provides:
+- ``f.*`` helper module for building DefaultFilter instances.
+- ``FILTER_TYPE_SCHEMAS`` — map from CustomFilterType to the Pydantic validation model.
+- ``DEFAULT_FILTER_NAMES`` — frozenset of all core default-filter field names (snake + alias).
+- ``validate_routes(routes)`` — registration-time validator; raises PluginError.
+- ``validate_filter_call(spec, filter_name, value)`` — call-time validator; raises PluginError.
+- ``classify_filters(routes, resource, method, consumer_filters)`` — three-bucket ADR-0012
+  classifier that returns an OppFilters wire body.
+
+No generate.py / codegen dependency (DP-05). Correctness is enforced at runtime by Pydantic v2
+(DP-02/DP-04); there is no compile-time key/value narrowing claim.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from pydantic import BaseModel, ValidationError
+
+from common_grants_sdk.schemas.pydantic.filters.base import DefaultFilter
+from common_grants_sdk.schemas.pydantic.filters.boolean import BooleanComparisonFilter
+from common_grants_sdk.schemas.pydantic.filters.date import DateComparisonFilter, DateRangeFilter
+from common_grants_sdk.schemas.pydantic.filters.money import MoneyComparisonFilter, MoneyRangeFilter
+from common_grants_sdk.schemas.pydantic.filters.numeric import (
+    NumberArrayFilter,
+    NumberComparisonFilter,
+    NumberRangeFilter,
+)
+from common_grants_sdk.schemas.pydantic.filters.opportunity import OppDefaultFilters, OppFilters
+from common_grants_sdk.schemas.pydantic.filters.string import StringArrayFilter, StringComparisonFilter
+
+from .specs import CustomFilterSpec, CustomFilterType
+from .types import PluginError, PluginRoutes
+
+# ---------------------------------------------------------------------------
+# f.* helpers (CFP-03, DP-10)
+# ---------------------------------------------------------------------------
+
+
+class _FHelpers:
+    """Helper namespace mirroring the TS ``F`` object.
+
+    Import as ``from common_grants_sdk.extensions import f`` and use as
+    ``f.eq("open")``, ``f.in_([...])``, etc.
+
+    ``in_`` and ``not_in`` use the reserved-word workaround (DP-10):
+    the Python methods are ``f.in_`` / ``f.not_in`` while the wire operator
+    values are ``"in"`` / ``"notIn"`` (matching the TS SDK's ``F.in`` / ``F.notIn``).
+    """
+
+    def eq(self, value: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="eq", value=value)."""
+        return DefaultFilter(operator="eq", value=value)
+
+    def neq(self, value: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="neq", value=value)."""
+        return DefaultFilter(operator="neq", value=value)
+
+    def gt(self, value: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="gt", value=value)."""
+        return DefaultFilter(operator="gt", value=value)
+
+    def gte(self, value: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="gte", value=value)."""
+        return DefaultFilter(operator="gte", value=value)
+
+    def lt(self, value: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="lt", value=value)."""
+        return DefaultFilter(operator="lt", value=value)
+
+    def lte(self, value: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="lte", value=value)."""
+        return DefaultFilter(operator="lte", value=value)
+
+    def in_(self, value: list[Any]) -> DefaultFilter:
+        """Return DefaultFilter with wire operator "in" (Python keyword workaround: f.in_)."""
+        return DefaultFilter(operator="in", value=value)
+
+    def not_in(self, value: list[Any]) -> DefaultFilter:
+        """Return DefaultFilter with wire operator "notIn" (Python f.not_in vs TS F.notIn)."""
+        return DefaultFilter(operator="notIn", value=value)
+
+    def like(self, value: str) -> DefaultFilter:
+        """Return DefaultFilter(operator="like", value=value)."""
+        return DefaultFilter(operator="like", value=value)
+
+    def not_like(self, value: str) -> DefaultFilter:
+        """Return DefaultFilter(operator="notLike", value=value)."""
+        return DefaultFilter(operator="notLike", value=value)
+
+    def between(self, min: Any, max: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="between", value={"min": min, "max": max})."""
+        return DefaultFilter(operator="between", value={"min": min, "max": max})
+
+    def outside(self, min: Any, max: Any) -> DefaultFilter:
+        """Return DefaultFilter(operator="outside", value={"min": min, "max": max})."""
+        return DefaultFilter(operator="outside", value={"min": min, "max": max})
+
+
+#: Module-level singleton — use as ``f.eq(...)``, ``f.in_([...])``, etc.
+f = _FHelpers()
+
+# ---------------------------------------------------------------------------
+# FILTER_TYPE_SCHEMAS — call-time validation map (CFP-04)
+# ---------------------------------------------------------------------------
+
+#: Maps each CustomFilterType to the Pydantic model used to validate operator/value shape.
+#: ``integerComparison`` reuses ``NumberComparisonFilter`` (CFPV-03 deferred).
+#: ``booleanComparison`` uses the new ``BooleanComparisonFilter`` from plan 01.
+FILTER_TYPE_SCHEMAS: dict[CustomFilterType, type[BaseModel]] = {
+    CustomFilterType.STRING_COMPARISON: StringComparisonFilter,
+    CustomFilterType.STRING_ARRAY: StringArrayFilter,
+    CustomFilterType.NUMBER_COMPARISON: NumberComparisonFilter,
+    CustomFilterType.NUMBER_ARRAY: NumberArrayFilter,
+    CustomFilterType.NUMBER_RANGE: NumberRangeFilter,
+    CustomFilterType.INTEGER_COMPARISON: NumberComparisonFilter,  # CFPV-03: reuse
+    CustomFilterType.BOOLEAN_COMPARISON: BooleanComparisonFilter,
+    CustomFilterType.DATE_COMPARISON: DateComparisonFilter,
+    CustomFilterType.DATE_RANGE: DateRangeFilter,
+    CustomFilterType.MONEY_COMPARISON: MoneyComparisonFilter,
+    CustomFilterType.MONEY_RANGE: MoneyRangeFilter,
+}
+
+# ---------------------------------------------------------------------------
+# DEFAULT_FILTER_NAMES — must include BOTH snake_case field names AND camelCase aliases
+# (RESEARCH Pitfall 1 / DP-15: the "landmine" for camelCase alias lookup)
+# ---------------------------------------------------------------------------
+
+#: All core default-filter names from OppDefaultFilters: snake_case field names PLUS their
+#: camelCase ``alias`` values.  Both forms are needed so that ``validate_routes`` can catch
+#: a plugin author registering a custom filter whose name shadows either form (DP-15).
+DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
+    list(OppDefaultFilters.model_fields.keys())
+    + [v.alias for v in OppDefaultFilters.model_fields.values() if v.alias]
+)
+
+# ---------------------------------------------------------------------------
+# Strategy A: normalization maps for classify_filters
+# (RESEARCH A4 / Pitfall 6 — PINNED as the required construction path)
+#
+# OppDefaultFilters uses snake_case field names with camelCase aliases but does NOT
+# set populate_by_name=True.  Pydantic v2 therefore requires the alias form when
+# constructing OppFilters via **kwargs — passing the snake_case field name silently
+# results in None (the alias is the required construction key).
+#
+# Strategy A normalizes consumer keys to the alias (or field-name for fields without
+# an alias) before passing them to OppFilters(**...):
+#   - snake_case keys with a camelCase alias → converted to the alias (closeDateRange)
+#   - camelCase alias keys → kept as-is (already the alias)
+#   - keys with no alias (e.g. "status") → kept as-is (snake == wire key)
+# ---------------------------------------------------------------------------
+
+# Map from camelCase alias → snake_case field name (used for DEFAULT_FILTER_NAMES check).
+_ALIAS_TO_SNAKE: dict[str, str] = {
+    field_info.alias: field_name
+    for field_name, field_info in OppDefaultFilters.model_fields.items()
+    if field_info.alias
+}
+
+# Map from snake_case field name → camelCase alias (used for OppFilters construction).
+# Only fields that declare an alias are included; fields without aliases use their
+# snake_case name directly as the OppFilters constructor key (no alias needed).
+_SNAKE_TO_ALIAS: dict[str, str] = {
+    field_name: field_info.alias
+    for field_name, field_info in OppDefaultFilters.model_fields.items()
+    if field_info.alias
+}
+
+# ---------------------------------------------------------------------------
+# validate_routes — registration-time validator (CFP-05, DP-08, DP-15)
+# ---------------------------------------------------------------------------
+
+
+def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
+    """Registration-time validator for a plugin's route filter declarations.
+
+    Iterates every filter spec in ``routes`` and raises ``PluginError`` on:
+    1. Unknown ``filter_type`` (not in ``FILTER_TYPE_SCHEMAS``).
+    2. Filter name that collides with a core default-filter name in
+       ``DEFAULT_FILTER_NAMES`` (the DP-15 escape-hatch collision check).
+
+    The ``seen`` guard below is a defensive forward-looking comment only:
+    a Python ``dict[str, CustomFilterSpec]`` literal cannot hold duplicate keys,
+    so iterating ``.items()`` yields each key exactly once.  The guard is retained
+    for a future list-of-pairs API and will never fire with current dict semantics.
+
+    Args:
+        routes: Route-keyed filter declarations as ``PluginRoutes``.
+
+    Raises:
+        PluginError: On the first invalid declaration found.
+    """
+    for resource, methods in routes.items():
+        for method, filter_specs in methods.items():
+            seen: set[str] = set()  # unreachable with dict semantics; retained for a future list-of-pairs API
+            for filter_name, spec in filter_specs.items():
+                path = f"routes.{resource}.{method}.{filter_name}"
+                if spec.filter_type not in FILTER_TYPE_SCHEMAS:
+                    raise PluginError(
+                        f'Unknown filter_type "{spec.filter_type}" for filter "{filter_name}"',
+                        path=path,
+                        source_value=spec,
+                    )
+                if filter_name in DEFAULT_FILTER_NAMES:
+                    raise PluginError(
+                        f'Filter name "{filter_name}" collides with a default filter name',
+                        path=path,
+                        source_value=filter_name,
+                    )
+                if filter_name in seen:  # forward-looking guard; unreachable with dict semantics
+                    raise PluginError(
+                        f'Duplicate filter name "{filter_name}" in {resource}.{method}',
+                        path=path,
+                        source_value=filter_name,
+                    )
+                seen.add(filter_name)
+
+
+# ---------------------------------------------------------------------------
+# validate_filter_call — call-time validator (CFP-04, CFP-05, DP-08)
+# ---------------------------------------------------------------------------
+
+
+def validate_filter_call(
+    spec: Optional[CustomFilterSpec],
+    filter_name: str,
+    value: Any,
+) -> None:
+    """Call-time validator for a single filter value.
+
+    Validates ``value`` against the Pydantic model for ``spec.filter_type`` when
+    ``spec`` is provided (registered filter), or against ``DefaultFilter`` when
+    ``spec`` is ``None`` (ad-hoc / escape-hatch filter).
+
+    Correctness is enforced at runtime by Pydantic v2 — the marquee finding (DP-04).
+    No compile-time key/value narrowing is claimed.
+
+    Args:
+        spec: The registered ``CustomFilterSpec`` for this filter, or ``None`` for ad-hoc.
+        filter_name: The filter name (used in PluginError path).
+        value: The filter value to validate (typically a ``DefaultFilter`` instance).
+
+    Raises:
+        PluginError: On operator/value-shape mismatch, wrapping the pydantic
+            ``ValidationError`` as ``cause``.
+    """
+    if spec is not None:
+        model_cls = FILTER_TYPE_SCHEMAS[spec.filter_type]
+        try:
+            if isinstance(value, BaseModel):
+                model_cls.model_validate(value.model_dump())
+            else:
+                model_cls.model_validate(value)
+        except ValidationError as exc:
+            raise PluginError(
+                f'Filter "{filter_name}" failed validation: {exc.error_count()} error(s)',
+                path=filter_name,
+                source_value=value,
+                cause=exc,
+            ) from exc
+    else:
+        # Ad-hoc / escape-hatch: validate against DefaultFilter shape only
+        try:
+            if isinstance(value, DefaultFilter):
+                # Already a valid DefaultFilter instance
+                return
+            DefaultFilter.model_validate(value)
+        except (ValidationError, Exception) as exc:
+            raise PluginError(
+                f'Ad-hoc filter "{filter_name}" has an invalid DefaultFilter shape: {exc}',
+                path=filter_name,
+                source_value=value,
+                cause=exc if isinstance(exc, BaseException) else None,
+            ) from exc
+
+
+# ---------------------------------------------------------------------------
+# classify_filters — three-bucket ADR-0012 classifier (CFP-06, DP-05)
+# ---------------------------------------------------------------------------
+
+
+def classify_filters(
+    routes: PluginRoutes,
+    resource: str,
+    method: str,
+    consumer_filters: dict[str, Any],
+) -> OppFilters:
+    """Classify consumer filter dict into the ADR-0012 OppFilters wire body.
+
+    Three-bucket classification:
+    - Bucket 1 (default): key is in ``DEFAULT_FILTER_NAMES`` (snake or camelCase alias) →
+      normalize to snake_case, land in a named OppFilters field.
+    - Bucket 2 (registered custom): key matches a registered ``CustomFilterSpec`` for the
+      given resource/method → land in ``custom_filters``.
+    - Bucket 3 (ad-hoc): any other key → land in ``custom_filters`` passthrough.
+
+    OppFilters is constructed via **Strategy A** (RESEARCH A4, PINNED):
+    All default consumer keys are normalized to the form that ``OppFilters(**kwargs)``
+    accepts.  Because ``OppDefaultFilters`` does NOT set ``populate_by_name=True``,
+    Pydantic v2 requires the alias form (e.g. ``closeDateRange``) for aliased fields.
+    Snake_case keys (e.g. ``close_date_range``) are therefore mapped to their alias via
+    ``_SNAKE_TO_ALIAS`` before construction.  Fields without aliases (e.g. ``status``)
+    pass through unchanged.
+    Strategy B (``model_validate`` with ``populate_by_name=True``) is **forbidden** —
+    it requires modifying ``OppFilters.model_config``, which is out of scope for the PoC.
+
+    Args:
+        routes: Plugin route declarations (used to identify registered custom filters).
+        resource: Resource name (e.g. ``"opportunities"``).
+        method: Method name (e.g. ``"search"``).
+        consumer_filters: Flat ``{name: DefaultFilter}`` dict from the consumer call site.
+
+    Returns:
+        ``OppFilters`` wire body.  Call ``.model_dump(by_alias=True, exclude_none=True)``
+        for the ADR-0012 JSON wire shape.
+    """
+    registered_specs: dict[str, CustomFilterSpec] = (
+        routes.get(resource, {}).get(method, {})
+    )
+
+    default_fields: dict[str, Any] = {}
+    custom_buckets: dict[str, DefaultFilter] = {}
+
+    for key, value in consumer_filters.items():
+        if key in DEFAULT_FILTER_NAMES:
+            # Bucket 1: core default filter — Strategy A (RESEARCH A4, PINNED).
+            # OppFilters requires the alias form (e.g. "closeDateRange") when constructing
+            # via **kwargs because populate_by_name is not set on OppDefaultFilters.
+            # Normalize: camelCase aliases stay as-is; snake_case keys are mapped to their
+            # alias; keys with no alias (e.g. "status") are passed through unchanged.
+            if key in _ALIAS_TO_SNAKE:
+                # key is already the camelCase alias → use it directly
+                opp_key = key
+            else:
+                # key is snake_case → convert to alias if one exists, else keep as-is
+                opp_key = _SNAKE_TO_ALIAS.get(key, key)
+            validate_filter_call(None, key, value)
+            default_fields[opp_key] = value
+        elif key in registered_specs:
+            # Bucket 2: registered custom filter
+            spec = registered_specs[key]
+            validate_filter_call(spec, key, value)
+            custom_buckets[key] = value
+        else:
+            # Bucket 3: ad-hoc / escape-hatch passthrough
+            validate_filter_call(None, key, value)
+            custom_buckets[key] = value
+
+    # OppFilters requires the alias form for construction (populate_by_name is not set).
+    # Use "customFilters" (the alias) rather than "custom_filters" (the field name).
+    return OppFilters(
+        **default_fields,
+        customFilters=custom_buckets if custom_buckets else None,
+    )

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -7,12 +7,12 @@ Provides:
 - ``validate_routes(routes)`` — registration-time validator; raises PluginError.
 - ``validate_filter_call(spec, filter_name, value)`` — call-time validator; returns the
   wire-ready DefaultFilter; raises PluginError.
-- ``classify_filters(routes, resource, method, consumer_filters)`` — three-bucket ADR-0012
-  classifier that returns an OppFilters request body.
+- ``classify_filters(routes, resource, method, consumer_filters)`` — classifier producing
+  the ADR-0012 request-body shape (default named fields + ``customFilters``).
 
 No generate.py / codegen dependency. Correctness is enforced at runtime by Pydantic v2;
-there is no compile-time key/value narrowing claim (Python has no equivalent of the TS
-SDK's ``as const`` literal narrowing).
+there is no compile-time key/value narrowing claim (Python has no equivalent of TS
+``as const`` literal narrowing).
 """
 
 from __future__ import annotations
@@ -64,14 +64,14 @@ from .types import PluginError, PluginRoutes
 
 
 class _FHelpers:
-    """Helper namespace mirroring the TS ``F`` object.
+    """Helper namespace designed to mirror the ``F`` object planned for the TS SDK.
 
     Import as ``from common_grants_sdk.extensions import f`` and use as
     ``f.eq("open")``, ``f.in_([...])``, etc.
 
     ``in_`` and ``not_in`` use the reserved-word workaround:
     the Python methods are ``f.in_`` / ``f.not_in`` while the wire operator
-    values are ``"in"`` / ``"notIn"`` (matching the TS SDK's ``F.in`` / ``F.notIn``).
+    values are ``"in"`` / ``"notIn"`` (the TS surface uses ``F.in`` / ``F.notIn``).
     """
 
     def eq(self, value: Any) -> DefaultFilter:
@@ -140,8 +140,8 @@ f = _FHelpers()
 
 #: Maps each CustomFilterType to the Pydantic model used to validate operator/value shape.
 #: ``integerComparison`` and ``booleanComparison`` use the SDK-level
-#: ``IntegerComparisonFilter`` / ``BooleanComparisonFilter`` models (parallel to the
-#: TS SDK's ``IntegerComparisonFilterSchema`` / ``BooleanComparisonFilterSchema``).
+#: ``IntegerComparisonFilter`` / ``BooleanComparisonFilter`` models (designed to stay
+#: parallel to the schema surface planned for the TS custom-filters PoC).
 #: Read-only: the catalog is closed — registering new filter types is a spec/SDK
 #: change (extend CustomFilterType + this map together), not a runtime extension point.
 FILTER_TYPE_SCHEMAS: Mapping[CustomFilterType, type[BaseModel]] = MappingProxyType(
@@ -168,7 +168,7 @@ FILTER_TYPE_SCHEMAS: Mapping[CustomFilterType, type[BaseModel]] = MappingProxyTy
 #: camelCase ``alias`` values.  Both forms are needed by BOTH consumers of this set:
 #: ``validate_routes`` must catch a custom filter whose name shadows either form, and the
 #: bucket-1 membership test in ``classify_filters`` must route either key form to a named
-#: field (an alias-only set would silently drop camelCase keys into ``customFilters``).
+#: field (an alias-only set would silently drop snake_case keys into ``customFilters``).
 DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
     list(OppDefaultFilters.model_fields.keys())
     + [v.alias for v in OppDefaultFilters.model_fields.values() if v.alias]
@@ -210,8 +210,8 @@ def validate_routes(routes: PluginRoutes) -> None:
     Iterates every filter spec in ``routes`` and raises ``PluginError`` on:
     1. Unknown ``filter_type`` (not in ``FILTER_TYPE_SCHEMAS``).
     2. Filter name that collides with a core default-filter name in
-       ``DEFAULT_FILTER_NAMES`` (the escape-hatch collision check — core-shadowing
-       names must use the ``gov.<system>@<filterName>`` namespace instead).
+       ``DEFAULT_FILTER_NAMES`` (the escape-hatch collision check; a namespaced
+       key such as ``gov.<system>@<filterName>`` passes through as ad-hoc instead).
 
     Duplicate custom-filter names need no check: ``routes`` is dict-keyed, so a
     duplicate name cannot reach this validator (a duplicated literal key collapses
@@ -271,7 +271,7 @@ def validate_filter_call(
 
     Returns the validated filter as a ``DefaultFilter`` carrying the coerced
     operator/value — the wire payload is exactly what passed validation, never
-    the raw input (lax coercion can differ from the input, e.g. ``"42"`` → 42.0).
+    the raw input (lax coercion can differ from the input, e.g. ``"42"`` → ``42``).
     Model instances are re-validated via ``model_dump()`` rather than trusted:
     the filter models are mutable, so an instance that was valid at construction
     may not be valid now.
@@ -290,8 +290,8 @@ def validate_filter_call(
     Raises:
         PluginError: On operator/value-shape mismatch (wrapping the pydantic
             ``ValidationError`` as ``cause``), or on a ``spec.filter_type`` not
-            present in ``FILTER_TYPE_SCHEMAS`` — ``validate_routes`` catches the
-            latter at registration time.
+            present in ``FILTER_TYPE_SCHEMAS`` — call ``validate_routes(routes)``
+            at registration time to catch the latter earlier.
     """
     payload = value.model_dump() if isinstance(value, BaseModel) else value
     if spec is not None:
@@ -299,8 +299,8 @@ def validate_filter_call(
         if model_cls is None:
             raise PluginError(
                 f'Unknown filter_type "{spec.filter_type}" for filter '
-                f'"{filter_name}" — validate_routes(routes) catches this at '
-                "registration time",
+                f'"{filter_name}" — call validate_routes(routes) at '
+                "registration time to catch this earlier",
                 path=f"filters.{filter_name}",
                 source_value=spec,
             )
@@ -332,7 +332,7 @@ def validate_filter_call(
 
 
 # ---------------------------------------------------------------------------
-# classify_filters — three-bucket ADR-0012 classifier
+# classify_filters — ADR-0012 request-body classifier
 # ---------------------------------------------------------------------------
 
 

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -8,11 +8,9 @@ Provides:
 - ``validate_filter_call(spec, filter_name, value)`` — call-time validator; returns the
   wire-ready DefaultFilter; raises PluginError.
 - ``classify_filters(routes, resource, method, consumer_filters)`` — classifier producing
-  the ADR-0012 request-body shape (default named fields + ``customFilters``).
+  the ``OppFilters`` search request body (default named fields + ``customFilters``).
 
-No generate.py / codegen dependency. Correctness is enforced at runtime by Pydantic v2;
-there is no compile-time key/value narrowing claim (Python has no equivalent of TS
-``as const`` literal narrowing).
+No generate.py / codegen dependency. Correctness is enforced at runtime by Pydantic v2.
 """
 
 from __future__ import annotations
@@ -63,14 +61,13 @@ from .types import PluginError, PluginRoutes
 
 
 class _FHelpers:
-    """Helper namespace designed to mirror the ``F`` object planned for the TS SDK.
+    """Helper namespace for building ``DefaultFilter`` instances.
 
     Import as ``from common_grants_sdk.extensions import f`` and use as
     ``f.eq("open")``, ``f.in_([...])``, etc.
 
-    ``in_`` and ``not_in`` use the reserved-word workaround:
-    the Python methods are ``f.in_`` / ``f.not_in`` while the wire operator
-    values are ``"in"`` / ``"notIn"`` (the TS surface uses ``F.in`` / ``F.notIn``).
+    ``in_`` and ``not_in`` avoid Python reserved words; the wire operator
+    values they emit are still ``"in"`` / ``"notIn"``.
     """
 
     def eq(self, value: Any) -> DefaultFilter:
@@ -106,7 +103,7 @@ class _FHelpers:
         return DefaultFilter(operator=ArrayOperator.IN, value=value)
 
     def not_in(self, value: list[Any]) -> DefaultFilter:
-        """Return DefaultFilter with wire operator "notIn" (Python f.not_in vs TS F.notIn)."""
+        """Return DefaultFilter with wire operator "notIn"."""
         return DefaultFilter(operator=ArrayOperator.NOT_IN, value=value)
 
     def like(self, value: str) -> DefaultFilter:
@@ -139,7 +136,7 @@ f = _FHelpers()
 
 #: Maps each CustomFilterType to the Pydantic model used to validate operator/value shape.
 #: ``booleanComparison`` uses the SDK-level ``BooleanComparisonFilter`` model (the spec
-#: defines no boolean filter; the TS SDK carries the same SDK-level schema).
+#: defines no boolean filter model).
 #: Read-only: the catalog is closed — registering new filter types is a spec/SDK
 #: change (extend CustomFilterType + this map together), not a runtime extension point.
 FILTER_TYPE_SCHEMAS: Mapping[CustomFilterType, type[BaseModel]] = MappingProxyType(
@@ -282,9 +279,6 @@ def validate_filter_call(
     the filter models are mutable, so an instance that was valid at construction
     may not be valid now.
 
-    Correctness is enforced at runtime by Pydantic v2; no compile-time key/value
-    narrowing is claimed (Python has no equivalent of TS ``as const`` narrowing).
-
     Args:
         spec: The registered ``CustomFilterSpec`` for this filter, or ``None`` for ad-hoc.
         filter_name: The filter name (used in PluginError path).
@@ -342,13 +336,16 @@ def validate_filter_call(
 # ---------------------------------------------------------------------------
 
 
+# The Opportunity binding (OppDefaultFilters / OppFilters) is a known limitation;
+# deriving both from the declared resource is tracked in
+# https://github.com/HHS/simpler-grants-protocol/issues/896.
 def classify_filters(
     routes: PluginRoutes,
     resource: str,
     method: str,
     consumer_filters: Mapping[str, DefaultFilter | dict[str, Any]],
 ) -> OppFilters:
-    """Classify consumer filter dict into the ADR-0012 OppFilters request body.
+    """Classify consumer filter dict into the ``OppFilters`` search request body.
 
     Three-bucket classification:
     - Bucket 1 (default): key is in ``DEFAULT_FILTER_NAMES`` (snake or camelCase alias) →
@@ -358,9 +355,8 @@ def classify_filters(
     - Bucket 3 (ad-hoc): any other key → land in ``custom_filters`` passthrough.
 
     The classifier is opportunity-bound today: default names come from
-    ``OppDefaultFilters`` and the wire body is ``OppFilters``. Deriving both
-    from the declared resource is tracked in
-    https://github.com/HHS/simpler-grants-protocol/issues/896.
+    ``OppDefaultFilters`` and the wire body is ``OppFilters``. A future
+    revision will derive both from the declared resource.
 
     Registered specs are looked up by the exact ``(resource, method)`` strings
     declared in ``routes``. A non-matching pair (e.g. a pluralization typo in
@@ -389,7 +385,7 @@ def classify_filters(
     Returns:
         ``OppFilters`` request body.  Call
         ``.model_dump(by_alias=True, exclude_none=True, mode="json")`` for the JSON
-        body of the ADR-0012 search request — ``mode="json"`` is required because
+        body of the search request — ``mode="json"`` is required because
         coerced ``date`` objects are not JSON-serializable in the default python
         mode (operator enums are ``StrEnum`` and serialize fine either way).
 

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -7,7 +7,7 @@ Provides:
 - ``validate_routes(routes)`` — registration-time validator; raises PluginError.
 - ``validate_filter_call(spec, filter_name, value)`` — call-time validator; raises PluginError.
 - ``classify_filters(routes, resource, method, consumer_filters)`` — three-bucket ADR-0012
-  classifier that returns an OppFilters wire body.
+  classifier that returns an OppFilters request body.
 
 No generate.py / codegen dependency. Correctness is enforced at runtime by Pydantic v2;
 there is no compile-time key/value narrowing claim (Python has no equivalent of the TS
@@ -177,7 +177,7 @@ DEFAULT_FILTER_NAMES: frozenset[str] = frozenset(
 # without an alias) before passing them to OppFilters(**...):
 #   - snake_case keys with a camelCase alias → converted to the alias (closeDateRange)
 #   - camelCase alias keys → kept as-is (already the alias)
-#   - keys with no alias (e.g. "status") → kept as-is (snake == wire key)
+#   - keys with no alias (e.g. "status") → kept as-is (snake == request key)
 # ---------------------------------------------------------------------------
 
 # Map from camelCase alias → snake_case field name (used for DEFAULT_FILTER_NAMES check).
@@ -306,7 +306,7 @@ def classify_filters(
     method: str,
     consumer_filters: dict[str, Any],
 ) -> OppFilters:
-    """Classify consumer filter dict into the ADR-0012 OppFilters wire body.
+    """Classify consumer filter dict into the ADR-0012 OppFilters request body.
 
     Three-bucket classification:
     - Bucket 1 (default): key is in ``DEFAULT_FILTER_NAMES`` (snake or camelCase alias) →
@@ -332,8 +332,8 @@ def classify_filters(
         consumer_filters: Flat ``{name: DefaultFilter}`` dict from the consumer call site.
 
     Returns:
-        ``OppFilters`` wire body.  Call ``.model_dump(by_alias=True, exclude_none=True)``
-        for the ADR-0012 JSON wire shape.
+        ``OppFilters`` request body.  Call ``.model_dump(by_alias=True, exclude_none=True)``
+        for the JSON body of the ADR-0012 search request.
 
     Raises:
         PluginError: When any filter value fails validation — registered and ad-hoc

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -246,12 +246,19 @@ def validate_filter_call(
     spec: Optional[CustomFilterSpec],
     filter_name: str,
     value: Any,
-) -> None:
+) -> DefaultFilter:
     """Call-time validator for a single filter value.
 
     Validates ``value`` against the Pydantic model for ``spec.filter_type`` when
     ``spec`` is provided (registered filter), or against ``DefaultFilter`` when
     ``spec`` is ``None`` (ad-hoc / escape-hatch filter).
+
+    Returns the validated filter as a ``DefaultFilter`` carrying the coerced
+    operator/value — the wire payload is exactly what passed validation, never
+    the raw input (lax coercion can differ from the input, e.g. ``"42"`` → 42.0).
+    Model instances are re-validated via ``model_dump()`` rather than trusted:
+    the filter models are mutable, so an instance that was valid at construction
+    may not be valid now.
 
     Correctness is enforced at runtime by Pydantic v2; no compile-time key/value
     narrowing is claimed (Python has no equivalent of TS ``as const`` narrowing).
@@ -261,17 +268,28 @@ def validate_filter_call(
         filter_name: The filter name (used in PluginError path).
         value: The filter value to validate (typically a ``DefaultFilter`` instance).
 
+    Returns:
+        The validated filter as a ``DefaultFilter`` with coerced operator/value.
+
     Raises:
-        PluginError: On operator/value-shape mismatch, wrapping the pydantic
-            ``ValidationError`` as ``cause``.
+        PluginError: On operator/value-shape mismatch (wrapping the pydantic
+            ``ValidationError`` as ``cause``), or on a ``spec.filter_type`` not
+            present in ``FILTER_TYPE_SCHEMAS`` — ``validate_routes`` catches the
+            latter at registration time.
     """
+    payload = value.model_dump() if isinstance(value, BaseModel) else value
     if spec is not None:
-        model_cls = FILTER_TYPE_SCHEMAS[spec.filter_type]
+        model_cls = FILTER_TYPE_SCHEMAS.get(spec.filter_type)
+        if model_cls is None:
+            raise PluginError(
+                f'Unknown filter_type "{spec.filter_type}" for filter '
+                f'"{filter_name}" — validate_routes(routes) catches this at '
+                "registration time",
+                path=f"filters.{filter_name}",
+                source_value=spec,
+            )
         try:
-            if isinstance(value, BaseModel):
-                model_cls.model_validate(value.model_dump())
-            else:
-                model_cls.model_validate(value)
+            validated = model_cls.model_validate(payload)
         except ValidationError as exc:
             raise PluginError(
                 f'Filter "{filter_name}" failed validation: {exc.error_count()} error(s)',
@@ -279,20 +297,21 @@ def validate_filter_call(
                 source_value=value,
                 cause=exc,
             ) from exc
-    else:
-        # Ad-hoc / escape-hatch: validate against DefaultFilter shape only
-        try:
-            if isinstance(value, DefaultFilter):
-                # Already a valid DefaultFilter instance
-                return
-            DefaultFilter.model_validate(value)
-        except ValidationError as exc:
-            raise PluginError(
-                f'Ad-hoc filter "{filter_name}" has an invalid DefaultFilter shape: {exc}',
-                path=f"filters.{filter_name}",
-                source_value=value,
-                cause=exc,
-            ) from exc
+        # Re-shape to DefaultFilter so the wire bucket carries the coerced
+        # operator/value. DefaultFilter.value is Any per the core spec, so
+        # nothing the typed model accepted can fail here.
+        return DefaultFilter.model_validate(validated.model_dump())
+    # Ad-hoc / escape-hatch: validate against DefaultFilter shape only
+    try:
+        return DefaultFilter.model_validate(payload)
+    except ValidationError as exc:
+        raise PluginError(
+            f'Ad-hoc filter "{filter_name}" has an invalid DefaultFilter shape: '
+            f"{exc.error_count()} error(s)",
+            path=f"filters.{filter_name}",
+            source_value=value,
+            cause=exc,
+        ) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -310,7 +329,7 @@ def classify_filters(
 
     Three-bucket classification:
     - Bucket 1 (default): key is in ``DEFAULT_FILTER_NAMES`` (snake or camelCase alias) →
-      normalize to snake_case, land in a named OppFilters field.
+      normalize to the camelCase alias form, land in a named OppFilters field.
     - Bucket 2 (registered custom): key matches a registered ``CustomFilterSpec`` for the
       given resource/method → land in ``custom_filters``.
     - Bucket 3 (ad-hoc): any other key → land in ``custom_filters`` passthrough.
@@ -369,14 +388,13 @@ def classify_filters(
                 opp_key = _SNAKE_TO_ALIAS.get(key, key)
             default_fields[opp_key] = value
         elif key in registered_specs:
-            # Bucket 2: registered custom filter
+            # Bucket 2: registered custom filter — ship the validated value,
+            # never the raw input (see validate_filter_call)
             spec = registered_specs[key]
-            validate_filter_call(spec, key, value)
-            custom_buckets[key] = value
+            custom_buckets[key] = validate_filter_call(spec, key, value)
         else:
-            # Bucket 3: ad-hoc / escape-hatch passthrough
-            validate_filter_call(None, key, value)
-            custom_buckets[key] = value
+            # Bucket 3: ad-hoc / escape-hatch passthrough — ship the validated value
+            custom_buckets[key] = validate_filter_call(None, key, value)
 
     # OppFilters requires the alias form for construction (populate_by_name is not set).
     # Use "customFilters" (the alias) rather than "custom_filters" (the field name).
@@ -391,12 +409,20 @@ def classify_filters(
     except ValidationError as exc:
         # Name the failing field(s) so bucket-1 errors are as pinpointed as the
         # filters.<name> paths raised for buckets 2/3. The loc values are the
-        # alias keys used at construction (e.g. "closeDateRange").
-        failed = sorted({str(err["loc"][0]) for err in exc.errors() if err.get("loc")})
+        # alias keys used at construction (e.g. "closeDateRange"); a loc nested
+        # under "customFilters" names the custom filter itself, not the wrapper.
+        failed = sorted(
+            {
+                str(err["loc"][1])
+                if len(err["loc"]) > 1 and err["loc"][0] == "customFilters"
+                else str(err["loc"][0])
+                for err in exc.errors()
+                if err.get("loc")
+            }
+        )
         field_list = ", ".join(failed) if failed else "<unknown>"
         raise PluginError(
-            f"Default filter(s) {field_list} failed validation: "
-            f"{exc.error_count()} error(s)",
+            f"Filter(s) {field_list} failed validation: {exc.error_count()} error(s)",
             path=f"filters.{failed[0]}" if len(failed) == 1 else "filters",
             source_value=default_fields,
             cause=exc,

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -19,17 +19,36 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, ValidationError
 
-from common_grants_sdk.schemas.pydantic.filters.base import DefaultFilter
+from common_grants_sdk.schemas.pydantic.filters.base import (
+    ArrayOperator,
+    ComparisonOperator,
+    DefaultFilter,
+    EquivalenceOperator,
+    RangeOperator,
+    StringOperator,
+)
 from common_grants_sdk.schemas.pydantic.filters.boolean import BooleanComparisonFilter
-from common_grants_sdk.schemas.pydantic.filters.date import DateComparisonFilter, DateRangeFilter
-from common_grants_sdk.schemas.pydantic.filters.money import MoneyComparisonFilter, MoneyRangeFilter
+from common_grants_sdk.schemas.pydantic.filters.date import (
+    DateComparisonFilter,
+    DateRangeFilter,
+)
+from common_grants_sdk.schemas.pydantic.filters.money import (
+    MoneyComparisonFilter,
+    MoneyRangeFilter,
+)
 from common_grants_sdk.schemas.pydantic.filters.numeric import (
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRangeFilter,
 )
-from common_grants_sdk.schemas.pydantic.filters.opportunity import OppDefaultFilters, OppFilters
-from common_grants_sdk.schemas.pydantic.filters.string import StringArrayFilter, StringComparisonFilter
+from common_grants_sdk.schemas.pydantic.filters.opportunity import (
+    OppDefaultFilters,
+    OppFilters,
+)
+from common_grants_sdk.schemas.pydantic.filters.string import (
+    StringArrayFilter,
+    StringComparisonFilter,
+)
 
 from .specs import CustomFilterSpec, CustomFilterType
 from .types import PluginError, PluginRoutes
@@ -52,51 +71,59 @@ class _FHelpers:
 
     def eq(self, value: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="eq", value=value)."""
-        return DefaultFilter(operator="eq", value=value)
+        return DefaultFilter(operator=EquivalenceOperator.EQUAL, value=value)
 
     def neq(self, value: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="neq", value=value)."""
-        return DefaultFilter(operator="neq", value=value)
+        return DefaultFilter(operator=EquivalenceOperator.NOT_EQUAL, value=value)
 
     def gt(self, value: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="gt", value=value)."""
-        return DefaultFilter(operator="gt", value=value)
+        return DefaultFilter(operator=ComparisonOperator.GREATER_THAN, value=value)
 
     def gte(self, value: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="gte", value=value)."""
-        return DefaultFilter(operator="gte", value=value)
+        return DefaultFilter(
+            operator=ComparisonOperator.GREATER_THAN_OR_EQUAL, value=value
+        )
 
     def lt(self, value: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="lt", value=value)."""
-        return DefaultFilter(operator="lt", value=value)
+        return DefaultFilter(operator=ComparisonOperator.LESS_THAN, value=value)
 
     def lte(self, value: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="lte", value=value)."""
-        return DefaultFilter(operator="lte", value=value)
+        return DefaultFilter(
+            operator=ComparisonOperator.LESS_THAN_OR_EQUAL, value=value
+        )
 
     def in_(self, value: list[Any]) -> DefaultFilter:
         """Return DefaultFilter with wire operator "in" (Python keyword workaround: f.in_)."""
-        return DefaultFilter(operator="in", value=value)
+        return DefaultFilter(operator=ArrayOperator.IN, value=value)
 
     def not_in(self, value: list[Any]) -> DefaultFilter:
         """Return DefaultFilter with wire operator "notIn" (Python f.not_in vs TS F.notIn)."""
-        return DefaultFilter(operator="notIn", value=value)
+        return DefaultFilter(operator=ArrayOperator.NOT_IN, value=value)
 
     def like(self, value: str) -> DefaultFilter:
         """Return DefaultFilter(operator="like", value=value)."""
-        return DefaultFilter(operator="like", value=value)
+        return DefaultFilter(operator=StringOperator.LIKE, value=value)
 
     def not_like(self, value: str) -> DefaultFilter:
         """Return DefaultFilter(operator="notLike", value=value)."""
-        return DefaultFilter(operator="notLike", value=value)
+        return DefaultFilter(operator=StringOperator.NOT_LIKE, value=value)
 
     def between(self, min: Any, max: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="between", value={"min": min, "max": max})."""
-        return DefaultFilter(operator="between", value={"min": min, "max": max})
+        return DefaultFilter(
+            operator=RangeOperator.BETWEEN, value={"min": min, "max": max}
+        )
 
     def outside(self, min: Any, max: Any) -> DefaultFilter:
         """Return DefaultFilter(operator="outside", value={"min": min, "max": max})."""
-        return DefaultFilter(operator="outside", value={"min": min, "max": max})
+        return DefaultFilter(
+            operator=RangeOperator.OUTSIDE, value={"min": min, "max": max}
+        )
 
 
 #: Module-level singleton — use as ``f.eq(...)``, ``f.in_([...])``, etc.
@@ -194,7 +221,9 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
     """
     for resource, methods in routes.items():
         for method, filter_specs in methods.items():
-            seen: set[str] = set()  # unreachable with dict semantics; retained for a future list-of-pairs API
+            seen: set[str] = (
+                set()
+            )  # unreachable with dict semantics; retained for a future list-of-pairs API
             for filter_name, spec in filter_specs.items():
                 path = f"routes.{resource}.{method}.{filter_name}"
                 if spec.filter_type not in FILTER_TYPE_SCHEMAS:
@@ -209,7 +238,9 @@ def validate_routes(routes: PluginRoutes) -> None:  # noqa: C901
                         path=path,
                         source_value=filter_name,
                     )
-                if filter_name in seen:  # forward-looking guard; unreachable with dict semantics
+                if (
+                    filter_name in seen
+                ):  # forward-looking guard; unreachable with dict semantics
                     raise PluginError(
                         f'Duplicate filter name "{filter_name}" in {resource}.{method}',
                         path=path,
@@ -316,8 +347,8 @@ def classify_filters(
         ``OppFilters`` wire body.  Call ``.model_dump(by_alias=True, exclude_none=True)``
         for the ADR-0012 JSON wire shape.
     """
-    registered_specs: dict[str, CustomFilterSpec] = (
-        routes.get(resource, {}).get(method, {})
+    registered_specs: dict[str, CustomFilterSpec] = routes.get(resource, {}).get(
+        method, {}
     )
 
     default_fields: dict[str, Any] = {}

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -298,12 +298,12 @@ def validate_filter_call(
                 # Already a valid DefaultFilter instance
                 return
             DefaultFilter.model_validate(value)
-        except (ValidationError, Exception) as exc:
+        except ValidationError as exc:
             raise PluginError(
                 f'Ad-hoc filter "{filter_name}" has an invalid DefaultFilter shape: {exc}',
                 path=filter_name,
                 source_value=value,
-                cause=exc if isinstance(exc, BaseException) else None,
+                cause=exc,
             ) from exc
 
 
@@ -346,6 +346,11 @@ def classify_filters(
     Returns:
         ``OppFilters`` wire body.  Call ``.model_dump(by_alias=True, exclude_none=True)``
         for the ADR-0012 JSON wire shape.
+
+    Raises:
+        PluginError: When any filter value fails validation — registered and ad-hoc
+            values at classification time, default values at ``OppFilters``
+            construction. The error surface is uniform across all three buckets.
     """
     registered_specs: dict[str, CustomFilterSpec] = routes.get(resource, {}).get(
         method, {}
@@ -361,13 +366,16 @@ def classify_filters(
             # via **kwargs because populate_by_name is not set on OppDefaultFilters.
             # Normalize: camelCase aliases stay as-is; snake_case keys are mapped to their
             # alias; keys with no alias (e.g. "status") are passed through unchanged.
+            # No validate_filter_call here: default values are validated at the wrapped
+            # OppFilters construction below, against the named field's REAL type (e.g.
+            # status → StringArrayFilter) — stricter than the permissive DefaultFilter
+            # check, and the single validation point for this bucket.
             if key in _ALIAS_TO_SNAKE:
                 # key is already the camelCase alias → use it directly
                 opp_key = key
             else:
                 # key is snake_case → convert to alias if one exists, else keep as-is
                 opp_key = _SNAKE_TO_ALIAS.get(key, key)
-            validate_filter_call(None, key, value)
             default_fields[opp_key] = value
         elif key in registered_specs:
             # Bucket 2: registered custom filter
@@ -381,7 +389,18 @@ def classify_filters(
 
     # OppFilters requires the alias form for construction (populate_by_name is not set).
     # Use "customFilters" (the alias) rather than "custom_filters" (the field name).
-    return OppFilters(
-        **default_fields,
-        customFilters=custom_buckets if custom_buckets else None,
-    )
+    # This construction is the validation point for bucket-1 (default) values — wrap
+    # pydantic failures in PluginError so the error contract is uniform across all
+    # three buckets (consumers catch `except PluginError` regardless of bucket).
+    try:
+        return OppFilters(
+            **default_fields,
+            customFilters=custom_buckets if custom_buckets else None,
+        )
+    except ValidationError as exc:
+        raise PluginError(
+            f"Default filter failed validation: {exc.error_count()} error(s)",
+            path=f"routes.{resource}.{method}",
+            source_value=default_fields,
+            cause=exc,
+        ) from exc

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -102,8 +102,8 @@ def define_plugin(
         Passed through to PluginConfig.routes unvalidated. Registration-time
         validation is explicit: call validate_routes() (extensions/filters.py)
         on the declarations, e.g. at plugin startup. classify_filters() does
-        not invoke it (matching the TS SDK, where validateRoutes is a
-        standalone check).
+        not invoke it (matching the TS custom-filters PoC design, where route
+        validation is a standalone check).
     """
     return PluginConfig(
         extensions=extensions,

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -102,8 +102,7 @@ def define_plugin(
         Passed through to PluginConfig.routes unvalidated. Registration-time
         validation is explicit: call validate_routes() (extensions/filters.py)
         on the declarations, e.g. at plugin startup. classify_filters() does
-        not invoke it (matching the TS custom-filters PoC design, where route
-        validation is a standalone check).
+        not invoke it; route validation is a standalone check.
     """
     return PluginConfig(
         extensions=extensions,

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -83,7 +83,10 @@ def define_plugin(
     schemas: Any = None,
     routes: PluginRoutes | None = None,
 ) -> PluginConfig[Any]:
-    """Create a PluginConfig consumed by the code generator.
+    """Create a PluginConfig from plugin declarations.
+
+    Schema inputs are consumed by the code generator; route-keyed filter
+    declarations are consumed by the runtime filter engine (extensions/filters.py).
 
     No compilation occurs here — inputs are stored as-is. The code generator
     (generate.py) compiles ObjectSchemasInput → ObjectSchemas by injecting

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -8,6 +8,7 @@ from typing import Any, Generic, TypeVar, overload
 from .types import (
     PluginExtensions,
     PluginExtensionsMeta,
+    PluginRoutes,
 )
 
 T = TypeVar("T")
@@ -36,6 +37,7 @@ class PluginConfig(Generic[TSchemas]):
     extensions: PluginExtensions | None = None
     meta: PluginExtensionsMeta | None = None
     schemas: TSchemas | None = None
+    routes: PluginRoutes | None = None
 
 
 @dataclass
@@ -62,6 +64,7 @@ def define_plugin(
     meta: PluginExtensionsMeta | None = ...,
     extensions: PluginExtensions | None = ...,
     schemas: None = ...,
+    routes: PluginRoutes | None = ...,
 ) -> PluginConfig[None]: ...
 
 
@@ -70,6 +73,7 @@ def define_plugin(
     meta: PluginExtensionsMeta | None = ...,
     extensions: PluginExtensions | None = ...,
     schemas: TSchemas = ...,
+    routes: PluginRoutes | None = ...,
 ) -> PluginConfig[TSchemas]: ...
 
 
@@ -77,6 +81,7 @@ def define_plugin(
     meta: PluginExtensionsMeta | None = None,
     extensions: PluginExtensions | None = None,
     schemas: Any = None,
+    routes: PluginRoutes | None = None,
 ) -> PluginConfig[Any]:
     """Create a PluginConfig consumed by the code generator.
 
@@ -88,11 +93,17 @@ def define_plugin(
     (e.g. {"Opportunity": ObjectSchemasInput[MyNative, MyCg](...) }) preserves
     those per-object generics on the returned PluginConfig rather than widening
     them to Any.
+
+    routes: optional route-keyed custom-filter declarations (DP-06).
+        Shape: {resourceName: {methodName: {filterName: CustomFilterSpec}}}.
+        Passed through to PluginConfig.routes; validated by validate_routes()
+        (extensions/filters.py) when the filter classifier is invoked.
     """
     return PluginConfig(
         extensions=extensions,
         meta=meta,
         schemas=schemas,
+        routes=routes,
     )
 
 

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -94,7 +94,7 @@ def define_plugin(
     those per-object generics on the returned PluginConfig rather than widening
     them to Any.
 
-    routes: optional route-keyed custom-filter declarations (DP-06).
+    routes: optional route-keyed custom-filter declarations.
         Shape: {resourceName: {methodName: {filterName: CustomFilterSpec}}}.
         Passed through to PluginConfig.routes; validated by validate_routes()
         (extensions/filters.py) when the filter classifier is invoked.

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -96,8 +96,11 @@ def define_plugin(
 
     routes: optional route-keyed custom-filter declarations.
         Shape: {resourceName: {methodName: {filterName: CustomFilterSpec}}}.
-        Passed through to PluginConfig.routes; validated by validate_routes()
-        (extensions/filters.py) when the filter classifier is invoked.
+        Passed through to PluginConfig.routes unvalidated. Registration-time
+        validation is explicit: call validate_routes() (extensions/filters.py)
+        on the declarations, e.g. at plugin startup. classify_filters() does
+        not invoke it (matching the TS SDK, where validateRoutes is a
+        standalone check).
     """
     return PluginConfig(
         extensions=extensions,

--- a/lib/python-sdk/common_grants_sdk/extensions/specs.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/specs.py
@@ -33,11 +33,13 @@ class CustomFilterType(StrEnum):
     MONEY_RANGE = "moneyRange"
 
 
-@dataclass
+@dataclass(frozen=True)
 class CustomFilterSpec:
     """Per-filter declaration: filter_type constrains to a known type; description is optional.
 
-    No ``value`` field — operators are derived from filter_type at classify time.
+    Frozen: a spec is an immutable declaration; mutating one after registration
+    would bypass validate_routes. No ``value`` field — the allowed operator set
+    is enforced by the filter_type's validation model at call time.
     """
 
     filter_type: CustomFilterType

--- a/lib/python-sdk/common_grants_sdk/extensions/specs.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/specs.py
@@ -18,7 +18,7 @@ ConflictStrategy = Literal["error", "first_wins", "last_wins"]
 
 
 class CustomFilterType(StrEnum):
-    """11-value enum of filter types (DP-14). Uses *Comparison/*Array/*Range wire values."""
+    """11-value enum of filter types. Uses *Comparison/*Array/*Range wire values."""
 
     STRING_COMPARISON = "stringComparison"
     STRING_ARRAY = "stringArray"
@@ -37,7 +37,7 @@ class CustomFilterType(StrEnum):
 class CustomFilterSpec:
     """Per-filter declaration: filter_type constrains to a known type; description is optional.
 
-    No ``value`` field — operators are derived from filter_type at classify time (DP-07).
+    No ``value`` field — operators are derived from filter_type at classify time.
     """
 
     filter_type: CustomFilterType

--- a/lib/python-sdk/common_grants_sdk/extensions/specs.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/specs.py
@@ -18,7 +18,7 @@ ConflictStrategy = Literal["error", "first_wins", "last_wins"]
 
 
 class CustomFilterType(StrEnum):
-    """11-value enum of filter types. Uses *Comparison/*Array/*Range wire values."""
+    """Catalog of registerable filter types. Uses *Comparison/*Array/*Range wire values."""
 
     STRING_COMPARISON = "stringComparison"
     STRING_ARRAY = "stringArray"

--- a/lib/python-sdk/common_grants_sdk/extensions/specs.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/specs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypedDict
 
 from ..schemas.pydantic.fields.custom import CustomFieldType
@@ -14,6 +15,33 @@ if TYPE_CHECKING:
     )
 
 ConflictStrategy = Literal["error", "first_wins", "last_wins"]
+
+
+class CustomFilterType(StrEnum):
+    """11-value enum of filter types (DP-14). Uses *Comparison/*Array/*Range wire values."""
+
+    STRING_COMPARISON = "stringComparison"
+    STRING_ARRAY = "stringArray"
+    NUMBER_COMPARISON = "numberComparison"
+    NUMBER_ARRAY = "numberArray"
+    NUMBER_RANGE = "numberRange"
+    INTEGER_COMPARISON = "integerComparison"
+    BOOLEAN_COMPARISON = "booleanComparison"
+    DATE_COMPARISON = "dateComparison"
+    DATE_RANGE = "dateRange"
+    MONEY_COMPARISON = "moneyComparison"
+    MONEY_RANGE = "moneyRange"
+
+
+@dataclass
+class CustomFilterSpec:
+    """Per-filter declaration: filter_type constrains to a known type; description is optional.
+
+    No ``value`` field — operators are derived from filter_type at classify time (DP-07).
+    """
+
+    filter_type: CustomFilterType
+    description: Optional[str] = None
 
 
 @dataclass

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -25,7 +25,7 @@ Handler = Callable[[Any, Any], Any]
 # Route-keyed custom-filter declaration aliases.
 # CustomFilterSpec is referenced as a forward string to keep the TYPE_CHECKING guard
 # effective at runtime — types.py already imports from specs at module level for
-# CustomFieldSpec; the guard here covers the new CustomFilterSpec reference only.
+# CustomFieldSpec; the guard here covers the CustomFilterSpec reference only.
 RouteMethodFilters = dict[str, "CustomFilterSpec"]  # {filterName: spec}
 RouteDeclarations = dict[str, RouteMethodFilters]  # {methodName: {filterName: spec}}
 PluginRoutes = dict[str, RouteDeclarations]  # {resourceName: {method: {name: spec}}}

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from .specs import CustomFieldSpec
+
+if TYPE_CHECKING:
+    from .specs import CustomFilterSpec
 
 TNative = TypeVar("TNative")
 TCommon = TypeVar("TCommon")
@@ -18,6 +21,14 @@ PluginCapability = Literal["customFields", "customFilters", "transforms", "clien
 
 # Type aliases
 Handler = Callable[[Any, Any], Any]
+
+# Route-keyed custom-filter declaration aliases (DP-06).
+# CustomFilterSpec is referenced as a forward string to keep the TYPE_CHECKING guard
+# effective at runtime — types.py already imports from specs at module level for
+# CustomFieldSpec; the guard here covers the new CustomFilterSpec reference only.
+RouteMethodFilters = dict[str, "CustomFilterSpec"]  # {filterName: spec}
+RouteDeclarations = dict[str, RouteMethodFilters]  # {methodName: {filterName: spec}}
+PluginRoutes = dict[str, RouteDeclarations]  # {resourceName: {method: {name: spec}}}
 
 
 class PluginError(Exception):

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Literal, TypeVar
+from typing import Any, Callable, Generic, Literal, NotRequired, TypedDict, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -19,10 +19,26 @@ PluginCapability = Literal["customFields", "customFilters", "transforms", "clien
 # Type aliases
 Handler = Callable[[Any, Any], Any]
 
-# Route-keyed custom-filter declaration aliases.
+# Route-keyed custom-filter declaration types, mirroring the TS SDK shape:
+# PluginRoutes = {resourceName: {methodName: RouteDeclarations}}.
 RouteMethodFilters = dict[str, CustomFilterSpec]  # {filterName: spec}
-RouteDeclarations = dict[str, RouteMethodFilters]  # {methodName: {filterName: spec}}
-PluginRoutes = dict[str, RouteDeclarations]  # {resourceName: {method: {name: spec}}}
+
+
+class RouteDeclarations(TypedDict):
+    """Filter declarations for a single route method (e.g. ``search``).
+
+    Filters are keyed by name and the key is optional — a method may appear
+    in the route map with no filter declarations, and future declaration
+    kinds can ride alongside ``filters`` without a shape change. Mirrors the
+    TS SDK's ``RouteDeclarations`` interface.
+    """
+
+    filters: NotRequired[RouteMethodFilters]
+
+
+PluginRoutes = dict[
+    str, dict[str, RouteDeclarations]
+]  # {resource: {method: declarations}}
 
 
 class PluginError(Exception):

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -3,14 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Generic, Literal, TypeVar
+from typing import Any, Callable, Generic, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from .specs import CustomFieldSpec
-
-if TYPE_CHECKING:
-    from .specs import CustomFilterSpec
+from .specs import CustomFieldSpec, CustomFilterSpec
 
 TNative = TypeVar("TNative")
 TCommon = TypeVar("TCommon")
@@ -23,10 +20,7 @@ PluginCapability = Literal["customFields", "customFilters", "transforms", "clien
 Handler = Callable[[Any, Any], Any]
 
 # Route-keyed custom-filter declaration aliases.
-# CustomFilterSpec is referenced as a forward string to keep the TYPE_CHECKING guard
-# effective at runtime — types.py already imports from specs at module level for
-# CustomFieldSpec; the guard here covers the CustomFilterSpec reference only.
-RouteMethodFilters = dict[str, "CustomFilterSpec"]  # {filterName: spec}
+RouteMethodFilters = dict[str, CustomFilterSpec]  # {filterName: spec}
 RouteDeclarations = dict[str, RouteMethodFilters]  # {methodName: {filterName: spec}}
 PluginRoutes = dict[str, RouteDeclarations]  # {resourceName: {method: {name: spec}}}
 

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -27,10 +27,9 @@ RouteMethodFilters = dict[str, CustomFilterSpec]  # {filterName: spec}
 class RouteDeclarations(TypedDict):
     """Filter declarations for a single route method (e.g. ``search``).
 
-    Filters are keyed by name and the key is optional — a method may appear
-    in the route map with no filter declarations, and future declaration
-    kinds can ride alongside ``filters`` without a shape change. Mirrors the
-    TS SDK's ``RouteDeclarations`` interface.
+    ``filters`` maps filter name → ``CustomFilterSpec`` and is optional: a
+    method may appear in the route map with no declarations. Mirrors the TS
+    SDK's ``RouteDeclarations`` interface.
     """
 
     filters: NotRequired[RouteMethodFilters]

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -28,8 +28,7 @@ class RouteDeclarations(TypedDict):
     """Filter declarations for a single route method (e.g. ``search``).
 
     ``filters`` maps filter name → ``CustomFilterSpec`` and is optional: a
-    method may appear in the route map with no declarations. Mirrors the TS
-    SDK's ``RouteDeclarations`` interface.
+    method may appear in the route map with no declarations.
     """
 
     filters: NotRequired[RouteMethodFilters]

--- a/lib/python-sdk/common_grants_sdk/extensions/types.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/types.py
@@ -22,7 +22,7 @@ PluginCapability = Literal["customFields", "customFilters", "transforms", "clien
 # Type aliases
 Handler = Callable[[Any, Any], Any]
 
-# Route-keyed custom-filter declaration aliases (DP-06).
+# Route-keyed custom-filter declaration aliases.
 # CustomFilterSpec is referenced as a forward string to keep the TYPE_CHECKING guard
 # effective at runtime — types.py already imports from specs at module level for
 # CustomFieldSpec; the guard here covers the new CustomFilterSpec reference only.

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/__init__.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/__init__.py
@@ -21,6 +21,7 @@ __all__ = [  # noqa: RUF022
     # Boolean Filters
     "BooleanComparisonFilter",
     # Numeric Filters
+    "IntegerComparisonFilter",
     "NumberArrayFilter",
     "NumberComparisonFilter",
     "NumberRange",
@@ -54,6 +55,7 @@ from .money import (
     InvalidMoneyValueError,
 )
 from .numeric import (
+    IntegerComparisonFilter,
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRange,

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/__init__.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/__init__.py
@@ -18,6 +18,8 @@ __all__ = [  # noqa: RUF022
     "MoneyComparisonFilter",
     "MoneyRange",
     "MoneyRangeFilter",
+    # Boolean Filters
+    "BooleanComparisonFilter",
     # Numeric Filters
     "NumberArrayFilter",
     "NumberComparisonFilter",
@@ -39,6 +41,7 @@ from .base import (
     RangeOperator,
     StringOperator,
 )
+from .boolean import BooleanComparisonFilter
 from .date import (
     DateComparisonFilter,
     DateRange,

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/__init__.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/__init__.py
@@ -21,7 +21,6 @@ __all__ = [  # noqa: RUF022
     # Boolean Filters
     "BooleanComparisonFilter",
     # Numeric Filters
-    "IntegerComparisonFilter",
     "NumberArrayFilter",
     "NumberComparisonFilter",
     "NumberRange",
@@ -55,7 +54,6 @@ from .money import (
     InvalidMoneyValueError,
 )
 from .numeric import (
-    IntegerComparisonFilter,
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRange,

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/base.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/base.py
@@ -1,7 +1,7 @@
 """Filter models for the CommonGrants API."""
 
 from enum import StrEnum
-from typing import Union
+from typing import Any, Union
 
 from pydantic import Field, field_validator
 
@@ -64,7 +64,11 @@ class DefaultFilter(CommonGrantsBaseModel):
         StringOperator,
         RangeOperator,
     ] = Field(..., description="The operator to apply to the filter value")
-    value: Union[str, int, float, list, dict] = Field(
+    # Core spec (filters/base.tsp) declares `value: unknown` — any narrowing here
+    # diverges from the contract and mutates inputs (e.g. a union without `bool`
+    # lax-coerces True → 1). Strict per-type checking belongs to the typed filter
+    # models (StringArrayFilter, IntegerComparisonFilter, ...), not this base.
+    value: Any = Field(
         ...,
         description="The value to use for the filter operation",
     )

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/base.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/base.py
@@ -67,7 +67,7 @@ class DefaultFilter(CommonGrantsBaseModel):
     # Core spec (filters/base.tsp) declares `value: unknown` — any narrowing here
     # diverges from the contract and mutates inputs (e.g. a union without `bool`
     # lax-coerces True → 1). Strict per-type checking belongs to the typed filter
-    # models (StringArrayFilter, IntegerComparisonFilter, ...), not this base.
+    # models (StringArrayFilter, NumberComparisonFilter, ...), not this base.
     value: Any = Field(
         ...,
         description="The value to use for the filter operation",

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
@@ -1,0 +1,24 @@
+"""Boolean filter schemas."""
+
+from pydantic import Field, field_validator
+
+from ..base import CommonGrantsBaseModel
+from .base import EquivalenceOperator
+
+
+class BooleanComparisonFilter(CommonGrantsBaseModel):
+    """Filter that matches a boolean value for equality (eq | neq)."""
+
+    operator: EquivalenceOperator = Field(
+        ...,
+        description="The operator to apply to the filter value",
+    )
+    value: bool = Field(..., description="The boolean value to compare against")
+
+    @field_validator("operator", mode="before")
+    @classmethod
+    def validate_operator(cls, v):
+        """Convert string to enum if needed."""
+        if isinstance(v, str):
+            return EquivalenceOperator(v)
+        return v

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
@@ -9,8 +9,8 @@ from .base import EquivalenceOperator
 class BooleanComparisonFilter(CommonGrantsBaseModel):
     """Filter that matches a boolean value for equality (eq | neq).
 
-    Strict boolean: 1/0 and "true"/"false" are rejected (mirrors the TS SDK's
-    BooleanComparisonFilterSchema, where ``z.boolean()`` rejects both).
+    Strict boolean: 1/0 and "true"/"false" are rejected, matching Zod
+    ``z.boolean()`` semantics in the schema surface planned for the TS SDK.
     """
 
     operator: EquivalenceOperator = Field(

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
@@ -1,19 +1,23 @@
 """Boolean filter schemas."""
 
-from pydantic import Field, field_validator
+from pydantic import Field, StrictBool, field_validator
 
 from ..base import CommonGrantsBaseModel
 from .base import EquivalenceOperator
 
 
 class BooleanComparisonFilter(CommonGrantsBaseModel):
-    """Filter that matches a boolean value for equality (eq | neq)."""
+    """Filter that matches a boolean value for equality (eq | neq).
+
+    Strict boolean: 1/0 and "true"/"false" are rejected (mirrors the TS SDK's
+    BooleanComparisonFilterSchema, where ``z.boolean()`` rejects both).
+    """
 
     operator: EquivalenceOperator = Field(
         ...,
         description="The operator to apply to the filter value",
     )
-    value: bool = Field(..., description="The boolean value to compare against")
+    value: StrictBool = Field(..., description="The boolean value to compare against")
 
     @field_validator("operator", mode="before")
     @classmethod

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
@@ -9,8 +9,11 @@ from .base import EquivalenceOperator
 class BooleanComparisonFilter(CommonGrantsBaseModel):
     """Filter that matches a boolean value for equality (eq | neq).
 
-    Strict boolean: 1/0 and "true"/"false" are rejected, matching Zod
-    ``z.boolean()`` semantics in the schema surface planned for the TS SDK.
+    Strict boolean: 1/0 and "true"/"false" are rejected, matching the Zod
+    ``z.boolean()`` semantics of the TS SDK's ``BooleanComparisonFilterSchema``.
+
+    No spec model backs this filter yet: the core spec defines no boolean
+    filter, so both SDKs carry an SDK-level model until one lands.
     """
 
     operator: EquivalenceOperator = Field(

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
@@ -8,6 +8,7 @@ from ..base import CommonGrantsBaseModel
 from .base import (
     ArrayOperator,
     ComparisonOperator,
+    EquivalenceOperator,
     RangeOperator,
 )
 
@@ -24,9 +25,13 @@ class NumberRange(CommonGrantsBaseModel):
 
 
 class NumberComparisonFilter(CommonGrantsBaseModel):
-    """Filter that matches numbers against a specific value."""
+    """Filter that matches numbers against a specific value.
 
-    operator: ComparisonOperator = Field(
+    Accepts equivalence operators (``eq``/``neq``) in addition to comparison
+    operators, per the core spec (filters/numeric.tsp, since protocol v0.3).
+    """
+
+    operator: ComparisonOperator | EquivalenceOperator = Field(
         ...,
         description="The comparison operator to apply to the filter value",
     )
@@ -39,19 +44,26 @@ class NumberComparisonFilter(CommonGrantsBaseModel):
     def validate_operator(cls, v):
         """Convert string to enum if needed."""
         if isinstance(v, str):
-            return ComparisonOperator(v)
+            if v in [op.value for op in ComparisonOperator]:
+                return ComparisonOperator(v)
+            elif v in [op.value for op in EquivalenceOperator]:
+                return EquivalenceOperator(v)
         return v
 
 
 class IntegerComparisonFilter(CommonGrantsBaseModel):
     """Filter that matches integers against a specific value.
 
-    Strict integer: fractional values and numeric strings are rejected
-    (mirrors the TS SDK's IntegerComparisonFilterSchema, where
-    ``z.number().int()`` rejects both).
+    Operator surface matches ``NumberComparisonFilter`` (comparison plus
+    ``eq``/``neq``), as in the TS SDK's IntegerComparisonFilterSchema.
+
+    Strict integer: fractional values and numeric strings are rejected, as in
+    the TS SDK (``z.number().int()``). Stricter than TS on integral floats:
+    ``100.0`` is rejected here but is indistinguishable from ``100`` in
+    JavaScript.
     """
 
-    operator: ComparisonOperator = Field(
+    operator: ComparisonOperator | EquivalenceOperator = Field(
         ...,
         description="The comparison operator to apply to the filter value",
     )
@@ -62,7 +74,10 @@ class IntegerComparisonFilter(CommonGrantsBaseModel):
     def validate_operator(cls, v):
         """Convert string to enum if needed."""
         if isinstance(v, str):
-            return ComparisonOperator(v)
+            if v in [op.value for op in ComparisonOperator]:
+                return ComparisonOperator(v)
+            elif v in [op.value for op in EquivalenceOperator]:
+                return EquivalenceOperator(v)
         return v
 
 

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
@@ -17,11 +17,30 @@ from .base import (
 # ############################################################
 
 
+def _ensure_not_bool(v: object) -> object:
+    """Reject bool before union coercion.
+
+    bool subclasses int in Python, so a ``Union[int, float]`` field
+    lax-coerces ``True`` -> ``1`` and a boolean silently ships as a number —
+    the same wire corruption ``DefaultFilter.value: Any`` guards against.
+    ``z.number()`` rejects booleans, so rejection keeps the SDKs aligned.
+    """
+    if isinstance(v, bool):
+        raise ValueError("value must be a number, not a bool")
+    return v
+
+
 class NumberRange(CommonGrantsBaseModel):
     """Represents a range between two numeric values."""
 
     min: Union[int, float] = Field(..., description="The minimum value in the range")
     max: Union[int, float] = Field(..., description="The maximum value in the range")
+
+    @field_validator("min", "max", mode="before")
+    @classmethod
+    def reject_bool(cls, v):
+        """Reject bool min/max (would lax-coerce to 1/0; see _ensure_not_bool)."""
+        return _ensure_not_bool(v)
 
 
 class NumberComparisonFilter(CommonGrantsBaseModel):
@@ -49,6 +68,12 @@ class NumberComparisonFilter(CommonGrantsBaseModel):
             elif v in [op.value for op in EquivalenceOperator]:
                 return EquivalenceOperator(v)
         return v
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def reject_bool(cls, v):
+        """Reject bool values (would lax-coerce to 1/0; see _ensure_not_bool)."""
+        return _ensure_not_bool(v)
 
 
 class IntegerComparisonFilter(CommonGrantsBaseModel):
@@ -116,4 +141,13 @@ class NumberArrayFilter(CommonGrantsBaseModel):
         """Convert string to enum if needed."""
         if isinstance(v, str):
             return ArrayOperator(v)
+        return v
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def reject_bool_items(cls, v):
+        """Reject bool items (each would lax-coerce to 1/0; see _ensure_not_bool)."""
+        if isinstance(v, list):
+            for item in v:
+                _ensure_not_bool(item)
         return v

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
@@ -80,12 +80,12 @@ class IntegerComparisonFilter(CommonGrantsBaseModel):
     """Filter that matches integers against a specific value.
 
     Operator surface matches ``NumberComparisonFilter`` (comparison plus
-    ``eq``/``neq``), as in the TS SDK's IntegerComparisonFilterSchema.
+    ``eq``/``neq``), as in the schema surface planned for the TS SDK.
 
-    Strict integer: fractional values and numeric strings are rejected, as in
-    the TS SDK (``z.number().int()``). Stricter than TS on integral floats:
-    ``100.0`` is rejected here but is indistinguishable from ``100`` in
-    JavaScript.
+    Strict integer: fractional values and numeric strings are rejected, as Zod
+    ``z.number().int()`` does in the planned TS counterpart. Stricter than TS
+    on integral floats: ``100.0`` is rejected here but is indistinguishable
+    from ``100`` in JavaScript.
     """
 
     operator: ComparisonOperator | EquivalenceOperator = Field(

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
@@ -2,7 +2,7 @@
 
 from typing import Union
 
-from pydantic import Field, field_validator
+from pydantic import Field, StrictInt, field_validator
 
 from ..base import CommonGrantsBaseModel
 from .base import (
@@ -32,6 +32,31 @@ class NumberComparisonFilter(CommonGrantsBaseModel):
     )
     value: Union[int, float] = Field(
         ..., description="The numeric value to compare against"
+    )
+
+    @field_validator("operator", mode="before")
+    @classmethod
+    def validate_operator(cls, v):
+        """Convert string to enum if needed."""
+        if isinstance(v, str):
+            return ComparisonOperator(v)
+        return v
+
+
+class IntegerComparisonFilter(CommonGrantsBaseModel):
+    """Filter that matches integers against a specific value.
+
+    Strict integer: fractional values and numeric strings are rejected
+    (mirrors the TS SDK's IntegerComparisonFilterSchema, where
+    ``z.number().int()`` rejects both).
+    """
+
+    operator: ComparisonOperator = Field(
+        ...,
+        description="The comparison operator to apply to the filter value",
+    )
+    value: StrictInt = Field(
+        ..., description="The integer value to compare against"
     )
 
     @field_validator("operator", mode="before")

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
@@ -55,9 +55,7 @@ class IntegerComparisonFilter(CommonGrantsBaseModel):
         ...,
         description="The comparison operator to apply to the filter value",
     )
-    value: StrictInt = Field(
-        ..., description="The integer value to compare against"
-    )
+    value: StrictInt = Field(..., description="The integer value to compare against")
 
     @field_validator("operator", mode="before")
     @classmethod

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py
@@ -2,7 +2,7 @@
 
 from typing import Union
 
-from pydantic import Field, StrictInt, field_validator
+from pydantic import Field, field_validator
 
 from ..base import CommonGrantsBaseModel
 from .base import (
@@ -74,36 +74,6 @@ class NumberComparisonFilter(CommonGrantsBaseModel):
     def reject_bool(cls, v):
         """Reject bool values (would lax-coerce to 1/0; see _ensure_not_bool)."""
         return _ensure_not_bool(v)
-
-
-class IntegerComparisonFilter(CommonGrantsBaseModel):
-    """Filter that matches integers against a specific value.
-
-    Operator surface matches ``NumberComparisonFilter`` (comparison plus
-    ``eq``/``neq``), as in the schema surface planned for the TS SDK.
-
-    Strict integer: fractional values and numeric strings are rejected, as Zod
-    ``z.number().int()`` does in the planned TS counterpart. Stricter than TS
-    on integral floats: ``100.0`` is rejected here but is indistinguishable
-    from ``100`` in JavaScript.
-    """
-
-    operator: ComparisonOperator | EquivalenceOperator = Field(
-        ...,
-        description="The comparison operator to apply to the filter value",
-    )
-    value: StrictInt = Field(..., description="The integer value to compare against")
-
-    @field_validator("operator", mode="before")
-    @classmethod
-    def validate_operator(cls, v):
-        """Convert string to enum if needed."""
-        if isinstance(v, str):
-            if v in [op.value for op in ComparisonOperator]:
-                return ComparisonOperator(v)
-            elif v in [op.value for op in EquivalenceOperator]:
-                return EquivalenceOperator(v)
-        return v
 
 
 class NumberRangeFilter(CommonGrantsBaseModel):

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Custom filters example — codegen-free ADR-0012 request-body demo.
+"""Custom filters example — codegen-free request-body demo.
 
 Demonstrates route-keyed custom filter declaration, flat call-site classification,
-and the three-bucket ADR-0012 request body (default named fields + customFilters record)
+and the three-bucket ``OppFilters`` request body (default named fields + customFilters record)
 using the grants.gov canonical example from #646/#869.
 
 No code generation (custom filters are a pure-runtime classifier).  The example
@@ -91,7 +91,7 @@ def main() -> None:
         grants_gov.routes, "opportunities", "search", consumer_filters
     )
 
-    print("\nRequest body (ADR-0012, by_alias=True, exclude_none=True, mode='json'):")
+    print("\nRequest body (by_alias=True, exclude_none=True, mode='json'):")
     print(
         json.dumps(
             request_body.model_dump(by_alias=True, exclude_none=True, mode="json"),

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Custom filters PoC — codegen-free ADR-0012 wire body demo.
+"""Custom filters example — codegen-free ADR-0012 wire body demo.
 
 Demonstrates route-keyed custom filter declaration, flat call-site classification,
 and the three-bucket ADR-0012 wire body (default named fields + customFilters record)
@@ -21,7 +21,7 @@ from common_grants_sdk.extensions.specs import CustomFilterSpec, CustomFilterTyp
 from common_grants_sdk.extensions.types import PluginError, PluginExtensionsMeta
 
 # ---------------------------------------------------------------------------
-# Plugin declaration — route-keyed custom filter specs (CFP-01, DP-06)
+# Plugin declaration — route-keyed custom filter specs
 # ---------------------------------------------------------------------------
 
 grants_gov = define_plugin(
@@ -93,7 +93,7 @@ def main() -> None:
     )
 
     # --- PluginError demo — bad call raises and is caught ---
-    _section("VALIDATION — bad operator raises PluginError (runtime guarantee, CFP-04)")
+    _section("VALIDATION — bad operator raises PluginError (runtime guarantee)")
 
     # agency is registered as STRING_ARRAY (expects ArrayOperator: in/notIn).
     # Passing f.eq(...) (EquivalenceOperator.EQUAL) triggers call-time validation failure.

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -108,7 +108,12 @@ def main() -> None:
     try:
         classify_filters(grants_gov.routes, "opportunities", "search", bad_filters)
     except PluginError as exc:
+        # str(exc) summarizes the first failure; the structured fields carry
+        # the full detail — exc.path names the failing filter, exc.cause is
+        # the underlying pydantic ValidationError for programmatic access.
         print(f"PluginError caught: {exc}")
+        print(f"  path:  {exc.path}")
+        print(f"  cause: {type(exc.cause).__name__}")
 
     # --- Plugin metadata ---
     _section("PLUGIN METADATA")

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Custom filters PoC — codegen-free ADR-0012 wire body demo.
+
+Demonstrates route-keyed custom filter declaration, flat call-site classification,
+and the three-bucket ADR-0012 wire body (default named fields + customFilters record)
+using the grants.gov canonical example from #646/#869.
+
+No code generation (custom filters are a pure-runtime classifier).  The example
+imports directly from ``common_grants_sdk.extensions`` — no codegen schemas needed.
+
+Run (from lib/python-sdk/):
+    poetry run python examples/custom_filters.py
+"""
+
+from __future__ import annotations
+
+import json
+
+from common_grants_sdk.extensions import classify_filters, define_plugin, f
+from common_grants_sdk.extensions.specs import CustomFilterSpec, CustomFilterType
+from common_grants_sdk.extensions.types import PluginError, PluginExtensionsMeta
+
+# ---------------------------------------------------------------------------
+# Plugin declaration — route-keyed custom filter specs (CFP-01, DP-06)
+# ---------------------------------------------------------------------------
+
+grants_gov = define_plugin(
+    meta=PluginExtensionsMeta(
+        name="grants-gov",
+        version="0.1.0",
+        sourceSystem="grants.gov",
+        capabilities=["customFilters"],
+    ),
+    routes={
+        "opportunities": {
+            "search": {
+                "agency": CustomFilterSpec(filter_type=CustomFilterType.STRING_ARRAY),
+                "fundingProgram": CustomFilterSpec(
+                    filter_type=CustomFilterType.STRING_COMPARISON,
+                    description="Program name filter",
+                ),
+            }
+        }
+    },
+)
+
+
+def _section(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(title)
+    print("=" * 60)
+
+
+def main() -> None:
+    # --- Declared routes ---
+    _section("PLUGIN ROUTES (declared)")
+    if grants_gov.routes:
+        for resource, methods in grants_gov.routes.items():
+            for method, filters in methods.items():
+                print(f"  {resource}.{method}:")
+                for name, spec in filters.items():
+                    desc = f" — {spec.description}" if spec.description else ""
+                    print(f"    {name}: {spec.filter_type.value}{desc}")
+
+    # --- Classify: default + registered custom + ad-hoc ---
+    _section("CLASSIFY FILTERS — default + custom + ad-hoc (canonical grants.gov demo)")
+
+    # Mixing three kinds of filters in a single flat dict:
+    #   "status"         — default core filter (snake_case key)
+    #   "closeDateRange" — default core filter (camelCase alias key — the alias-landmine case)
+    #   "agency"         — registered custom filter (routes.opportunities.search.agency)
+    #   "fundingProgram" — registered custom filter (routes.opportunities.search.fundingProgram)
+    #   "legacyTag"      — ad-hoc passthrough (not registered, not a core default)
+    consumer_filters = {
+        "status": f.in_(["open", "forecasted"]),
+        "closeDateRange": f.between("2026-01-01", "2026-12-31"),
+        "agency": f.in_(["NSF", "NIH"]),
+        "fundingProgram": f.eq("research-grants"),
+        "legacyTag": f.eq("priority"),
+    }
+
+    assert grants_gov.routes is not None
+    wire_body = classify_filters(
+        grants_gov.routes, "opportunities", "search", consumer_filters
+    )
+
+    print("\nWire body (ADR-0012, by_alias=True, exclude_none=True, mode='json'):")
+    print(
+        json.dumps(
+            wire_body.model_dump(by_alias=True, exclude_none=True, mode="json"),
+            indent=2,
+        )
+    )
+
+    # --- PluginError demo — bad call raises and is caught ---
+    _section("VALIDATION — bad operator raises PluginError (runtime guarantee, CFP-04)")
+
+    # agency is registered as STRING_ARRAY (expects ArrayOperator: in/notIn).
+    # Passing f.eq(...) (EquivalenceOperator.EQUAL) triggers call-time validation failure.
+    bad_filters = {
+        "agency": f.eq(
+            "wrong-operator-for-array-type"
+        ),  # eq is not a valid STRING_ARRAY op
+    }
+    try:
+        classify_filters(grants_gov.routes, "opportunities", "search", bad_filters)
+    except PluginError as exc:
+        print(f"PluginError caught: {exc}")
+
+    # --- Plugin metadata ---
+    _section("PLUGIN METADATA")
+    if grants_gov.meta:
+        print(f"name:         {grants_gov.meta.name}")
+        print(f"version:      {grants_gov.meta.version}")
+        print(f"sourceSystem: {grants_gov.meta.source_system}")
+        print(f"capabilities: {grants_gov.meta.capabilities}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -66,14 +66,17 @@ def main() -> None:
     _section("CLASSIFY FILTERS — default + custom + ad-hoc (canonical grants.gov demo)")
 
     # Mixing three kinds of filters in a single flat dict:
-    #   "status"         — default core filter (snake_case key)
-    #   "closeDateRange" — default core filter (camelCase alias key — the alias-landmine case)
+    #   "status"            — default core filter (snake_case key, no alias)
+    #   "close_date_range"  — default core filter, snake_case key for an ALIASED field:
+    #                         the classifier must normalize it to "closeDateRange" in the
+    #                         wire body (an unnormalized snake key would silently land in
+    #                         customFilters — the alias landmine)
     #   "agency"         — registered custom filter (routes.opportunities.search.agency)
     #   "fundingProgram" — registered custom filter (routes.opportunities.search.fundingProgram)
     #   "legacyTag"      — ad-hoc passthrough (not registered, not a core default)
     consumer_filters = {
         "status": f.in_(["open", "forecasted"]),
-        "closeDateRange": f.between("2026-01-01", "2026-12-31"),
+        "close_date_range": f.between("2026-01-01", "2026-12-31"),
         "agency": f.in_(["NSF", "NIH"]),
         "fundingProgram": f.eq("research-grants"),
         "legacyTag": f.eq("priority"),

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Custom filters example — codegen-free ADR-0012 wire body demo.
+"""Custom filters example — codegen-free ADR-0012 request-body demo.
 
 Demonstrates route-keyed custom filter declaration, flat call-site classification,
-and the three-bucket ADR-0012 wire body (default named fields + customFilters record)
+and the three-bucket ADR-0012 request body (default named fields + customFilters record)
 using the grants.gov canonical example from #646/#869.
 
 No code generation (custom filters are a pure-runtime classifier).  The example
@@ -80,14 +80,14 @@ def main() -> None:
     }
 
     assert grants_gov.routes is not None
-    wire_body = classify_filters(
+    request_body = classify_filters(
         grants_gov.routes, "opportunities", "search", consumer_filters
     )
 
-    print("\nWire body (ADR-0012, by_alias=True, exclude_none=True, mode='json'):")
+    print("\nRequest body (ADR-0012, by_alias=True, exclude_none=True, mode='json'):")
     print(
         json.dumps(
-            wire_body.model_dump(by_alias=True, exclude_none=True, mode="json"),
+            request_body.model_dump(by_alias=True, exclude_none=True, mode="json"),
             indent=2,
         )
     )

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -34,11 +34,15 @@ grants_gov = define_plugin(
     routes={
         "opportunities": {
             "search": {
-                "agency": CustomFilterSpec(filter_type=CustomFilterType.STRING_ARRAY),
-                "fundingProgram": CustomFilterSpec(
-                    filter_type=CustomFilterType.STRING_COMPARISON,
-                    description="Program name filter",
-                ),
+                "filters": {
+                    "agency": CustomFilterSpec(
+                        filter_type=CustomFilterType.STRING_ARRAY
+                    ),
+                    "fundingProgram": CustomFilterSpec(
+                        filter_type=CustomFilterType.STRING_COMPARISON,
+                        description="Program name filter",
+                    ),
+                }
             }
         }
     },
@@ -56,9 +60,9 @@ def main() -> None:
     _section("PLUGIN ROUTES (declared)")
     if grants_gov.routes:
         for resource, methods in grants_gov.routes.items():
-            for method, filters in methods.items():
+            for method, declarations in methods.items():
                 print(f"  {resource}.{method}:")
-                for name, spec in filters.items():
+                for name, spec in declarations.get("filters", {}).items():
                     desc = f" — {spec.description}" if spec.description else ""
                     print(f"    {name}: {spec.filter_type.value}{desc}")
 

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -69,8 +69,8 @@ def main() -> None:
     #   "status"            — default core filter (snake_case key, no alias)
     #   "close_date_range"  — default core filter, snake_case key for an ALIASED field:
     #                         the classifier must normalize it to "closeDateRange" in the
-    #                         wire body (an unnormalized snake key would silently land in
-    #                         customFilters — the alias landmine)
+    #                         wire body (an unnormalized snake key would be silently
+    #                         dropped from the wire body — the alias landmine)
     #   "agency"         — registered custom filter (routes.opportunities.search.agency)
     #   "fundingProgram" — registered custom filter (routes.opportunities.search.fundingProgram)
     #   "legacyTag"      — ad-hoc passthrough (not registered, not a core default)

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -467,14 +467,29 @@ def test_boolean_filter_value_survives_to_wire_as_json_true():
 def test_registered_filter_ships_validated_value_not_raw_input():
     """The wire body carries the value that passed validation, not the raw input.
 
-    NumberComparisonFilter lax-coerces "42" -> 42.0; shipping the raw string
-    would mean the payload differs from what validation approved.
+    NumberComparisonFilter lax-coerces "42" -> 42 (smart-union resolves the
+    int|float union to int first); shipping the raw string would mean the
+    payload differs from what validation approved.
     """
     result = classify_filters(
         WIRE_ROUTES, "opportunities", "search", {"awardCount": f.gt("42")}
     )
     body = result.model_dump(by_alias=True, exclude_none=True, mode="json")
-    assert body["customFilters"]["awardCount"]["value"] == 42.0
+    assert body["customFilters"]["awardCount"]["value"] == 42
+    assert isinstance(body["customFilters"]["awardCount"]["value"], int)
+
+
+def test_number_comparison_registered_filter_rejects_bool():
+    """f.eq(True) on a numberComparison-registered filter raises, never ships 1.
+
+    bool subclasses int; without an explicit rejection the int|float union
+    lax-coerces True -> 1 and the wire silently carries a number for a
+    boolean — the corruption class the DefaultFilter.value widening fixed.
+    """
+    with pytest.raises(PluginError):
+        classify_filters(
+            WIRE_ROUTES, "opportunities", "search", {"awardCount": f.eq(True)}
+        )
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")  # pydantic warns during the

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -343,6 +343,23 @@ def test_classify_default_wrong_shape_raises_plugin_error():
     assert isinstance(exc_info.value.__cause__, ValidationError)
 
 
+def test_validate_filter_call_integer_comparison_rejects_non_integer():
+    """A registered integerComparison filter raises PluginError for a fractional value.
+
+    integerComparison validates against IntegerComparisonFilter (strict int),
+    not the looser NumberComparisonFilter.
+    """
+    spec = CustomFilterSpec(filter_type=CustomFilterType.INTEGER_COMPARISON)
+    with pytest.raises(PluginError):
+        validate_filter_call(spec, "awardCount", f.gt(100.5))
+
+
+def test_validate_filter_call_integer_comparison_passes_valid_int():
+    """A registered integerComparison filter accepts an integer value."""
+    spec = CustomFilterSpec(filter_type=CustomFilterType.INTEGER_COMPARISON)
+    validate_filter_call(spec, "awardCount", f.gt(100))
+
+
 def test_classify_default_camel_alias_wrong_shape_raises_plugin_error():
     """A wrong-shaped default filter via its camelCase alias also raises PluginError.
 

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -245,10 +245,9 @@ def test_oppfilters_mixed_case_roundtrip():
 
 def test_validate_routes_unknown_filter_type_raises():
     """validate_routes raises PluginError when filter_type is not in FILTER_TYPE_SCHEMAS."""
-    # Manually construct a spec with a bogus filter_type bypassing the enum
-    bad_spec = CustomFilterSpec.__new__(CustomFilterSpec)
-    object.__setattr__(bad_spec, "filter_type", "unknownType")  # type: ignore[arg-type]
-    object.__setattr__(bad_spec, "description", None)
+    # Dataclasses don't validate field types at runtime, so a bogus filter_type
+    # can be passed directly (the annotation is for type checkers only).
+    bad_spec = CustomFilterSpec(filter_type="unknownType")  # type: ignore[arg-type]
 
     routes = {"opportunities": {"search": {"myFilter": bad_spec}}}
     with pytest.raises(PluginError, match="Unknown filter_type"):

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -1,0 +1,308 @@
+"""Tests for classify_filters, f helpers, validate_routes, and validate_filter_call
+in common_grants_sdk.extensions.filters."""
+
+from __future__ import annotations
+
+import pytest
+from common_grants_sdk.extensions.filters import (
+    classify_filters,
+    f,
+    validate_filter_call,
+    validate_routes,
+)
+from common_grants_sdk.extensions.specs import CustomFilterSpec, CustomFilterType
+from common_grants_sdk.extensions.types import PluginError
+from common_grants_sdk.schemas.pydantic.filters.opportunity import OppFilters
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+AGENCY_SPEC = CustomFilterSpec(filter_type=CustomFilterType.STRING_ARRAY)
+FUNDING_PROGRAM_SPEC = CustomFilterSpec(
+    filter_type=CustomFilterType.STRING_COMPARISON,
+    description="Program name filter",
+)
+
+SAMPLE_ROUTES = {
+    "opportunities": {
+        "search": {
+            "agency": AGENCY_SPEC,
+            "fundingProgram": FUNDING_PROGRAM_SPEC,
+        }
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# f.* helpers
+# ---------------------------------------------------------------------------
+
+
+def test_f_eq():
+    """f.eq returns DefaultFilter with operator "eq"."""
+    flt = f.eq("open")
+    assert flt.operator == "eq"
+    assert flt.value == "open"
+
+
+def test_f_neq():
+    """f.neq returns DefaultFilter with operator "neq"."""
+    flt = f.neq("closed")
+    assert flt.operator == "neq"
+    assert flt.value == "closed"
+
+
+def test_f_gt():
+    """f.gt returns DefaultFilter with operator "gt"."""
+    flt = f.gt(100)
+    assert flt.operator == "gt"
+    assert flt.value == 100
+
+
+def test_f_like():
+    """f.like returns DefaultFilter with operator "like"."""
+    flt = f.like("%grants%")
+    assert flt.operator == "like"
+    assert flt.value == "%grants%"
+
+
+def test_f_in_uses_wire_value():
+    """f.in_ uses reserved-word workaround; wire operator is "in" (not "in_")."""
+    flt = f.in_(["NSF", "NIH"])
+    assert flt.operator == "in"
+    assert flt.value == ["NSF", "NIH"]
+
+
+def test_f_not_in_uses_camel_wire_value():
+    """f.not_in produces wire operator "notIn" (Python f.not_in vs TS F.notIn divergence)."""
+    flt = f.not_in(["archived"])
+    assert flt.operator == "notIn"
+    assert flt.value == ["archived"]
+
+
+def test_f_between():
+    """f.between produces operator "between" and {"min": a, "max": b} value."""
+    flt = f.between("2026-01-01", "2026-12-31")
+    assert flt.operator == "between"
+    assert flt.value == {"min": "2026-01-01", "max": "2026-12-31"}
+
+
+def test_f_outside():
+    """f.outside produces operator "outside" and {"min": a, "max": b} value."""
+    flt = f.outside(0, 50)
+    assert flt.operator == "outside"
+    assert flt.value == {"min": 0, "max": 50}
+
+
+# ---------------------------------------------------------------------------
+# classify_filters: three-bucket classification
+# ---------------------------------------------------------------------------
+
+
+def test_classify_default_snake_key_lands_in_named_field():
+    """Default snake_case key (e.g. "status") lands in a named OppFilters field, not customFilters."""
+    consumer_filters = {"status": f.in_(["open"])}
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert isinstance(result, OppFilters)
+    assert result.status is not None
+    assert result.custom_filters is None
+
+
+def test_classify_default_camel_alias_lands_in_named_field():
+    """THE LANDMINE: camelCase alias "closeDateRange" must land in named field, NOT customFilters."""
+    consumer_filters = {"closeDateRange": f.between("2026-01-01", "2026-12-31")}
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert isinstance(result, OppFilters)
+    # The camelCase alias must normalize to the snake_case field
+    assert result.close_date_range is not None
+    # It must NOT appear in customFilters
+    if result.custom_filters:
+        assert "closeDateRange" not in result.custom_filters
+
+
+def test_classify_registered_custom_filter_lands_in_custom_filters():
+    """A registered custom filter (e.g. "agency") lands in OppFilters.custom_filters."""
+    consumer_filters = {"agency": f.in_(["NSF", "NIH"])}
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert isinstance(result, OppFilters)
+    assert result.custom_filters is not None
+    assert "agency" in result.custom_filters
+
+
+def test_classify_adhoc_unregistered_filter_lands_in_custom_filters():
+    """An unregistered ad-hoc key (e.g. "legacyTag") passes through to customFilters."""
+    consumer_filters = {"legacyTag": f.eq("priority")}
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert isinstance(result, OppFilters)
+    assert result.custom_filters is not None
+    assert "legacyTag" in result.custom_filters
+
+
+def test_classify_escape_hatch_key_lands_in_custom_filters():
+    """gov.<system>@<filter> escape-hatch keys pass through to customFilters."""
+    consumer_filters = {"gov.someSystem@someFilter": f.eq("test")}
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert isinstance(result, OppFilters)
+    assert result.custom_filters is not None
+    assert "gov.someSystem@someFilter" in result.custom_filters
+
+
+# ---------------------------------------------------------------------------
+# Wire-body shape
+# ---------------------------------------------------------------------------
+
+
+def test_wire_body_has_default_fields_at_top_level_and_custom_filters_nested():
+    """model_dump(by_alias=True, exclude_none=True) yields ADR-0012 wire shape.
+
+    Default filters appear at top level; custom/ad-hoc appear under "customFilters".
+    """
+    consumer_filters = {
+        "status": f.in_(["open"]),
+        "agency": f.in_(["NSF"]),
+        "legacyTag": f.eq("priority"),
+    }
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    wire = result.model_dump(by_alias=True, exclude_none=True)
+
+    # Default field appears at top level
+    assert "status" in wire
+    # Custom and ad-hoc filters are nested under customFilters
+    assert "customFilters" in wire
+    assert "agency" in wire["customFilters"]
+    assert "legacyTag" in wire["customFilters"]
+    # customFilters is NOT a top-level key for a default filter
+    assert "status" not in wire.get("customFilters", {})
+
+
+def test_wire_body_no_custom_filters_key_when_all_defaults():
+    """customFilters key is absent from wire body when all filters are default fields."""
+    consumer_filters = {"status": f.in_(["open"])}
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    wire = result.model_dump(by_alias=True, exclude_none=True)
+    assert "customFilters" not in wire
+
+
+def test_oppfilters_mixed_case_roundtrip():
+    """Strategy A proof (RESEARCH A4, HIGH-risk assumption, now PINNED).
+
+    A mix of snake_case and camelCase default keys — including 'closeDateRange' as
+    a camelCase alias — must normalize to the correct snake_case field names and
+    produce the correct ADR-0012 wire JSON via model_dump(by_alias=True, exclude_none=True).
+
+    Asserts:
+    - closeDateRange lands in its named default field (close_date_range), NOT in customFilters.
+    - wire output uses camelCase aliases (by_alias=True).
+    """
+    consumer_filters = {
+        "status": f.in_(["open", "forecasted"]),  # snake_case default
+        "closeDateRange": f.between("2026-01-01", "2026-12-31"),  # camelCase alias default
+    }
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert isinstance(result, OppFilters)
+
+    # camelCase alias must land in named field
+    assert result.close_date_range is not None
+
+    wire = result.model_dump(by_alias=True, exclude_none=True)
+
+    # Both named fields appear at top level with their wire (alias) names
+    assert "status" in wire
+    assert "closeDateRange" in wire
+
+    # closeDateRange is NOT in customFilters
+    assert "customFilters" not in wire or "closeDateRange" not in wire.get(
+        "customFilters", {}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registration-time validation (validate_routes) — RAISES PluginError
+# ---------------------------------------------------------------------------
+
+
+def test_validate_routes_unknown_filter_type_raises():
+    """validate_routes raises PluginError when filter_type is not in FILTER_TYPE_SCHEMAS."""
+    # Manually construct a spec with a bogus filter_type bypassing the enum
+    bad_spec = CustomFilterSpec.__new__(CustomFilterSpec)
+    object.__setattr__(bad_spec, "filter_type", "unknownType")  # type: ignore[arg-type]
+    object.__setattr__(bad_spec, "description", None)
+
+    routes = {"opportunities": {"search": {"myFilter": bad_spec}}}
+    with pytest.raises(PluginError, match="Unknown filter_type"):
+        validate_routes(routes)
+
+
+def test_validate_routes_collision_with_default_filter_name_raises():
+    """validate_routes raises PluginError when a custom filter name collides with a CORE DEFAULT name.
+
+    This is the DP-15 escape-hatch collision check. E.g. naming a custom filter "status"
+    would shadow the core default "status" field — must be caught at registration time.
+    """
+    routes = {
+        "opportunities": {
+            "search": {
+                "status": CustomFilterSpec(
+                    filter_type=CustomFilterType.STRING_ARRAY,
+                    description="Should collide with default",
+                ),
+            }
+        }
+    }
+    with pytest.raises(PluginError, match="collides"):
+        validate_routes(routes)
+
+
+def test_validate_routes_collision_with_camel_alias_raises():
+    """validate_routes raises PluginError for camelCase alias collision (e.g. "closeDateRange")."""
+    routes = {
+        "opportunities": {
+            "search": {
+                "closeDateRange": CustomFilterSpec(
+                    filter_type=CustomFilterType.DATE_RANGE,
+                    description="Should collide with default alias",
+                ),
+            }
+        }
+    }
+    with pytest.raises(PluginError, match="collides"):
+        validate_routes(routes)
+
+
+def test_validate_routes_valid_routes_do_not_raise():
+    """validate_routes does not raise for a fully valid routes dict."""
+    # Should not raise
+    validate_routes(SAMPLE_ROUTES)
+
+
+# ---------------------------------------------------------------------------
+# Call-time validation (validate_filter_call) — RAISES PluginError
+# ---------------------------------------------------------------------------
+
+
+def test_validate_filter_call_registered_bad_operator_raises():
+    """validate_filter_call raises PluginError when a registered filter has an operator/value mismatch."""
+    # AGENCY_SPEC is STRING_ARRAY — an "eq" with a scalar value is wrong for StringArrayFilter
+    bad_filter = f.eq("not-an-array")
+    with pytest.raises(PluginError):
+        validate_filter_call(AGENCY_SPEC, "agency", bad_filter)
+
+
+def test_validate_filter_call_adhoc_invalid_shape_raises():
+    """validate_filter_call raises PluginError when an ad-hoc filter has an invalid DefaultFilter shape."""
+    # Pass None as spec (ad-hoc), with something that isn't a DefaultFilter
+    class _BadShape:
+        operator = "not_a_real_operator"
+        value = object()  # not a valid value type
+
+    with pytest.raises(PluginError):
+        validate_filter_call(None, "legacyTag", _BadShape())  # type: ignore[arg-type]
+
+
+def test_validate_filter_call_valid_registered_does_not_raise():
+    """validate_filter_call does not raise for a valid registered filter call."""
+    valid_filter = f.in_(["NSF", "NIH"])
+    # Should not raise — agency is STRING_ARRAY, in_ with list is valid
+    validate_filter_call(AGENCY_SPEC, "agency", valid_filter)

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -201,7 +201,7 @@ def test_wire_body_no_custom_filters_key_when_all_defaults():
 
 
 def test_oppfilters_mixed_case_roundtrip():
-    """Strategy A proof (RESEARCH A4, HIGH-risk assumption, now PINNED).
+    """Alias-normalization round-trip proof.
 
     A mix of snake_case and camelCase default keys — including 'closeDateRange' as
     a camelCase alias — must normalize to the correct snake_case field names and
@@ -257,7 +257,7 @@ def test_validate_routes_unknown_filter_type_raises():
 def test_validate_routes_collision_with_default_filter_name_raises():
     """validate_routes raises PluginError when a custom filter name collides with a CORE DEFAULT name.
 
-    This is the DP-15 escape-hatch collision check. E.g. naming a custom filter "status"
+    This is the escape-hatch collision check. E.g. naming a custom filter "status"
     would shadow the core default "status" field — must be caught at registration time.
     """
     routes = {

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -3,10 +3,14 @@ in common_grants_sdk.extensions.filters."""
 
 from __future__ import annotations
 
+import json
+from datetime import date
+
 import pytest
 from pydantic import ValidationError
 
 from common_grants_sdk.extensions.filters import (
+    FILTER_TYPE_SCHEMAS,
     classify_filters,
     f,
     validate_filter_call,
@@ -122,9 +126,9 @@ def test_classify_default_camel_alias_lands_in_named_field():
     assert isinstance(result, OppFilters)
     # The camelCase alias must normalize to the snake_case field
     assert result.close_date_range is not None
-    # It must NOT appear in customFilters
-    if result.custom_filters:
-        assert "closeDateRange" not in result.custom_filters
+    # It must NOT appear in customFilters (a conditional check here could
+    # never fail on the path it guards — assert the bucket is empty outright)
+    assert result.custom_filters is None
 
 
 def test_classify_registered_custom_filter_lands_in_custom_filters():
@@ -429,3 +433,193 @@ def test_classify_default_camel_alias_wrong_shape_raises_plugin_error():
             "search",
             {"closeDateRange": f.eq("2026-01-01")},
         )
+
+
+# ---------------------------------------------------------------------------
+# Wire-body integrity: the value that passed validation is the value shipped
+# ---------------------------------------------------------------------------
+
+WIRE_ROUTES = {
+    "opportunities": {
+        "search": {
+            "isOpen": CustomFilterSpec(filter_type=CustomFilterType.BOOLEAN_COMPARISON),
+            "awardCount": CustomFilterSpec(
+                filter_type=CustomFilterType.NUMBER_COMPARISON
+            ),
+        }
+    }
+}
+
+
+def test_boolean_filter_value_survives_to_wire_as_json_true():
+    """f.eq(True) serializes as JSON true, not 1.
+
+    DefaultFilter.value is Any per the core spec (filters/base.tsp `unknown`);
+    a narrowed union without bool lax-coerced True -> 1 and corrupted the wire.
+    """
+    result = classify_filters(
+        WIRE_ROUTES, "opportunities", "search", {"isOpen": f.eq(True)}
+    )
+    body = result.model_dump(by_alias=True, exclude_none=True, mode="json")
+    assert body["customFilters"]["isOpen"]["value"] is True
+
+
+def test_registered_filter_ships_validated_value_not_raw_input():
+    """The wire body carries the value that passed validation, not the raw input.
+
+    NumberComparisonFilter lax-coerces "42" -> 42.0; shipping the raw string
+    would mean the payload differs from what validation approved.
+    """
+    result = classify_filters(
+        WIRE_ROUTES, "opportunities", "search", {"awardCount": f.gt("42")}
+    )
+    body = result.model_dump(by_alias=True, exclude_none=True, mode="json")
+    assert body["customFilters"]["awardCount"]["value"] == 42.0
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")  # pydantic warns during the
+# model_dump of the mutated instance, before re-validation raises
+def test_mutated_adhoc_instance_is_revalidated_and_raises():
+    """An ad-hoc DefaultFilter mutated after construction raises instead of shipping.
+
+    The filter models are mutable; the ad-hoc branch must re-validate instances
+    rather than trust isinstance.
+    """
+    flt = f.eq("x")
+    flt.operator = "bogus"  # type: ignore[assignment]
+    with pytest.raises(PluginError):
+        classify_filters(SAMPLE_ROUTES, "opportunities", "search", {"legacy": flt})
+
+
+def test_unknown_filter_type_raises_plugin_error_not_key_error():
+    """A spec whose filter_type never passed validate_routes raises PluginError.
+
+    The uniform error contract holds even when registration-time validation was
+    skipped — consumers catching `except PluginError` must not see a KeyError.
+    """
+    spec = CustomFilterSpec(filter_type="bogusType")  # type: ignore[arg-type]
+    with pytest.raises(PluginError):
+        validate_filter_call(spec, "x", f.eq(1))
+
+
+def test_validate_filter_call_adhoc_accepts_raw_dict():
+    """Ad-hoc validation accepts a raw operator/value dict and returns a DefaultFilter."""
+    validated = validate_filter_call(None, "x", {"operator": "eq", "value": "v"})
+    assert validated.operator == "eq"
+    assert validated.value == "v"
+
+
+# ---------------------------------------------------------------------------
+# Alias normalization (snake form), serialization contract, error paths
+# ---------------------------------------------------------------------------
+
+
+def test_classify_default_snake_form_of_aliased_key_normalizes_to_alias():
+    """Snake_case key for an ALIASED field lands in the named field, not customFilters.
+
+    Exercises the _SNAKE_TO_ALIAS hit branch: without normalization,
+    OppFilters(close_date_range=...) is silently dropped by pydantic
+    (populate_by_name is not set) and the field stays None.
+    """
+    consumer_filters = {"close_date_range": f.between("2026-01-01", "2026-12-31")}
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
+    assert result.close_date_range is not None
+    assert result.custom_filters is None
+
+
+def test_request_body_mode_json_round_trip():
+    """The documented model_dump(mode="json") call yields a json.dumps-able body.
+
+    Coerced date objects only serialize in json mode — this is the ADR-0012
+    wire body the classifier exists to produce.
+    """
+    consumer_filters = {
+        "close_date_range": f.between(date(2026, 1, 1), date(2026, 12, 31)),
+        "agency": f.in_(["NSF"]),
+    }
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
+    body = json.loads(
+        json.dumps(result.model_dump(by_alias=True, exclude_none=True, mode="json"))
+    )
+    assert body["closeDateRange"]["operator"] == "between"
+    assert body["closeDateRange"]["value"]["min"] == "2026-01-01"
+    assert body["customFilters"]["agency"]["operator"] == "in"
+
+
+def test_classify_empty_filters_dict_yields_empty_body():
+    """An empty consumer dict produces an OppFilters with no customFilters entry."""
+    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", {})
+    assert result.custom_filters is None
+    body = result.model_dump(by_alias=True, exclude_none=True, mode="json")
+    assert "customFilters" not in body
+
+
+def test_filter_type_schemas_covers_every_custom_filter_type():
+    """Every CustomFilterType member has a validation model.
+
+    A catalog member without a FILTER_TYPE_SCHEMAS entry would reject valid
+    registrations in validate_routes — this assert turns that drift into a
+    CI failure at the moment the enum and the map diverge.
+    """
+    assert set(FILTER_TYPE_SCHEMAS) == set(CustomFilterType)
+
+
+def test_plugin_error_path_is_uniform_across_buckets():
+    """All three buckets raise PluginError with a filters.<name> path."""
+    with pytest.raises(PluginError) as exc1:
+        classify_filters(
+            SAMPLE_ROUTES, "opportunities", "search", {"status": f.eq("open")}
+        )
+    assert exc1.value.path == "filters.status"
+
+    with pytest.raises(PluginError) as exc2:
+        classify_filters(
+            SAMPLE_ROUTES, "opportunities", "search", {"agency": f.eq("NSF")}
+        )
+    assert exc2.value.path == "filters.agency"
+
+    with pytest.raises(PluginError) as exc3:
+        classify_filters(
+            SAMPLE_ROUTES, "opportunities", "search", {"adhoc": {"operator": "bogus"}}
+        )
+    assert exc3.value.path == "filters.adhoc"
+
+
+def test_multiple_failing_defaults_use_collective_path():
+    """Two failing default filters produce the collective path "filters"."""
+    with pytest.raises(PluginError) as exc_info:
+        classify_filters(
+            SAMPLE_ROUTES,
+            "opportunities",
+            "search",
+            {"status": f.eq("open"), "closeDateRange": f.eq("x")},
+        )
+    assert exc_info.value.path == "filters"
+
+
+@pytest.mark.parametrize(
+    ("helper", "args", "operator", "value"),
+    [
+        ("eq", ("open",), "eq", "open"),
+        ("neq", ("x",), "neq", "x"),
+        ("gt", (1,), "gt", 1),
+        ("gte", (1,), "gte", 1),
+        ("lt", (1,), "lt", 1),
+        ("lte", (1,), "lte", 1),
+        ("in_", (["a"],), "in", ["a"]),
+        ("not_in", (["a"],), "notIn", ["a"]),
+        ("like", ("%x%",), "like", "%x%"),
+        ("not_like", ("%x%",), "notLike", "%x%"),
+        ("between", (0, 1), "between", {"min": 0, "max": 1}),
+        ("outside", (0, 1), "outside", {"min": 0, "max": 1}),
+    ],
+)
+def test_f_helper_wire_values(helper, args, operator, value):
+    """Every f helper produces its documented wire operator and value shape."""
+    flt = getattr(f, helper)(*args)
+    assert flt.operator == operator
+    assert flt.value == value

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -33,8 +33,10 @@ FUNDING_PROGRAM_SPEC = CustomFilterSpec(
 SAMPLE_ROUTES = {
     "opportunities": {
         "search": {
-            "agency": AGENCY_SPEC,
-            "fundingProgram": FUNDING_PROGRAM_SPEC,
+            "filters": {
+                "agency": AGENCY_SPEC,
+                "fundingProgram": FUNDING_PROGRAM_SPEC,
+            }
         }
     }
 }
@@ -223,7 +225,7 @@ def test_validate_routes_unknown_filter_type_raises():
     # can be passed directly (the annotation is for type checkers only).
     bad_spec = CustomFilterSpec(filter_type="unknownType")  # type: ignore[arg-type]
 
-    routes = {"opportunities": {"search": {"myFilter": bad_spec}}}
+    routes = {"opportunities": {"search": {"filters": {"myFilter": bad_spec}}}}
     with pytest.raises(PluginError, match="Unknown filter_type"):
         validate_routes(routes)
 
@@ -237,10 +239,12 @@ def test_validate_routes_collision_with_default_filter_name_raises():
     routes = {
         "opportunities": {
             "search": {
-                "status": CustomFilterSpec(
-                    filter_type=CustomFilterType.STRING_ARRAY,
-                    description="Should collide with default",
-                ),
+                "filters": {
+                    "status": CustomFilterSpec(
+                        filter_type=CustomFilterType.STRING_ARRAY,
+                        description="Should collide with default",
+                    ),
+                }
             }
         }
     }
@@ -253,10 +257,12 @@ def test_validate_routes_collision_with_camel_alias_raises():
     routes = {
         "opportunities": {
             "search": {
-                "closeDateRange": CustomFilterSpec(
-                    filter_type=CustomFilterType.DATE_RANGE,
-                    description="Should collide with default alias",
-                ),
+                "filters": {
+                    "closeDateRange": CustomFilterSpec(
+                        filter_type=CustomFilterType.DATE_RANGE,
+                        description="Should collide with default alias",
+                    ),
+                }
             }
         }
     }
@@ -408,10 +414,14 @@ def test_classify_default_camel_alias_wrong_shape_raises_plugin_error():
 WIRE_ROUTES = {
     "opportunities": {
         "search": {
-            "isOpen": CustomFilterSpec(filter_type=CustomFilterType.BOOLEAN_COMPARISON),
-            "awardCount": CustomFilterSpec(
-                filter_type=CustomFilterType.NUMBER_COMPARISON
-            ),
+            "filters": {
+                "isOpen": CustomFilterSpec(
+                    filter_type=CustomFilterType.BOOLEAN_COMPARISON
+                ),
+                "awardCount": CustomFilterSpec(
+                    filter_type=CustomFilterType.NUMBER_COMPARISON
+                ),
+            }
         }
     }
 }

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -328,6 +328,62 @@ def test_validate_filter_call_valid_registered_does_not_raise():
     validate_filter_call(AGENCY_SPEC, "agency", valid_filter)
 
 
+def test_validate_filter_call_money_comparison_passes_valid_money():
+    """A registered moneyComparison filter accepts a comparison operator and Money value.
+
+    Money.amount is a decimal STRING ("1000000"), not a number — the shape that
+    drifted in the TS compile-time filter map and was locked there with
+    compile-error tests; covered here at the runtime layer.
+    """
+    spec = CustomFilterSpec(filter_type=CustomFilterType.MONEY_COMPARISON)
+    validate_filter_call(
+        spec, "awardFloor", f.gt({"amount": "1000000", "currency": "USD"})
+    )
+
+
+def test_validate_filter_call_money_comparison_rejects_array_operator():
+    """A registered moneyComparison filter raises PluginError for an array operator."""
+    spec = CustomFilterSpec(filter_type=CustomFilterType.MONEY_COMPARISON)
+    with pytest.raises(PluginError):
+        validate_filter_call(
+            spec, "awardFloor", f.in_([{"amount": "1000000", "currency": "USD"}])
+        )
+
+
+def test_validate_filter_call_money_comparison_rejects_numeric_amount():
+    """A registered moneyComparison filter raises PluginError for a numeric amount.
+
+    Money.amount is a DecimalString — a raw number is the wrong shape.
+    """
+    spec = CustomFilterSpec(filter_type=CustomFilterType.MONEY_COMPARISON)
+    with pytest.raises(PluginError):
+        validate_filter_call(
+            spec, "awardFloor", f.gt({"amount": 1000.5, "currency": "USD"})
+        )
+
+
+def test_validate_filter_call_money_range_passes_valid_range():
+    """A registered moneyRange filter accepts between with {min, max} Money values."""
+    spec = CustomFilterSpec(filter_type=CustomFilterType.MONEY_RANGE)
+    validate_filter_call(
+        spec,
+        "awardRange",
+        f.between(
+            {"amount": "10000", "currency": "USD"},
+            {"amount": "500000", "currency": "USD"},
+        ),
+    )
+
+
+def test_validate_filter_call_money_range_rejects_comparison_operator():
+    """A registered moneyRange filter raises PluginError for a comparison operator."""
+    spec = CustomFilterSpec(filter_type=CustomFilterType.MONEY_RANGE)
+    with pytest.raises(PluginError):
+        validate_filter_call(
+            spec, "awardRange", f.gt({"amount": "10000", "currency": "USD"})
+        )
+
+
 def test_classify_default_wrong_shape_raises_plugin_error():
     """A wrong-shaped DEFAULT filter raises PluginError, not a raw pydantic ValidationError.
 

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -544,6 +544,50 @@ def test_classify_default_snake_form_of_aliased_key_normalizes_to_alias():
     assert result.custom_filters is None
 
 
+def test_classify_both_forms_of_same_default_filter_raises():
+    """Supplying snake AND camel forms of one default filter raises PluginError.
+
+    Both keys normalize to "closeDateRange"; without the guard, dict
+    assignment silently drops whichever range the consumer's dict ordered
+    first (plausible when merging filter dicts from two naming conventions).
+    """
+    consumer_filters = {
+        "close_date_range": f.between("2026-01-01", "2026-06-30"),
+        "closeDateRange": f.between("2026-07-01", "2026-12-31"),
+    }
+    with pytest.raises(PluginError, match="more than once") as exc_info:
+        classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    assert exc_info.value.path == "filters.closeDateRange"
+
+
+@pytest.mark.parametrize(
+    ("resource", "method"),
+    [
+        ("opportunities", "list"),  # method not declared in routes
+        ("opportunity", "search"),  # resource near-miss (pluralization)
+    ],
+)
+def test_classify_unmatched_route_treats_registered_name_as_adhoc(resource, method):
+    """A (resource, method) pair with no routes entry has NO registered bucket.
+
+    "agency" is registered as STRING_ARRAY under opportunities.search only;
+    via any other route pair it is validated as permissive ad-hoc, so
+    f.eq("NSF") (invalid for STRING_ARRAY) passes through to customFilters.
+    Discriminates both levels of the routes[resource][method] lookup — a
+    regression that flattens or mis-keys it either wrongly applies the spec
+    or wrongly skips it.
+    """
+    result = classify_filters(SAMPLE_ROUTES, resource, method, {"agency": f.eq("NSF")})
+    assert result.custom_filters is not None
+    assert result.custom_filters["agency"].value == "NSF"
+
+    # ...and the same filter via the declared pair IS spec-validated and rejected
+    with pytest.raises(PluginError):
+        classify_filters(
+            SAMPLE_ROUTES, "opportunities", "search", {"agency": f.eq("NSF")}
+        )
+
+
 def test_request_body_mode_json_round_trip():
     """The documented model_dump(mode="json") call yields a json.dumps-able body.
 

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -161,12 +161,12 @@ def test_classify_escape_hatch_key_lands_in_custom_filters():
 
 
 # ---------------------------------------------------------------------------
-# Wire-body shape
+# Request-body shape
 # ---------------------------------------------------------------------------
 
 
-def test_wire_body_has_default_fields_at_top_level_and_custom_filters_nested():
-    """model_dump(by_alias=True, exclude_none=True) yields ADR-0012 wire shape.
+def test_request_body_has_default_fields_at_top_level_and_custom_filters_nested():
+    """model_dump(by_alias=True, exclude_none=True) yields the ADR-0012 request-body shape.
 
     Default filters appear at top level; custom/ad-hoc appear under "customFilters".
     """
@@ -178,26 +178,26 @@ def test_wire_body_has_default_fields_at_top_level_and_custom_filters_nested():
     result = classify_filters(
         SAMPLE_ROUTES, "opportunities", "search", consumer_filters
     )
-    wire = result.model_dump(by_alias=True, exclude_none=True)
+    request_body = result.model_dump(by_alias=True, exclude_none=True)
 
     # Default field appears at top level
-    assert "status" in wire
+    assert "status" in request_body
     # Custom and ad-hoc filters are nested under customFilters
-    assert "customFilters" in wire
-    assert "agency" in wire["customFilters"]
-    assert "legacyTag" in wire["customFilters"]
+    assert "customFilters" in request_body
+    assert "agency" in request_body["customFilters"]
+    assert "legacyTag" in request_body["customFilters"]
     # customFilters is NOT a top-level key for a default filter
-    assert "status" not in wire.get("customFilters", {})
+    assert "status" not in request_body.get("customFilters", {})
 
 
-def test_wire_body_no_custom_filters_key_when_all_defaults():
-    """customFilters key is absent from wire body when all filters are default fields."""
+def test_request_body_no_custom_filters_key_when_all_defaults():
+    """customFilters key is absent from the request body when all filters are default fields."""
     consumer_filters = {"status": f.in_(["open"])}
     result = classify_filters(
         SAMPLE_ROUTES, "opportunities", "search", consumer_filters
     )
-    wire = result.model_dump(by_alias=True, exclude_none=True)
-    assert "customFilters" not in wire
+    request_body = result.model_dump(by_alias=True, exclude_none=True)
+    assert "customFilters" not in request_body
 
 
 def test_oppfilters_mixed_case_roundtrip():
@@ -205,11 +205,11 @@ def test_oppfilters_mixed_case_roundtrip():
 
     A mix of snake_case and camelCase default keys — including 'closeDateRange' as
     a camelCase alias — must normalize to the correct snake_case field names and
-    produce the correct ADR-0012 wire JSON via model_dump(by_alias=True, exclude_none=True).
+    produce the correct ADR-0012 request JSON via model_dump(by_alias=True, exclude_none=True).
 
     Asserts:
     - closeDateRange lands in its named default field (close_date_range), NOT in customFilters.
-    - wire output uses camelCase aliases (by_alias=True).
+    - request-body output uses camelCase aliases (by_alias=True).
     """
     consumer_filters = {
         "status": f.in_(["open", "forecasted"]),  # snake_case default
@@ -225,14 +225,14 @@ def test_oppfilters_mixed_case_roundtrip():
     # camelCase alias must land in named field
     assert result.close_date_range is not None
 
-    wire = result.model_dump(by_alias=True, exclude_none=True)
+    request_body = result.model_dump(by_alias=True, exclude_none=True)
 
-    # Both named fields appear at top level with their wire (alias) names
-    assert "status" in wire
-    assert "closeDateRange" in wire
+    # Both named fields appear at top level with their alias names
+    assert "status" in request_body
+    assert "closeDateRange" in request_body
 
     # closeDateRange is NOT in customFilters
-    assert "customFilters" not in wire or "closeDateRange" not in wire.get(
+    assert "customFilters" not in request_body or "closeDateRange" not in request_body.get(
         "customFilters", {}
     )
 

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -45,60 +45,32 @@ SAMPLE_ROUTES = {
 # ---------------------------------------------------------------------------
 
 
-def test_f_eq():
-    """f.eq returns DefaultFilter with operator "eq"."""
-    flt = f.eq("open")
-    assert flt.operator == "eq"
-    assert flt.value == "open"
+@pytest.mark.parametrize(
+    ("helper", "args", "operator", "value"),
+    [
+        ("eq", ("open",), "eq", "open"),
+        ("neq", ("x",), "neq", "x"),
+        ("gt", (1,), "gt", 1),
+        ("gte", (1,), "gte", 1),
+        ("lt", (1,), "lt", 1),
+        ("lte", (1,), "lte", 1),
+        ("in_", (["a"],), "in", ["a"]),
+        ("not_in", (["a"],), "notIn", ["a"]),
+        ("like", ("%x%",), "like", "%x%"),
+        ("not_like", ("%x%",), "notLike", "%x%"),
+        ("between", (0, 1), "between", {"min": 0, "max": 1}),
+        ("outside", (0, 1), "outside", {"min": 0, "max": 1}),
+    ],
+)
+def test_f_helper_wire_values(helper, args, operator, value):
+    """Every f helper produces its documented wire operator and value shape.
 
-
-def test_f_neq():
-    """f.neq returns DefaultFilter with operator "neq"."""
-    flt = f.neq("closed")
-    assert flt.operator == "neq"
-    assert flt.value == "closed"
-
-
-def test_f_gt():
-    """f.gt returns DefaultFilter with operator "gt"."""
-    flt = f.gt(100)
-    assert flt.operator == "gt"
-    assert flt.value == 100
-
-
-def test_f_like():
-    """f.like returns DefaultFilter with operator "like"."""
-    flt = f.like("%grants%")
-    assert flt.operator == "like"
-    assert flt.value == "%grants%"
-
-
-def test_f_in_uses_wire_value():
-    """f.in_ uses reserved-word workaround; wire operator is "in" (not "in_")."""
-    flt = f.in_(["NSF", "NIH"])
-    assert flt.operator == "in"
-    assert flt.value == ["NSF", "NIH"]
-
-
-def test_f_not_in_uses_camel_wire_value():
-    """f.not_in produces wire operator "notIn" (Python f.not_in vs TS F.notIn divergence)."""
-    flt = f.not_in(["archived"])
-    assert flt.operator == "notIn"
-    assert flt.value == ["archived"]
-
-
-def test_f_between():
-    """f.between produces operator "between" and {"min": a, "max": b} value."""
-    flt = f.between("2026-01-01", "2026-12-31")
-    assert flt.operator == "between"
-    assert flt.value == {"min": "2026-01-01", "max": "2026-12-31"}
-
-
-def test_f_outside():
-    """f.outside produces operator "outside" and {"min": a, "max": b} value."""
-    flt = f.outside(0, 50)
-    assert flt.operator == "outside"
-    assert flt.value == {"min": 0, "max": 50}
+    Includes the reserved-word workarounds: Python f.in_ / f.not_in produce
+    wire operators "in" / "notIn".
+    """
+    flt = getattr(f, helper)(*args)
+    assert flt.operator == operator
+    assert flt.value == value
 
 
 # ---------------------------------------------------------------------------
@@ -235,11 +207,9 @@ def test_oppfilters_mixed_case_roundtrip():
     assert "status" in request_body
     assert "closeDateRange" in request_body
 
-    # closeDateRange is NOT in customFilters
-    assert (
-        "customFilters" not in request_body
-        or "closeDateRange" not in request_body.get("customFilters", {})
-    )
+    # Nothing landed in customFilters — assert the bucket is absent outright
+    # (a conditional check could never fail on the path it guards)
+    assert "customFilters" not in request_body
 
 
 # ---------------------------------------------------------------------------
@@ -658,27 +628,3 @@ def test_multiple_failing_defaults_use_collective_path():
             {"status": f.eq("open"), "closeDateRange": f.eq("x")},
         )
     assert exc_info.value.path == "filters"
-
-
-@pytest.mark.parametrize(
-    ("helper", "args", "operator", "value"),
-    [
-        ("eq", ("open",), "eq", "open"),
-        ("neq", ("x",), "neq", "x"),
-        ("gt", (1,), "gt", 1),
-        ("gte", (1,), "gte", 1),
-        ("lt", (1,), "lt", 1),
-        ("lte", (1,), "lte", 1),
-        ("in_", (["a"],), "in", ["a"]),
-        ("not_in", (["a"],), "notIn", ["a"]),
-        ("like", ("%x%",), "like", "%x%"),
-        ("not_like", ("%x%",), "notLike", "%x%"),
-        ("between", (0, 1), "between", {"min": 0, "max": 1}),
-        ("outside", (0, 1), "outside", {"min": 0, "max": 1}),
-    ],
-)
-def test_f_helper_wire_values(helper, args, operator, value):
-    """Every f helper produces its documented wire operator and value shape."""
-    flt = getattr(f, helper)(*args)
-    assert flt.operator == operator
-    assert flt.value == value

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -373,21 +373,17 @@ def test_classify_default_wrong_shape_raises_plugin_error():
     assert isinstance(exc_info.value.__cause__, ValidationError)
 
 
-def test_validate_filter_call_integer_comparison_rejects_non_integer():
-    """A registered integerComparison filter raises PluginError for a fractional value.
+def test_validate_filter_call_integer_comparison_validates_as_number():
+    """A registered integerComparison filter validates against NumberComparisonFilter.
 
-    integerComparison validates against IntegerComparisonFilter (strict int),
-    not the looser NumberComparisonFilter.
+    The spec defines no integer filter model, so the int constraint is not
+    schema-enforced (same as the TS SDK); a numeric value passes, a non-numeric
+    value fails.
     """
     spec = CustomFilterSpec(filter_type=CustomFilterType.INTEGER_COMPARISON)
-    with pytest.raises(PluginError):
-        validate_filter_call(spec, "awardCount", f.gt(100.5))
-
-
-def test_validate_filter_call_integer_comparison_passes_valid_int():
-    """A registered integerComparison filter accepts an integer value."""
-    spec = CustomFilterSpec(filter_type=CustomFilterType.INTEGER_COMPARISON)
     validate_filter_call(spec, "awardCount", f.gt(100))
+    with pytest.raises(PluginError):
+        validate_filter_call(spec, "awardCount", f.gt("not a number"))
 
 
 def test_classify_default_camel_alias_wrong_shape_raises_plugin_error():

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -232,8 +232,9 @@ def test_oppfilters_mixed_case_roundtrip():
     assert "closeDateRange" in request_body
 
     # closeDateRange is NOT in customFilters
-    assert "customFilters" not in request_body or "closeDateRange" not in request_body.get(
-        "customFilters", {}
+    assert (
+        "customFilters" not in request_body
+        or "closeDateRange" not in request_body.get("customFilters", {})
     )
 
 

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -4,6 +4,8 @@ in common_grants_sdk.extensions.filters."""
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
+
 from common_grants_sdk.extensions.filters import (
     classify_filters,
     f,
@@ -324,3 +326,33 @@ def test_validate_filter_call_valid_registered_does_not_raise():
     valid_filter = f.in_(["NSF", "NIH"])
     # Should not raise — agency is STRING_ARRAY, in_ with list is valid
     validate_filter_call(AGENCY_SPEC, "agency", valid_filter)
+
+
+def test_classify_default_wrong_shape_raises_plugin_error():
+    """A wrong-shaped DEFAULT filter raises PluginError, not a raw pydantic ValidationError.
+
+    "status" is a StringArrayFilter (ArrayOperator + list[str]); f.eq("open") is an
+    equivalence filter. The error contract must be uniform across all three buckets:
+    consumers following the documented `except PluginError` pattern must catch this.
+    """
+    with pytest.raises(PluginError) as exc_info:
+        classify_filters(
+            SAMPLE_ROUTES, "opportunities", "search", {"status": f.eq("open")}
+        )
+    # The underlying pydantic error is preserved as cause for programmatic access
+    assert isinstance(exc_info.value.__cause__, ValidationError)
+
+
+def test_classify_default_camel_alias_wrong_shape_raises_plugin_error():
+    """A wrong-shaped default filter via its camelCase alias also raises PluginError.
+
+    "closeDateRange" is a DateRangeFilter; f.eq("2026-01-01") is an equivalence
+    filter — the alias normalization path must surface the same PluginError.
+    """
+    with pytest.raises(PluginError):
+        classify_filters(
+            SAMPLE_ROUTES,
+            "opportunities",
+            "search",
+            {"closeDateRange": f.eq("2026-01-01")},
+        )

--- a/lib/python-sdk/tests/extensions/test_filters.py
+++ b/lib/python-sdk/tests/extensions/test_filters.py
@@ -14,7 +14,6 @@ from common_grants_sdk.extensions.specs import CustomFilterSpec, CustomFilterTyp
 from common_grants_sdk.extensions.types import PluginError
 from common_grants_sdk.schemas.pydantic.filters.opportunity import OppFilters
 
-
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
@@ -104,7 +103,9 @@ def test_f_outside():
 def test_classify_default_snake_key_lands_in_named_field():
     """Default snake_case key (e.g. "status") lands in a named OppFilters field, not customFilters."""
     consumer_filters = {"status": f.in_(["open"])}
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     assert isinstance(result, OppFilters)
     assert result.status is not None
     assert result.custom_filters is None
@@ -113,7 +114,9 @@ def test_classify_default_snake_key_lands_in_named_field():
 def test_classify_default_camel_alias_lands_in_named_field():
     """THE LANDMINE: camelCase alias "closeDateRange" must land in named field, NOT customFilters."""
     consumer_filters = {"closeDateRange": f.between("2026-01-01", "2026-12-31")}
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     assert isinstance(result, OppFilters)
     # The camelCase alias must normalize to the snake_case field
     assert result.close_date_range is not None
@@ -125,7 +128,9 @@ def test_classify_default_camel_alias_lands_in_named_field():
 def test_classify_registered_custom_filter_lands_in_custom_filters():
     """A registered custom filter (e.g. "agency") lands in OppFilters.custom_filters."""
     consumer_filters = {"agency": f.in_(["NSF", "NIH"])}
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     assert isinstance(result, OppFilters)
     assert result.custom_filters is not None
     assert "agency" in result.custom_filters
@@ -134,7 +139,9 @@ def test_classify_registered_custom_filter_lands_in_custom_filters():
 def test_classify_adhoc_unregistered_filter_lands_in_custom_filters():
     """An unregistered ad-hoc key (e.g. "legacyTag") passes through to customFilters."""
     consumer_filters = {"legacyTag": f.eq("priority")}
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     assert isinstance(result, OppFilters)
     assert result.custom_filters is not None
     assert "legacyTag" in result.custom_filters
@@ -143,7 +150,9 @@ def test_classify_adhoc_unregistered_filter_lands_in_custom_filters():
 def test_classify_escape_hatch_key_lands_in_custom_filters():
     """gov.<system>@<filter> escape-hatch keys pass through to customFilters."""
     consumer_filters = {"gov.someSystem@someFilter": f.eq("test")}
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     assert isinstance(result, OppFilters)
     assert result.custom_filters is not None
     assert "gov.someSystem@someFilter" in result.custom_filters
@@ -164,7 +173,9 @@ def test_wire_body_has_default_fields_at_top_level_and_custom_filters_nested():
         "agency": f.in_(["NSF"]),
         "legacyTag": f.eq("priority"),
     }
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     wire = result.model_dump(by_alias=True, exclude_none=True)
 
     # Default field appears at top level
@@ -180,7 +191,9 @@ def test_wire_body_has_default_fields_at_top_level_and_custom_filters_nested():
 def test_wire_body_no_custom_filters_key_when_all_defaults():
     """customFilters key is absent from wire body when all filters are default fields."""
     consumer_filters = {"status": f.in_(["open"])}
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     wire = result.model_dump(by_alias=True, exclude_none=True)
     assert "customFilters" not in wire
 
@@ -198,9 +211,13 @@ def test_oppfilters_mixed_case_roundtrip():
     """
     consumer_filters = {
         "status": f.in_(["open", "forecasted"]),  # snake_case default
-        "closeDateRange": f.between("2026-01-01", "2026-12-31"),  # camelCase alias default
+        "closeDateRange": f.between(
+            "2026-01-01", "2026-12-31"
+        ),  # camelCase alias default
     }
-    result = classify_filters(SAMPLE_ROUTES, "opportunities", "search", consumer_filters)
+    result = classify_filters(
+        SAMPLE_ROUTES, "opportunities", "search", consumer_filters
+    )
     assert isinstance(result, OppFilters)
 
     # camelCase alias must land in named field
@@ -292,6 +309,7 @@ def test_validate_filter_call_registered_bad_operator_raises():
 
 def test_validate_filter_call_adhoc_invalid_shape_raises():
     """validate_filter_call raises PluginError when an ad-hoc filter has an invalid DefaultFilter shape."""
+
     # Pass None as spec (ad-hoc), with something that isn't a DefaultFilter
     class _BadShape:
         operator = "not_a_real_operator"

--- a/lib/python-sdk/tests/extensions/test_plugin.py
+++ b/lib/python-sdk/tests/extensions/test_plugin.py
@@ -1,6 +1,7 @@
 """Tests for plugin.py — PluginExtensions-based API."""
 
 from common_grants_sdk.extensions.plugin import Plugin, PluginConfig, define_plugin
+from common_grants_sdk.extensions.specs import CustomFilterSpec, CustomFilterType
 from common_grants_sdk.extensions.types import (
     ObjectSchemasInput,
     PluginExtensions,
@@ -23,6 +24,19 @@ def test_define_plugin_with_extensions():
     ext = PluginExtensions()
     config = define_plugin(extensions=ext)
     assert config.extensions is ext
+
+
+def test_define_plugin_routes_passthrough():
+    """define_plugin stores routes as-is on PluginConfig.routes (no validation)."""
+    routes = {
+        "opportunities": {
+            "search": {
+                "agency": CustomFilterSpec(filter_type=CustomFilterType.STRING_ARRAY)
+            }
+        }
+    }
+    config = define_plugin(routes=routes)
+    assert config.routes is routes
 
 
 def test_define_plugin_with_meta_and_schemas():

--- a/lib/python-sdk/tests/extensions/test_plugin.py
+++ b/lib/python-sdk/tests/extensions/test_plugin.py
@@ -31,7 +31,11 @@ def test_define_plugin_routes_passthrough():
     routes = {
         "opportunities": {
             "search": {
-                "agency": CustomFilterSpec(filter_type=CustomFilterType.STRING_ARRAY)
+                "filters": {
+                    "agency": CustomFilterSpec(
+                        filter_type=CustomFilterType.STRING_ARRAY
+                    )
+                }
             }
         }
     }

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -29,6 +29,7 @@ from common_grants_sdk.schemas.pydantic.filters.money import (
     InvalidMoneyValueError,
 )
 from common_grants_sdk.schemas.pydantic.filters.numeric import (
+    IntegerComparisonFilter,
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRange,
@@ -551,3 +552,33 @@ def test_boolean_comparison_filter_rejects_invalid_value():
 
     with pytest.raises(ValidationError):
         BooleanComparisonFilter(operator="eq", value=42)
+
+
+def test_integer_comparison_filter_constructs():
+    """IntegerComparisonFilter constructs with valid operator and integer value."""
+    filter_obj = IntegerComparisonFilter(operator="gt", value=100)
+    assert filter_obj.operator == ComparisonOperator.GREATER_THAN
+    assert filter_obj.value == 100
+
+
+def test_integer_comparison_filter_rejects_non_integer_float():
+    """IntegerComparisonFilter raises ValidationError for a fractional value."""
+    with pytest.raises(ValidationError):
+        IntegerComparisonFilter(operator="gt", value=100.5)
+
+
+def test_integer_comparison_filter_rejects_numeric_string():
+    """IntegerComparisonFilter raises ValidationError for a numeric string (strict int).
+
+    Mirrors the TS IntegerComparisonFilterSchema, where z.number().int()
+    rejects string input; the strict annotation disables pydantic's lax
+    str -> int coercion.
+    """
+    with pytest.raises(ValidationError):
+        IntegerComparisonFilter(operator="gt", value="100")
+
+
+def test_integer_comparison_filter_rejects_invalid_operator():
+    """IntegerComparisonFilter raises ValidationError for non-comparison operators."""
+    with pytest.raises(ValidationError):
+        IntegerComparisonFilter(operator="in", value=100)

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -596,6 +596,44 @@ def test_integer_comparison_filter_rejects_numeric_string():
 
 
 def test_integer_comparison_filter_rejects_invalid_operator():
-    """IntegerComparisonFilter raises ValidationError for non-comparison operators."""
+    """IntegerComparisonFilter raises ValidationError for operators outside its surface.
+
+    "in" is an ArrayOperator — not in the comparison/equivalence union.
+    """
     with pytest.raises(ValidationError):
         IntegerComparisonFilter(operator="in", value=100)
+
+
+def test_numeric_comparison_filters_accept_equivalence_operators():
+    """Number and Integer comparison filters accept eq/neq.
+
+    The core spec (filters/numeric.tsp) widened the operator surface to
+    ComparisonOperators | EquivalenceOperators in protocol v0.3; the TS SDK
+    tracks it and these models must match.
+    """
+    assert NumberComparisonFilter(operator="eq", value=3).operator == "eq"
+    assert NumberComparisonFilter(operator="neq", value=3.5).operator == "neq"
+    assert IntegerComparisonFilter(operator="eq", value=3).operator == "eq"
+    assert IntegerComparisonFilter(operator="neq", value=3).operator == "neq"
+
+
+def test_integer_comparison_filter_rejects_bool():
+    """IntegerComparisonFilter raises ValidationError for True/False.
+
+    bool subclasses int in Python; StrictInt's explicit bool rejection is what
+    keeps True out (the TS side rejects it at typeof level). Without strict,
+    lax coercion turns True into 1 silently.
+    """
+    with pytest.raises(ValidationError):
+        IntegerComparisonFilter(operator="eq", value=True)
+
+
+def test_integer_comparison_filter_rejects_integral_float():
+    """IntegerComparisonFilter raises ValidationError for 100.0.
+
+    Documented cross-SDK divergence: JavaScript cannot distinguish 100.0 from
+    100, so the TS schema accepts it; StrictInt rejects it. This pin makes the
+    divergence a recorded decision rather than an accident.
+    """
+    with pytest.raises(ValidationError):
+        IntegerComparisonFilter(operator="gt", value=100.0)

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -2,7 +2,9 @@
 
 from datetime import date
 import pytest
+from pydantic import ValidationError
 
+from common_grants_sdk.schemas.pydantic.filters.boolean import BooleanComparisonFilter
 from common_grants_sdk.schemas.pydantic.filters.base import (
     ArrayOperator,
     ComparisonOperator,
@@ -508,3 +510,44 @@ def test_number_array_filter():
     filter_obj = NumberArrayFilter(operator=ArrayOperator.IN, value=[1, 2.5, 3])
     assert filter_obj.operator == ArrayOperator.IN
     assert filter_obj.value == [1, 2.5, 3]
+
+
+def test_boolean_comparison_filter_constructs():
+    """BooleanComparisonFilter constructs with valid operator and value."""
+    filter_obj = BooleanComparisonFilter(operator="eq", value=True)
+    assert filter_obj.operator == EquivalenceOperator.EQUAL
+    assert filter_obj.value is True
+
+    filter_obj = BooleanComparisonFilter(operator="neq", value=False)
+    assert filter_obj.operator == EquivalenceOperator.NOT_EQUAL
+    assert filter_obj.value is False
+
+
+def test_boolean_comparison_filter_coerces_string_operator():
+    """BooleanComparisonFilter coerces string 'eq'/'neq' to EquivalenceOperator."""
+    filter_obj = BooleanComparisonFilter(operator="eq", value=True)
+    assert filter_obj.operator == EquivalenceOperator.EQUAL
+
+    filter_obj = BooleanComparisonFilter(operator="neq", value=True)
+    assert filter_obj.operator == EquivalenceOperator.NOT_EQUAL
+
+
+def test_boolean_comparison_filter_rejects_invalid_operator():
+    """BooleanComparisonFilter raises ValidationError for operator not in EquivalenceOperator."""
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="gt", value=True)
+
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="like", value=True)
+
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="in", value=True)
+
+
+def test_boolean_comparison_filter_rejects_invalid_value():
+    """BooleanComparisonFilter raises ValidationError for non-bool value."""
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="eq", value="not-a-bool")
+
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="eq", value=42)

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -637,3 +637,40 @@ def test_integer_comparison_filter_rejects_integral_float():
     """
     with pytest.raises(ValidationError):
         IntegerComparisonFilter(operator="gt", value=100.0)
+
+
+def test_number_comparison_filter_rejects_bool():
+    """NumberComparisonFilter raises ValidationError for True/False.
+
+    bool subclasses int, so the int|float union would lax-coerce True -> 1
+    and ship a number for a boolean — the same wire corruption the
+    DefaultFilter.value widening fixed, one layer down. z.number() rejects
+    booleans, so rejection also keeps the SDKs aligned.
+    """
+    with pytest.raises(ValidationError):
+        NumberComparisonFilter(operator="eq", value=True)
+
+    with pytest.raises(ValidationError):
+        NumberComparisonFilter(operator="gt", value=False)
+
+
+def test_number_array_filter_rejects_bool_items():
+    """NumberArrayFilter raises ValidationError when any item is a bool.
+
+    Same lax-coercion vector as NumberComparisonFilter: [True] would ship
+    as [1] without an explicit bool rejection.
+    """
+    with pytest.raises(ValidationError):
+        NumberArrayFilter(operator=ArrayOperator.IN, value=[1, True, 3])
+
+
+def test_number_range_rejects_bool_bounds():
+    """NumberRange raises ValidationError for a bool min or max.
+
+    Same lax-coercion vector: {"min": True, "max": 10} would ship min=1.
+    """
+    with pytest.raises(ValidationError):
+        NumberRange(min=True, max=10)
+
+    with pytest.raises(ValidationError):
+        NumberRange(min=0, max=False)

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -524,15 +524,6 @@ def test_boolean_comparison_filter_constructs():
     assert filter_obj.value is False
 
 
-def test_boolean_comparison_filter_coerces_string_operator():
-    """BooleanComparisonFilter coerces string 'eq'/'neq' to EquivalenceOperator."""
-    filter_obj = BooleanComparisonFilter(operator="eq", value=True)
-    assert filter_obj.operator == EquivalenceOperator.EQUAL
-
-    filter_obj = BooleanComparisonFilter(operator="neq", value=True)
-    assert filter_obj.operator == EquivalenceOperator.NOT_EQUAL
-
-
 def test_boolean_comparison_filter_rejects_invalid_operator():
     """BooleanComparisonFilter raises ValidationError for operator not in EquivalenceOperator."""
     with pytest.raises(ValidationError):
@@ -595,13 +586,17 @@ def test_integer_comparison_filter_rejects_numeric_string():
         IntegerComparisonFilter(operator="gt", value="100")
 
 
-def test_integer_comparison_filter_rejects_invalid_operator():
-    """IntegerComparisonFilter raises ValidationError for operators outside its surface.
+@pytest.mark.parametrize("model", [NumberComparisonFilter, IntegerComparisonFilter])
+@pytest.mark.parametrize("operator", ["in", "between", "like"])
+def test_comparison_filters_reject_invalid_operator(model, operator):
+    """Comparison filters raise ValidationError for operators outside their surface.
 
-    "in" is an ArrayOperator — not in the comparison/equivalence union.
+    Both models share the rewritten two-enum validate_operator dispatch whose
+    fallthrough returns unknown strings unchanged, relying on the enum-union
+    field to reject them — the rejection must hold on each model.
     """
     with pytest.raises(ValidationError):
-        IntegerComparisonFilter(operator="in", value=100)
+        model(operator=operator, value=100)
 
 
 def test_numeric_comparison_filters_accept_equivalence_operators():

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -29,7 +29,6 @@ from common_grants_sdk.schemas.pydantic.filters.money import (
     InvalidMoneyValueError,
 )
 from common_grants_sdk.schemas.pydantic.filters.numeric import (
-    IntegerComparisonFilter,
     NumberArrayFilter,
     NumberComparisonFilter,
     NumberRange,
@@ -562,76 +561,27 @@ def test_boolean_comparison_filter_rejects_coercible_values():
         BooleanComparisonFilter(operator="eq", value="true")
 
 
-def test_integer_comparison_filter_constructs():
-    """IntegerComparisonFilter constructs with valid operator and integer value."""
-    filter_obj = IntegerComparisonFilter(operator="gt", value=100)
-    assert filter_obj.operator == ComparisonOperator.GREATER_THAN
-    assert filter_obj.value == 100
-
-
-def test_integer_comparison_filter_rejects_non_integer_float():
-    """IntegerComparisonFilter raises ValidationError for a fractional value."""
-    with pytest.raises(ValidationError):
-        IntegerComparisonFilter(operator="gt", value=100.5)
-
-
-def test_integer_comparison_filter_rejects_numeric_string():
-    """IntegerComparisonFilter raises ValidationError for a numeric string (strict int).
-
-    Mirrors the TS IntegerComparisonFilterSchema, where z.number().int()
-    rejects string input; the strict annotation disables pydantic's lax
-    str -> int coercion.
-    """
-    with pytest.raises(ValidationError):
-        IntegerComparisonFilter(operator="gt", value="100")
-
-
-@pytest.mark.parametrize("model", [NumberComparisonFilter, IntegerComparisonFilter])
 @pytest.mark.parametrize("operator", ["in", "between", "like"])
-def test_comparison_filters_reject_invalid_operator(model, operator):
-    """Comparison filters raise ValidationError for operators outside their surface.
+def test_number_comparison_filter_rejects_invalid_operator(operator):
+    """NumberComparisonFilter raises ValidationError for operators outside its surface.
 
-    Both models share the rewritten two-enum validate_operator dispatch whose
-    fallthrough returns unknown strings unchanged, relying on the enum-union
-    field to reject them — the rejection must hold on each model.
+    The two-enum validate_operator dispatch's fallthrough returns unknown
+    strings unchanged, relying on the enum-union field to reject them — the
+    rejection must hold.
     """
     with pytest.raises(ValidationError):
-        model(operator=operator, value=100)
+        NumberComparisonFilter(operator=operator, value=100)
 
 
-def test_numeric_comparison_filters_accept_equivalence_operators():
-    """Number and Integer comparison filters accept eq/neq.
+def test_number_comparison_filter_accepts_equivalence_operators():
+    """NumberComparisonFilter accepts eq/neq.
 
     The core spec (filters/numeric.tsp) widened the operator surface to
     ComparisonOperators | EquivalenceOperators in protocol v0.3; the TS SDK
-    tracks it and these models must match.
+    tracks it and this model must match.
     """
     assert NumberComparisonFilter(operator="eq", value=3).operator == "eq"
     assert NumberComparisonFilter(operator="neq", value=3.5).operator == "neq"
-    assert IntegerComparisonFilter(operator="eq", value=3).operator == "eq"
-    assert IntegerComparisonFilter(operator="neq", value=3).operator == "neq"
-
-
-def test_integer_comparison_filter_rejects_bool():
-    """IntegerComparisonFilter raises ValidationError for True/False.
-
-    bool subclasses int in Python; StrictInt's explicit bool rejection is what
-    keeps True out (the TS side rejects it at typeof level). Without strict,
-    lax coercion turns True into 1 silently.
-    """
-    with pytest.raises(ValidationError):
-        IntegerComparisonFilter(operator="eq", value=True)
-
-
-def test_integer_comparison_filter_rejects_integral_float():
-    """IntegerComparisonFilter raises ValidationError for 100.0.
-
-    Documented cross-SDK divergence: JavaScript cannot distinguish 100.0 from
-    100, so the TS schema accepts it; StrictInt rejects it. This pin makes the
-    divergence a recorded decision rather than an accident.
-    """
-    with pytest.raises(ValidationError):
-        IntegerComparisonFilter(operator="gt", value=100.0)
 
 
 def test_number_comparison_filter_rejects_bool():

--- a/lib/python-sdk/tests/schemas/test_filters.py
+++ b/lib/python-sdk/tests/schemas/test_filters.py
@@ -554,6 +554,23 @@ def test_boolean_comparison_filter_rejects_invalid_value():
         BooleanComparisonFilter(operator="eq", value=42)
 
 
+def test_boolean_comparison_filter_rejects_coercible_values():
+    """BooleanComparisonFilter raises ValidationError for bool-coercible non-bool values.
+
+    Mirrors the TS BooleanComparisonFilterSchema, where z.boolean() rejects
+    1/0 and "true"/"false"; the strict annotation disables pydantic's lax
+    int/str -> bool coercion.
+    """
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="eq", value=1)
+
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="eq", value=0)
+
+    with pytest.raises(ValidationError):
+        BooleanComparisonFilter(operator="eq", value="true")
+
+
 def test_integer_comparison_filter_constructs():
     """IntegerComparisonFilter constructs with valid operator and integer value."""
     filter_obj = IntegerComparisonFilter(operator="gt", value=100)


### PR DESCRIPTION
### Summary

- Fixes #869 — the Python custom-filter PoC: validates the design recommended in SPIKE #646 (alongside counterpart TS PoC, #884) in the Python SDK — a custom filter on a sample CommonGrants search request (the `customFilters` property + standard Filter schema per ADR-0012) — and captures findings on the language-forced divergences to inform the full SDK implementation.
- Merges into the `HOLD-filters` bucket, parallel to the TS sibling PR #884. `lib/python-sdk/` only — no file overlap with #884.
- Time to review: ~30 minutes

### Changes proposed

**For plugin authors**
- Declare custom filters per resource/method — `define_plugin(routes={"opportunities": {"search": {"filters": {"agency": CustomFilterSpec(...)}}}})` — from a catalog of string/number/integer/boolean/date/money filter types.
- `PluginRoutes` mirrors the TS SDK shape exactly: per-method declarations sit in a `RouteDeclarations` `TypedDict` with an optional `filters` key, so the registration literal and the validation error paths (`routes.<resource>.<method>.filters.<name>`) are identical across both SDKs. Cross-SDK consumer testing showed why this matters: with the earlier Python-only shape (specs directly at the method level), a consumer porting that literal to the TS classifier had every registered filter silently downgraded to ad-hoc shape-only validation — wrong-value-type and unknown-type inputs were accepted instead of rejected.
- `validate_routes()` catches bad declarations at registration time: unknown filter types, and names that shadow a core default filter under either spelling.

**For SDK consumers**
- One flat `filters` dict per search call: default, registered-custom, and ad-hoc filters mix freely, snake_case or camelCase keys both work, and the classifier produces the correct ADR-0012 request body — no bucket bookkeeping at the call site.
- Anything invalid surfaces as a single catchable `PluginError` that names the failing filter, no matter which bucket it came from.
- The request body carries exactly the values that passed validation — booleans stay booleans (`true`, never `1`), and nothing unvalidated reaches the wire.
- `eq`/`neq` work on numeric comparison filters per protocol v0.3, so the same filter call accepts or rejects identically in both SDKs.
- `f` helpers (`f.eq`, `f.between`, `f.in_`, …) build filter values without hand-writing operator dicts.

**Runtime-vs-compile-time correctness (the central cross-SDK divergence)**
- The TS PoC's central proof is compile-time: `as const` narrowing rejects unknown keys and operator/value mismatches at `tsc` time. Python has no equivalent — correctness here is enforced **at runtime by Pydantic v2**. The pytest suite covers the same rejection matrix the TS `@ts-expect-error` tests cover, but as runtime `PluginError` assertions. Python adopters get runtime correctness; the compile-time DX story is TypeScript-specific.

**Findings captured for the full implementation**
- Pydantic-specific wire gotchas (alias-form construction, `mode="json"` serialization) are documented at their source in the module docs.
- One known value-strictness divergence remains (`"42"` as a number: TS rejects, Python coerces) — the protocol-level value types in #895 are the natural place to settle it.

No `lib/core` change; no changeset (PoC on a `HOLD-*` bucket, no production-dependency change — same as #884; re-evaluated when the bucket promotes).

### Context for reviewers

Follow-ups from this PoC pair are filed under the #645 epic: #895 (protocol-level boolean/integer filter models + value strictness), #896 (resource-agnostic classifier), #897 (escape-hatch semantics), #898 (ADR text corrections).

Verified with the real toolchain (from `lib/python-sdk/`):
- `make checks` — black, ruff, and mypy green.
- `make test` — 363 passed. The one failing test (`test_generate_models_typecheck_with_pyright_strict`) is pre-existing on the base branch and unrelated.
- `poetry run python examples/custom_filters.py` — runs green end-to-end, including the `except PluginError` demo.
- Exercised from a downstream consumer against the **wheel-installed** package shape (Poetry-built wheel in a fresh venv, not a source-path import).
- Cross-SDK parity exercised from the downstream-consumer harness: the Python and TS (#884) PoCs consume an identical shared fixture corpus through the wheel/tarball-installed packages, both run 5/5 green (2 accept + 3 adversarial reject cases), and their canonical-JSON output is byte-identical per case (recursive key sort + matched serializer settings, compare step exits 0). This run is what surfaced the routes-shape asymmetry that the `PluginRoutes` alignment above resolves.

### Additional information

Consumer-side classification (example output):
- `status` and `close_date_range` (normalized to `closeDateRange`) → top-level named fields (default bucket)
- `agency`, `fundingProgram` → `customFilters` (registered custom filters)
- `legacyTag` → `customFilters` (ad-hoc passthrough)
