### PR TITLE
[Website] Fix GFM tables rendering as raw markdown on .mdx pages

### DIFF
--- a/website/.cspell.json
+++ b/website/.cspell.json
@@ -50,7 +50,8 @@
     "HBCUs",
     "TCCUs",
     "widal001",
-    "categoricals"
+    "categoricals",
+    "withastro"
   ],
   "ignoreWords": [
     "opblock",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -8,6 +8,12 @@ import react from "@astrojs/react";
 // https://astro.build/config
 export default defineConfig({
   site: "https://commongrants.org",
+  // Restore the documented GFM default for .mdx files. Astro 6.4.x stopped
+  // populating `markdown.gfm`, and the @astrojs/mdx version bundled by
+  // Starlight 0.39.x silently drops remark-gfm when the value is absent,
+  // breaking tables in .mdx pages. See withastro/astro#16971. This line can
+  // be removed once Starlight is on @astrojs/mdx@^6 (Starlight >= 0.40.0).
+  markdown: { gfm: true },
   redirects: {
     // These pages were consolidated into a single page for the opportunity models.
     "/protocol/models/opp-base": "/protocol/models/opportunity#opportunitybase",


### PR DESCRIPTION
### Summary

- Fixes the broken tables on commongrants.org (e.g. [/protocol/models/organization/#table](https://commongrants.org/protocol/models/organization/#table)) — no tracked issue
- Time to review: 5 minutes

### Changes proposed

- Set `markdown: { gfm: true }` explicitly in `website/astro.config.mjs`
- Add `withastro` to the website cspell dictionary (used in the code comment)

### Context for reviewers

Astro 6.4.x stopped populating `markdown.gfm` with its documented default of `true` (a side effect of their markdown-processor refactor — upstream issue linked in the `astro.config.mjs` comment). The `@astrojs/mdx` version bundled by Starlight 0.39.x relies on that value being present and silently drops `remark-gfm` when it's absent, so GFM tables in `.mdx` files render as literal pipe text. Plain `.md` pages (the other ADRs, the spec) were unaffected, which is why only some pages broke. The regression reached us via the website-framework dependency bumps; the build stays green because the failure is render-only.

Setting the option explicitly restores the documented default and is a no-op once fixed upstream. The comment notes it can be removed when Starlight ships `@astrojs/mdx@^6` (Starlight >= 0.40.0).

Verified locally: built the site at `main` and confirmed 22 pages render tables as raw text (`grep -rl '<p>| ' dist`); rebuilt with this change and the count drops to 0, with the affected pages emitting real `<table>` markup. `prettier`, `eslint`, and `cspell` pass on the changed files.

### Additional information

Affected pages (all `.mdx` with markdown tables): protocol models (organization, mapping, applicant-type), all field/filter/response pages, protocol overview, pagination, sorting, custom-fields overview, and ADR-0022/0023.

The [PR preview](https://cg-pr-889.billy-daly.workers.dev/) can be used to spot-check `/protocol/models/organization/#table` before merge.