### PR TITLE
refactor(ts-sdk): update transform helper types

### DIFF
--- a/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
@@ -207,7 +207,7 @@ describe("definePlugin", () => {
 
       const plugin = definePlugin({
         schemas: {
-          Opportunity: { toCommon, fromCommon },
+          Opportunity: { sourceSchema: z.object({}).passthrough(), toCommon, fromCommon },
         },
       });
 
@@ -234,7 +234,7 @@ describe("definePlugin", () => {
 
       const plugin = definePlugin({
         schemas: {
-          Opportunity: { toCommon, fromCommon },
+          Opportunity: { sourceSchema: z.object({}).passthrough(), toCommon, fromCommon },
         },
       });
 
@@ -268,6 +268,43 @@ describe("definePlugin", () => {
         // @ts-expect-error — toCommon is not callable on a schema-only entry
         plugin.schemas.Opportunity.toCommon({});
       }
+    });
+
+    it("rejects hand-written transforms without a sourceSchema (compile-time)", () => {
+      const noop = (): TransformResult<unknown> => ({ result: {}, errors: [] });
+      definePlugin({
+        schemas: {
+          // @ts-expect-error — the functions path requires a sourceSchema
+          Opportunity: { toCommon: noop, fromCommon: noop },
+        },
+      });
+    });
+
+    it("rejects a single transform direction (compile-time)", () => {
+      const noop = (): TransformResult<unknown> => ({ result: {}, errors: [] });
+      definePlugin({
+        schemas: {
+          // @ts-expect-error — the functions path requires both toCommon and fromCommon
+          Opportunity: { sourceSchema: z.object({}).passthrough(), toCommon: noop },
+        },
+      });
+    });
+
+    it("validates fromCommon output against the sourceSchema", () => {
+      const sourceSchema = z.object({ native_id: z.string() });
+      const plugin = definePlugin({
+        schemas: {
+          Opportunity: {
+            sourceSchema,
+            toCommon: (): TransformResult<unknown> => ({ result: validOpp, errors: [] }),
+            // Returns a source object missing the required native_id.
+            fromCommon: (): TransformResult<unknown> => ({ result: { wrong: true }, errors: [] }),
+          },
+        },
+      });
+
+      const out = plugin.schemas.Opportunity.fromCommon?.({} as never);
+      expect(out?.errors.length ?? 0).toBeGreaterThan(0);
     });
   });
 
@@ -337,12 +374,16 @@ const autoWireFromCommonMapping = {
   native_title: { field: "title" },
   native_id: { field: "id" },
 };
+// Transform entries require a sourceSchema. The mappings runtime here doesn't use
+// it, so a permissive shape is fine for these tests.
+const autoWireSourceSchema = z.object({}).passthrough();
 
 describe("definePlugin — auto-wiring from mappings", () => {
   it("auto-generates working toCommon/fromCommon from schemas.Opportunity.mappings", () => {
     const plugin = definePlugin({
       schemas: {
         Opportunity: {
+          sourceSchema: autoWireSourceSchema,
           mappings: {
             toCommon: autoWireToCommonMapping,
             fromCommon: autoWireFromCommonMapping,
@@ -377,6 +418,7 @@ describe("definePlugin — auto-wiring from mappings", () => {
       definePlugin({
         schemas: {
           Opportunity: {
+            sourceSchema: autoWireSourceSchema,
             mappings: {
               toCommon: autoWireToCommonMapping,
               fromCommon: autoWireFromCommonMapping,
@@ -401,6 +443,7 @@ describe("definePlugin — auto-wiring from mappings", () => {
       definePlugin({
         schemas: {
           Opportunity: {
+            sourceSchema: autoWireSourceSchema,
             mappings: {
               toCommon: autoWireToCommonMapping,
               fromCommon: autoWireFromCommonMapping,
@@ -418,6 +461,7 @@ describe("definePlugin — auto-wiring from mappings", () => {
       definePlugin({
         schemas: {
           Opportunity: {
+            sourceSchema: autoWireSourceSchema,
             mappings: {
               toCommon: autoWireToCommonMapping,
               // fromCommon intentionally absent
@@ -433,6 +477,7 @@ describe("definePlugin — auto-wiring from mappings", () => {
       definePlugin({
         schemas: {
           Opportunity: {
+            sourceSchema: autoWireSourceSchema,
             mappings: {
               // toCommon intentionally absent
               fromCommon: autoWireFromCommonMapping,
@@ -448,6 +493,7 @@ describe("definePlugin — auto-wiring from mappings", () => {
       definePlugin({
         schemas: {
           Opportunity: {
+            sourceSchema: autoWireSourceSchema,
             mappings: {
               toCommon: { unknownFieldXyz: { field: "data.x" } },
               fromCommon: autoWireFromCommonMapping,

--- a/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/define-plugin.spec.ts
@@ -253,6 +253,22 @@ describe("definePlugin", () => {
       expect(plugin.schemas.Opportunity.toCommon).toBeUndefined();
       expect(plugin.schemas.Opportunity.fromCommon).toBeUndefined();
     });
+
+    it("does not expose transform callables as callable on a schema-only entry", () => {
+      // A customFields-only entry resolves to the schema-only shape, so calling
+      // toCommon is a compile error (not just `undefined` at runtime). The guarded
+      // block never executes; the `@ts-expect-error` fails the build if the type
+      // ever starts exposing a callable transform here.
+      const plugin = definePlugin({
+        schemas: { Opportunity: { customFields: { legacyId: { fieldType: "integer" } } } },
+      });
+      expect(plugin.schemas.Opportunity.commonSchema).toBeDefined();
+      expect(plugin.schemas.Opportunity.customFields).toBeDefined();
+      if (false as boolean) {
+        // @ts-expect-error — toCommon is not callable on a schema-only entry
+        plugin.schemas.Opportunity.toCommon({});
+      }
+    });
   });
 
   // ############################################################################

--- a/lib/ts-sdk/__tests__/schemas/zod/types.spec.ts
+++ b/lib/ts-sdk/__tests__/schemas/zod/types.spec.ts
@@ -163,11 +163,16 @@ describe("ISODate Schema", () => {
     await expectZodMatchesJsonSchema(ISODateSchema, jsonSchemaId);
   });
 
+  it("accepts a Date object (normalized to YYYY-MM-DD, then parsed back to a Date)", () => {
+    const parsed = ISODateSchema.parse(new Date("2025-01-15T12:00:00Z"));
+    expect(parsed).toBeInstanceOf(Date);
+    expect(parsed.getUTCFullYear()).toBe(2025);
+    expect(parsed.getUTCDate()).toBe(15);
+  });
+
   it("should raise an error for an invalid ISODate", () => {
     // Must be in YYYY-MM-DD format
     expect(() => ISODateSchema.parse("01-01-2025")).toThrow();
-    // Must be a string, not a Date object
-    expect(() => ISODateSchema.parse(new Date())).toThrow();
     // Invalid date format
     expect(() => ISODateSchema.parse("not-a-date")).toThrow();
     // Missing parts
@@ -318,11 +323,13 @@ describe("OffsetDateTime Schema", () => {
     expect(withMsOffset2.getUTCHours()).toBe(20); // 12:00 + 8 hours = 20:00 UTC
   });
 
+  it("accepts a Date object (normalized to an ISO string, then parsed back to a Date)", () => {
+    expect(OffsetDateTimeSchema.parse(new Date("2025-01-01T00:00:00Z"))).toBeInstanceOf(Date);
+  });
+
   it("should raise an error for an invalid OffsetDateTime", () => {
     // Must be a valid ISO datetime string
     expect(() => OffsetDateTimeSchema.parse("not-a-datetime")).toThrow();
-    // Must be a string, not a Date object
-    expect(() => OffsetDateTimeSchema.parse(new Date())).toThrow();
     // Invalid datetime format (missing time)
     expect(() => OffsetDateTimeSchema.parse("2025-01-01")).toThrow();
     // Missing timezone

--- a/lib/ts-sdk/examples/transforms.ts
+++ b/lib/ts-sdk/examples/transforms.ts
@@ -1,12 +1,8 @@
 /**
- * Example script demonstrating bidirectional transforms through `definePlugin()`.
+ * Example script demonstrating bidirectional transforms through `definePlugin()`
+ * following three common plugin author scenarios
  *
- * Runs real data through each authoring path and verifies the round trip. It does
- * not call `buildTransforms()` directly — `definePlugin()` compiles the declarative
- * `mappings` internally. (The schema-only path, plus the schema-only / XOR
- * compile-time guarantees, are covered in `__tests__/extensions/define-plugin.spec.ts`.)
- *
- * Paths shown:
+ * Scenarios shown:
  *   1. Custom fields + declarative `mappings`   → definePlugin compiles them
  *   2. Custom fields + hand-written functions    → `ToCommon` / `FromCommon`
  *   3. Transforms with no custom fields          → base CommonGrants schema
@@ -15,7 +11,7 @@
  * Run with: `pnpm example:transforms`
  *
  * @remarks
- * The mappings path validates `toCommon` output against the extended common
+ * The mappings scenario validates `toCommon` output against the extended common
  * schema, so date strings are parsed into `Date` objects on the common side.
  * The round-trip checks below therefore assert on fields that survive verbatim
  * (ids, the three-state `source` null), not on the parsed date fields.
@@ -68,7 +64,7 @@ const SOURCE_DATA: GrantsGovSource = {
 };
 
 // Declared inline at each call below, but kept here too for the hand-written
-// path, which needs `typeof customFields` for its helper-type annotations.
+// scenario, which needs `typeof customFields` for its helper-type annotations.
 const customFields = {
   legacyId: {
     fieldType: CustomFieldType.integer,
@@ -78,11 +74,11 @@ const customFields = {
 } as const;
 
 // ############################################################################
-// Path 1 — custom fields + declarative mappings
+// Scenario 1 — custom fields + declarative mappings
 // ############################################################################
 
 // definePlugin() compiles these mappings into toCommon / fromCommon using the
-// built-in handlers (`field`, `match`, `const`). No buildTransforms() call here.
+// built-in handlers (`field`, `match`, `const`).
 const mappingsPlugin = definePlugin({
   meta: { name: "grants.gov (mappings)", sourceSystem: "grants.gov" },
   schemas: {
@@ -133,7 +129,7 @@ const mappingsPlugin = definePlugin({
 });
 
 // ############################################################################
-// Path 2 — custom fields + hand-written functions
+// Scenario 2 — custom fields + hand-written functions
 // ############################################################################
 
 // The author annotates the functions with `ToCommon` / `FromCommon`, passing the
@@ -149,7 +145,7 @@ type OpportunityTransform = {
   customFields: typeof customFields;
 };
 
-// The functions path is the override path for logic the declarative mappings
+// The functions scenario is the override for logic the declarative mappings
 // can't express — here, a status flag derived in code rather than via `match`.
 const toCommon: ToCommon<OpportunityTransform> = source => ({
   result: {
@@ -192,7 +188,7 @@ const functionsPlugin = definePlugin({
 });
 
 // ############################################################################
-// Path 3 — transforms with no custom fields
+// Scenario 3 — transforms with no custom fields
 // ############################################################################
 
 // Omit `customFields`; the common schema is the base CommonGrants Opportunity.
@@ -236,7 +232,7 @@ const noCustomFieldsPlugin = definePlugin({
 });
 
 // ############################################################################
-// Path X — mappings + functions on one entry is rejected (XOR)
+// Scenario X — mappings + functions on one entry is rejected (XOR)
 // ############################################################################
 
 // Providing both `mappings` and explicit callables is a compile error and a
@@ -254,9 +250,9 @@ function demonstrateXorIsRejected(): void {
         },
       },
     });
-    fail("path X: expected definePlugin to reject mappings + functions");
+    fail("scenario X: expected definePlugin to reject mappings + functions");
   } catch {
-    console.log("path X (XOR): mappings + functions rejected at runtime, too");
+    console.log("scenario X (XOR): mappings + functions rejected at runtime, too");
   }
 }
 
@@ -292,7 +288,7 @@ function roundTrip(
 ): void {
   // The harness drives every plugin through one shape; the resolved common
   // output type read off a built plugin is fine here (this is test plumbing, not
-  // the author-facing annotation the functions path above demonstrates).
+  // the author-facing annotation the functions scenario above demonstrates).
   type HarnessCommon = z.output<typeof mappingsPlugin.schemas.Opportunity.commonSchema>;
   const opp = plugin.schemas.Opportunity;
   const toCommonFn = opp.toCommon as (s: GrantsGovSource) => TransformResult<HarnessCommon>;
@@ -304,7 +300,7 @@ function roundTrip(
   const back = fromCommonFn(common.result);
   reportErrors(`${label} fromCommon`, back);
 
-  // The uuid round-trips verbatim in every path (unlike the parsed date fields).
+  // The uuid round-trips verbatim in every scenario (unlike the parsed date fields).
   check(
     `${label}: opportunity_uuid round-trips`,
     back.result.data.opportunity_uuid === SOURCE_DATA.data.opportunity_uuid
@@ -323,23 +319,23 @@ function roundTrip(
 function main(): void {
   console.log("=== Transforms via definePlugin ===\n");
 
-  console.log("--- Path 1: declarative mappings ---");
-  // `mappings` is kept on the entry for inspection (absent on the functions path).
+  console.log("--- Scenario 1: declarative mappings ---");
+  // `mappings` is kept on the entry for inspection (absent on the functions scenario).
   check("mappings inspectable", mappingsPlugin.schemas.Opportunity.mappings !== undefined);
   roundTrip("mappings", mappingsPlugin, { expectLegacyId: true });
 
-  console.log("\n--- Path 2: hand-written functions ---");
+  console.log("\n--- Scenario 2: hand-written functions ---");
   check(
-    "mappings absent (functions path)",
+    "mappings absent (functions scenario)",
     functionsPlugin.schemas.Opportunity.mappings === undefined
   );
   roundTrip("functions", functionsPlugin, { expectLegacyId: true });
 
-  console.log("\n--- Path 3: no custom fields ---");
+  console.log("\n--- Scenario 3: no custom fields ---");
   check("customFields absent", noCustomFieldsPlugin.schemas.Opportunity.customFields === undefined);
   roundTrip("base", noCustomFieldsPlugin, { expectLegacyId: false });
 
-  console.log("\n--- Path X: mappings XOR functions ---");
+  console.log("\n--- Scenario X: mappings XOR functions ---");
   demonstrateXorIsRejected();
 
   console.log("\n=== Example complete ===");

--- a/lib/ts-sdk/examples/transforms.ts
+++ b/lib/ts-sdk/examples/transforms.ts
@@ -1,260 +1,267 @@
 /**
- * Example script demonstrating bidirectional transforms. Shows:
- *   1. Defining `toCommon` / `fromCommon` mappings.
- *   2. Registering a custom mapping handler (`join`) for this call only.
- *   3. Validating `toCommon` output against the fully extended Zod schema
- *      (`withCustomFields(OpportunityBaseSchema, ...)`) — passing the base
- *      schema would silently weaken validation of typed custom fields.
- *   4. Exposing the compiled transform via `definePlugin({ schemas })`.
- *   5. Round-tripping `native → common → native` and printing both directions.
+ * Example script demonstrating bidirectional transforms through `definePlugin()`.
+ *
+ * Runs real data through each authoring path and verifies the round trip. It does
+ * not call `buildTransforms()` directly — `definePlugin()` compiles the declarative
+ * `mappings` internally. (The schema-only path, plus the schema-only / XOR
+ * compile-time guarantees, are covered in `__tests__/extensions/define-plugin.spec.ts`.)
+ *
+ * Paths shown:
+ *   1. Custom fields + declarative `mappings`   → definePlugin compiles them
+ *   2. Custom fields + hand-written functions    → `ToCommon` / `FromCommon`
+ *   3. Transforms with no custom fields          → base CommonGrants schema
+ *   X. `mappings` + functions on one entry       → rejected (mappings XOR functions)
  *
  * Run with: `pnpm example:transforms`
  *
  * @remarks
- * Zod's default `.parse()` strips unknown keys, so source-system fields that
- * have no home in the CommonGrants schema must round-trip through
- * `customFields` (declared on the extended schema). The example treats
- * `opportunity_number` this way.
+ * The mappings path validates `toCommon` output against the extended common
+ * schema, so date strings are parsed into `Date` objects on the common side.
+ * The round-trip checks below therefore assert on fields that survive verbatim
+ * (ids, the three-state `source` null), not on the parsed date fields.
  */
 
 import { z } from "zod";
 
 import { CustomFieldType } from "../src/constants";
 import {
-  buildTransforms,
   definePlugin,
-  getFromPath,
-  withCustomFields,
-  type Handler,
+  type FromCommon,
+  type ToCommon,
+  type TransformResult,
 } from "../src/extensions";
-import { OpportunityBaseSchema } from "../src/schemas/zod/models";
 
 // ############################################################################
-// Step 1 — Sample grants.gov source data
+// Shared setup — source schema, sample data, custom fields
 // ############################################################################
 
-// Note the `source_url: null` below — this is the publisher actively asserting
-// "doesn't apply" for the source URL (three-state null). The transforms
-// preserve it as `null` end-to-end rather than collapsing to absent, so a
-// downstream consumer can distinguish "publisher said N/A" from "publisher
-// didn't supply this."
-const SOURCE_DATA = {
+// Stands in for a real grants.gov payload schema. In a real plugin this would be
+// imported from wherever the source-system types live.
+const GrantsGovOpportunity = z.object({
+  data: z.object({
+    opportunity_uuid: z.string().uuid(),
+    opportunity_id: z.number().int(),
+    opportunity_title: z.string(),
+    opportunity_description: z.string(),
+    opportunity_status: z.string(),
+    // `source_url: null` below is the publisher actively asserting "doesn't
+    // apply" (three-state null). The transforms preserve it as `null` end to end
+    // rather than collapsing it to absent.
+    source_url: z.string().url().nullish(),
+    created_at: z.string(),
+    last_modified_at: z.string(),
+  }),
+});
+type GrantsGovSource = z.infer<typeof GrantsGovOpportunity>;
+
+const SOURCE_DATA: GrantsGovSource = {
   data: {
-    agency_name: "Department of Examples",
+    opportunity_uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+    opportunity_id: 12345,
+    opportunity_title: "Research into conservation techniques",
+    opportunity_description: "Funding to advance conservation research.",
+    opportunity_status: "posted",
+    source_url: null,
     created_at: "2025-01-15T09:00:00Z",
     last_modified_at: "2025-04-01T12:30:00Z",
-    opportunity_description:
-      "Funding to advance research into conservation techniques for endangered ecosystems.",
-    opportunity_id: 12345,
-    opportunity_number: "ABC-123-XYZ-001",
-    opportunity_status: "posted",
-    opportunity_title: "Research into conservation techniques",
-    opportunity_uuid: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-    source_url: null,
-    summary: {
-      applicant_types: ["state_governments"],
-    },
   },
 };
 
-// ############################################################################
-// Step 2 — Custom handlers (joined-label round trip)
-// ############################################################################
-
-// A mapping leaf like `{ field: "data.x" }` dispatches to a *handler* — a
-// `(data, spec) => value` function looked up by the leaf's key. `buildTransforms`
-// ships built-ins (`field`, `const`, `match`/`switch`, `numberToString`,
-// `stringToNumber`); anything beyond those is a custom handler you register on
-// the `handlers` map in Step 4. A mapping invokes one by name — `{ join: {...} }`
-// runs `joinFields` with `{...}` as its `spec`. `data` is always the whole object
-// under transform, so handler paths are absolute from its root (hence the
-// `data.`-prefixed paths below). A custom name that collides with a built-in is
-// rejected when `buildTransforms` runs.
-//
-// `join` and `split` are an inverse pair, here to demo a *derived* custom field
-// with no single source column: `join` composes `compositeLabel`
-// ("<opportunity_number> — <title>") on the toCommon side, and `split` recovers
-// `opportunity_number` back out of it on the fromCommon side. The round trip is
-// lossless only while the separator never occurs inside a constituent value —
-// see the NOTE on the `compositeLabel` mapping in Step 4.
-
-// join: concatenate the values at `spec.fields`, in order, joined by `spec.sep`
-// (default " "). undefined/null parts are dropped; when nothing survives it
-// returns undefined so the field is omitted rather than emitted as an empty "".
-const joinFields: Handler = (data, spec) => {
-  const s = (spec ?? {}) as { fields?: string[]; sep?: string };
-  const sep = s.sep ?? " ";
-  const parts = (s.fields ?? [])
-    .map(path => getFromPath(data, path))
-    .filter(v => v !== undefined && v !== null)
-    .map(String);
-  return parts.length > 0 ? parts.join(sep) : undefined;
-};
-
-// split: the inverse of join. Read the string at `spec.field`, split it on
-// `spec.sep` (default " "), and return the segment at `spec.index` (default 0).
-// Returns undefined when the source value is absent or the index is out of range.
-const splitField: Handler = (data, spec) => {
-  const s = (spec ?? {}) as { field?: string; sep?: string; index?: number };
-  const value = getFromPath(data, s.field ?? "");
-  if (value === undefined || value === null) return undefined;
-  const parts = String(value).split(s.sep ?? " ");
-  const idx = s.index ?? 0;
-  return idx < parts.length ? parts[idx] : undefined;
-};
-
-// ############################################################################
-// Step 3 — Custom field declarations + extended schema for validation
-// ############################################################################
-
-const customFieldSpecs = {
+// Declared inline at each call below, but kept here too for the hand-written
+// path, which needs `typeof customFields` for its helper-type annotations.
+const customFields = {
   legacyId: {
-    name: "legacyId",
     fieldType: CustomFieldType.integer,
     value: z.number().int(),
-    description: "Numeric ID from the legacy database (round-trip preserved).",
-  },
-  agencyName: {
-    name: "agencyName",
-    fieldType: CustomFieldType.string,
-    value: z.string(),
-    description: "Name of the agency hosting this opportunity.",
-  },
-  applicantTypes: {
-    name: "applicantTypes",
-    fieldType: CustomFieldType.array,
-    value: z.array(z.string()),
-    description: "Types of applicants eligible for this opportunity.",
-  },
-  // Derived field composed by the `join` handler; the `split` handler in
-  // fromCommon recovers opportunity_number from this value. Survives Zod
-  // validation because it's declared on the extended schema as a custom field.
-  compositeLabel: {
-    name: "compositeLabel",
-    fieldType: CustomFieldType.string,
-    value: z.string(),
-    description: "Composite label '<opportunity_number> — <opportunity_title>'.",
+    description: "Numeric ID from the legacy system (round-trip preserved).",
   },
 } as const;
 
-const ExtendedOpportunitySchema = withCustomFields(OpportunityBaseSchema, customFieldSpecs);
-
 // ############################################################################
-// Step 4 — Compile bidirectional transforms
+// Path 1 — custom fields + declarative mappings
 // ############################################################################
 
-const { toCommon, fromCommon } = buildTransforms(
-  {
-    id: { field: "data.opportunity_uuid" },
-    title: { field: "data.opportunity_title" },
-    description: { field: "data.opportunity_description" },
-    createdAt: { field: "data.created_at" },
-    lastModifiedAt: { field: "data.last_modified_at" },
-    // Three-state demo: native `source_url: null` carries the
-    // publisher's "doesn't apply" assertion. The `field` handler preserves
-    // the terminal null; the walker places it on the output as a real null
-    // (distinct from an absent key). Zod's `.nullish()` accepts it.
-    source: { field: "data.source_url" },
-    status: {
-      value: {
-        match: {
-          field: "data.opportunity_status",
-          case: {
-            posted: "open",
-            archived: "closed",
-            forecasted: "forecasted",
-          },
-          default: "custom",
-        },
-      },
-    },
-    customFields: {
-      legacyId: {
-        value: { field: "data.opportunity_id" },
-        name: "legacyId",
-        fieldType: "integer",
-      },
-      agencyName: {
-        value: { field: "data.agency_name" },
-        name: "agencyName",
-        fieldType: "string",
-      },
-      applicantTypes: {
-        value: { field: "data.summary.applicant_types" },
-        name: "applicantTypes",
-        fieldType: "array",
-      },
-      // Compose a derived label via the `join` custom handler; fromCommon
-      // recovers opportunity_number from it via `split`.
-      // NOTE: the separator must not appear inside any of the constituent
-      // field values, or `split` will produce a wrong result on the way back.
-      compositeLabel: {
-        value: {
-          join: {
-            fields: ["data.opportunity_number", "data.opportunity_title"],
-            sep: " — ",
-          },
-        },
-        name: "compositeLabel",
-        fieldType: "string",
-      },
-    },
-  },
-  {
-    data: {
-      opportunity_uuid: { field: "id" },
-      opportunity_title: { field: "title" },
-      opportunity_description: { field: "description" },
-      created_at: { field: "createdAt" },
-      last_modified_at: { field: "lastModifiedAt" },
-      // Recover opportunity_number from the joined label via `split`. The
-      // separator (` — `) must match what the `toCommon` side used to join,
-      // and it must not appear inside any constituent field value, or the
-      // split index will land on the wrong segment. See the join side above.
-      opportunity_number: {
-        split: { field: "customFields.compositeLabel.value", sep: " — ", index: 0 },
-      },
-      opportunity_id: { field: "customFields.legacyId.value" },
-      agency_name: { field: "customFields.agencyName.value" },
-      // Round-trip the "doesn't apply" assertion back to native: the null
-      // sourced from `source` on the CG side becomes `source_url: null` again.
-      source_url: { field: "source" },
-      summary: {
-        applicant_types: { field: "customFields.applicantTypes.value" },
-      },
-    },
-  },
-  new Map([
-    ["join", joinFields],
-    ["split", splitField],
-  ])
-  // Note: do NOT pass ExtendedOpportunitySchema here — definePlugin wraps
-  // toCommon with wrapWithSchemaValidation, which applies the schema once.
-  // Passing it here too would cause double-validation and fail on date fields
-  // (Zod's .transform() produces Date objects; a second pass expects strings).
-);
-
-// ############################################################################
-// Step 5 — Plug the compiled transforms into a plugin definition
-// ############################################################################
-
-// All per-object input — customFields, toCommon, and fromCommon — lives on
-// the same schemas[Opportunity] entry. See SchemaInput in
-// extensions/types.ts for details.
-const grantsGovPlugin = definePlugin({
-  meta: {
-    name: "grants.gov",
-    version: "0.1.0",
-    sourceSystem: "grants.gov",
-    capabilities: ["customFields", "transforms"],
-  },
+// definePlugin() compiles these mappings into toCommon / fromCommon using the
+// built-in handlers (`field`, `match`, `const`). No buildTransforms() call here.
+const mappingsPlugin = definePlugin({
+  meta: { name: "grants.gov (mappings)", sourceSystem: "grants.gov" },
   schemas: {
-    Opportunity: { customFields: customFieldSpecs, toCommon, fromCommon },
+    Opportunity: {
+      customFields,
+      sourceSchema: GrantsGovOpportunity,
+      mappings: {
+        toCommon: {
+          id: { field: "data.opportunity_uuid" },
+          title: { field: "data.opportunity_title" },
+          description: { field: "data.opportunity_description" },
+          // Three-state null: a terminal `null` is preserved as a real null.
+          source: { field: "data.source_url" },
+          createdAt: { field: "data.created_at" },
+          lastModifiedAt: { field: "data.last_modified_at" },
+          status: {
+            value: {
+              match: {
+                field: "data.opportunity_status",
+                case: { posted: "open", archived: "closed" },
+                default: "custom",
+              },
+            },
+          },
+          customFields: {
+            legacyId: {
+              value: { field: "data.opportunity_id" },
+              name: "legacyId",
+              fieldType: "integer",
+            },
+          },
+        },
+        fromCommon: {
+          data: {
+            opportunity_uuid: { field: "id" },
+            opportunity_title: { field: "title" },
+            opportunity_description: { field: "description" },
+            source_url: { field: "source" },
+            created_at: { field: "createdAt" },
+            last_modified_at: { field: "lastModifiedAt" },
+            opportunity_status: { const: "posted" },
+            opportunity_id: { field: "customFields.legacyId.value" },
+          },
+        },
+      },
+    },
   },
-} as const);
+});
 
 // ############################################################################
-// Step 6 — Run the round trip and report
+// Path 2 — custom fields + hand-written functions
+// ############################################################################
+
+// The author annotates the functions with `ToCommon` / `FromCommon`, passing the
+// same inputs `definePlugin()` uses — `model`, `sourceSchema`, and the
+// `customFields` specs they already have. The SDK resolves the common type from
+// those (no need to build or borrow a `commonSchema`). One common type is used
+// for both directions: the common date schemas accept either a string or a
+// `Date`, so the author builds and returns real `Date` values here, and reads
+// `Date` values back in `fromCommon`.
+type OpportunityTransform = {
+  model: "Opportunity";
+  sourceSchema: typeof GrantsGovOpportunity;
+  customFields: typeof customFields;
+};
+
+// The functions path is the override path for logic the declarative mappings
+// can't express — here, a status flag derived in code rather than via `match`.
+const toCommon: ToCommon<OpportunityTransform> = source => ({
+  result: {
+    id: source.data.opportunity_uuid,
+    title: source.data.opportunity_title,
+    description: source.data.opportunity_description,
+    source: source.data.source_url,
+    status: { value: source.data.opportunity_status === "posted" ? "open" : "custom" },
+    createdAt: new Date(source.data.created_at),
+    lastModifiedAt: new Date(source.data.last_modified_at),
+    customFields: {
+      legacyId: { name: "legacyId", fieldType: "integer", value: source.data.opportunity_id },
+    },
+  },
+  errors: [],
+});
+
+const fromCommon: FromCommon<OpportunityTransform> = common => ({
+  result: {
+    data: {
+      opportunity_uuid: common.id,
+      opportunity_id: common.customFields?.legacyId?.value ?? 0,
+      opportunity_title: common.title,
+      opportunity_description: common.description,
+      opportunity_status: "posted",
+      source_url: common.source ?? null,
+      // `createdAt` / `lastModifiedAt` arrive as `Date`; render back to strings.
+      created_at: common.createdAt.toISOString(),
+      last_modified_at: common.lastModifiedAt.toISOString(),
+    },
+  },
+  errors: [],
+});
+
+const functionsPlugin = definePlugin({
+  meta: { name: "grants.gov (functions)", sourceSystem: "grants.gov" },
+  schemas: {
+    Opportunity: { customFields, sourceSchema: GrantsGovOpportunity, toCommon, fromCommon },
+  },
+});
+
+// ############################################################################
+// Path 3 — transforms with no custom fields
+// ############################################################################
+
+// Omit `customFields`; the common schema is the base CommonGrants Opportunity.
+const noCustomFieldsPlugin = definePlugin({
+  meta: { name: "grants.gov (no custom fields)", sourceSystem: "grants.gov" },
+  schemas: {
+    Opportunity: {
+      sourceSchema: GrantsGovOpportunity,
+      mappings: {
+        toCommon: {
+          id: { field: "data.opportunity_uuid" },
+          title: { field: "data.opportunity_title" },
+          description: { field: "data.opportunity_description" },
+          source: { field: "data.source_url" },
+          createdAt: { field: "data.created_at" },
+          lastModifiedAt: { field: "data.last_modified_at" },
+          status: {
+            value: {
+              match: {
+                field: "data.opportunity_status",
+                case: { posted: "open", archived: "closed" },
+                default: "custom",
+              },
+            },
+          },
+        },
+        fromCommon: {
+          data: {
+            opportunity_uuid: { field: "id" },
+            opportunity_title: { field: "title" },
+            opportunity_description: { field: "description" },
+            source_url: { field: "source" },
+            created_at: { field: "createdAt" },
+            last_modified_at: { field: "lastModifiedAt" },
+            opportunity_status: { const: "posted" },
+          },
+        },
+      },
+    },
+  },
+});
+
+// ############################################################################
+// Path X — mappings + functions on one entry is rejected (XOR)
+// ############################################################################
+
+// Providing both `mappings` and explicit callables is a compile error and a
+// runtime error. Wrapped here so the runtime backstop can be demonstrated
+// without aborting the script.
+function demonstrateXorIsRejected(): void {
+  try {
+    definePlugin({
+      schemas: {
+        Opportunity: {
+          sourceSchema: GrantsGovOpportunity,
+          mappings: { toCommon: {}, fromCommon: {} },
+          // @ts-expect-error — mappings XOR functions: cannot provide both on one entry
+          toCommon,
+        },
+      },
+    });
+    fail("path X: expected definePlugin to reject mappings + functions");
+  } catch {
+    console.log("path X (XOR): mappings + functions rejected at runtime, too");
+  }
+}
+
+// ############################################################################
+// Run the round trips and report
 // ############################################################################
 
 function fail(message: string): never {
@@ -262,63 +269,80 @@ function fail(message: string): never {
   process.exit(1);
 }
 
-const toCommonResult = grantsGovPlugin.schemas.Opportunity.toCommon?.(SOURCE_DATA);
-if (!toCommonResult) fail("schemas.Opportunity.toCommon missing");
-if (toCommonResult.errors.length > 0) {
-  // The source data in this example is fixed and PII-free, so embedding
-  // `e.message` here is safe. Production adopters: `TransformError.message` can
-  // carry source values on the Zod-validation path (Zod's default error map
-  // embeds runtime values). See the README PII warning before copying this
-  // logging shape.
-  fail(
-    `toCommon failed: ${toCommonResult.errors
-      .map(e => `[${e.path ?? "?"}] ${e.message}`)
-      .join("; ")}`
-  );
+function check(label: string, condition: boolean): void {
+  if (!condition) fail(`✗ ${label}`);
+  console.log(`✓ ${label}`);
 }
 
-// The console output below dumps the entire transform result for demonstration.
-// Production callers should not log `result` without a PII review — applicant
-// records, EINs, and free-text fields routinely flow through `customFields`.
-console.log("=== toCommon (native → CommonGrants) ===");
-console.log(JSON.stringify(toCommonResult.result, null, 2));
-
-const fromCommonResult = grantsGovPlugin.schemas.Opportunity.fromCommon?.(toCommonResult.result);
-if (!fromCommonResult) fail("schemas.Opportunity.fromCommon missing");
-if (fromCommonResult.errors.length > 0) {
-  // Same PII caveat as the toCommon error block above — `e.message` may carry
-  // source values on the Zod path. Safe here because the example data is fixed.
-  fail(
-    `fromCommon failed: ${fromCommonResult.errors
-      .map(e => `[${e.path ?? "?"}] ${e.message}`)
-      .join("; ")}`
-  );
+function reportErrors(label: string, result: TransformResult<unknown>): void {
+  // Source data here is fixed and PII-free, so printing messages is safe.
+  // Production adopters: `TransformError.message` can carry source values on the
+  // Zod-validation path — see the README PII warning before copying this shape.
+  if (result.errors.length > 0) {
+    fail(
+      `${label} produced errors: ${result.errors.map(e => `[${e.path ?? "?"}] ${e.message}`).join("; ")}`
+    );
+  }
 }
 
-console.log("\n=== fromCommon (CommonGrants → native) ===");
-console.log(JSON.stringify(fromCommonResult.result, null, 2));
+function roundTrip(
+  label: string,
+  plugin: { schemas: { Opportunity: { toCommon?: unknown; fromCommon?: unknown } } },
+  opts: { expectLegacyId: boolean }
+): void {
+  // The harness drives every plugin through one shape; the resolved common
+  // output type read off a built plugin is fine here (this is test plumbing, not
+  // the author-facing annotation the functions path above demonstrates).
+  type HarnessCommon = z.output<typeof mappingsPlugin.schemas.Opportunity.commonSchema>;
+  const opp = plugin.schemas.Opportunity;
+  const toCommonFn = opp.toCommon as (s: GrantsGovSource) => TransformResult<HarnessCommon>;
+  const fromCommonFn = opp.fromCommon as (c: HarnessCommon) => TransformResult<GrantsGovSource>;
 
-// Spot-check a covered field round-trips.
-const native = fromCommonResult.result as {
-  data: { opportunity_number: string; source_url: string | null | undefined };
-};
-if (native.data.opportunity_number !== SOURCE_DATA.data.opportunity_number) {
-  fail(
-    `round-trip mismatch on opportunity_number: ${native.data.opportunity_number} ≠ ${SOURCE_DATA.data.opportunity_number}`
+  const common = toCommonFn(SOURCE_DATA);
+  reportErrors(`${label} toCommon`, common);
+
+  const back = fromCommonFn(common.result);
+  reportErrors(`${label} fromCommon`, back);
+
+  // The uuid round-trips verbatim in every path (unlike the parsed date fields).
+  check(
+    `${label}: opportunity_uuid round-trips`,
+    back.result.data.opportunity_uuid === SOURCE_DATA.data.opportunity_uuid
   );
+  // Three-state null survives both directions as a real null, not undefined.
+  check(
+    `${label}: source_url null ('doesn't apply') preserved`,
+    back.result.data.source_url === null
+  );
+  // The legacy id only round-trips when a custom field carries it across.
+  if (opts.expectLegacyId) {
+    check(`${label}: legacy opportunity_id round-trips`, back.result.data.opportunity_id === 12345);
+  }
 }
 
-// Three-state pin: an explicit `null` ("doesn't apply") on the
-// source side must survive both transforms as a real `null`, not collapse
-// to undefined ("not provided"). A future regression that put `undefined`
-// here instead of `null` would fail this check.
-if (native.data.source_url !== null) {
-  fail(
-    `three-state mismatch on source_url: expected explicit null ("doesn't apply"), got ${JSON.stringify(
-      native.data.source_url
-    )}`
+function main(): void {
+  console.log("=== Transforms via definePlugin ===\n");
+
+  console.log("--- Path 1: declarative mappings ---");
+  // `mappings` is kept on the entry for inspection (absent on the functions path).
+  check("mappings inspectable", mappingsPlugin.schemas.Opportunity.mappings !== undefined);
+  roundTrip("mappings", mappingsPlugin, { expectLegacyId: true });
+
+  console.log("\n--- Path 2: hand-written functions ---");
+  check(
+    "mappings absent (functions path)",
+    functionsPlugin.schemas.Opportunity.mappings === undefined
   );
+  roundTrip("functions", functionsPlugin, { expectLegacyId: true });
+
+  console.log("\n--- Path 3: no custom fields ---");
+  check("customFields absent", noCustomFieldsPlugin.schemas.Opportunity.customFields === undefined);
+  roundTrip("base", noCustomFieldsPlugin, { expectLegacyId: false });
+
+  console.log("\n--- Path X: mappings XOR functions ---");
+  demonstrateXorIsRejected();
+
+  console.log("\n=== Example complete ===");
 }
 
-console.log("\n✓ round-trip verified for fields covered by both mappings");
-console.log("✓ three-state null preserved: source_url null ('doesn't apply') round-tripped");
+main();

--- a/lib/ts-sdk/src/extensions/README.md
+++ b/lib/ts-sdk/src/extensions/README.md
@@ -32,6 +32,7 @@ The `@common-grants/sdk/extensions` module provides TypeScript utilities for wor
   - [Wiring transforms into a plugin](#wiring-transforms-into-a-plugin)
   - [Error handling](#error-handling)
 - [Best practices](#best-practices)
+  - [When you need `as const`](#when-you-need-as-const)
   - [Export value schemas alongside your plugin](#export-value-schemas-alongside-your-plugin)
   - [Use `peerDependencies` for `@common-grants/sdk`](#use-peerdependencies-for-common-grantssdk)
   - [Keep plugins focused](#keep-plugins-focused)
@@ -92,7 +93,7 @@ opportunity.customFields?.category?.value; // string
 
 **Key points:**
 
-- Pass `as const` to the specs object so TypeScript can infer literal `fieldType` values and preserve the specific keys.
+- `as const` on the specs is only needed when you assign them to a variable before the call; inline specs are inferred correctly without it. Forgetting it on a hoisted variable is a compile error. See [When you need `as const`](#when-you-need-as-const) for details.
 - If a `value` Zod schema is provided in the spec, the custom field's `value` property is typed according to that schema. Otherwise, a default type is inferred from `fieldType` (e.g. `"string"` -> `string`, `"integer"` -> `number`).
 - Unregistered custom fields still pass through validation but are typed as the base `CustomField` type (with `value: unknown`).
 
@@ -224,7 +225,7 @@ const myPlugin = definePlugin({
 ```
 
 > [!IMPORTANT]
-> Always pass `as const` to the options object for `definePlugin()` (and the specs object for `withCustomFields()`). Without it, TypeScript widens literal types like `"string"` to `string`, which prevents the type system from inferring the correct `value` type for each custom field.
+> Always pass `as const` to the options object for `definePlugin()` (and the specs object for `withCustomFields()`) as a safe default. Without it, TypeScript can widen literal types like `"string"` to `string`, which prevents the type system from inferring the correct `value` type for each custom field. It is strictly required only when you assign the specs to a variable before the call; see [When you need `as const`](#when-you-need-as-const) for the details.
 
 The returned `Plugin` object has two properties:
 
@@ -595,6 +596,38 @@ for (const err of out.errors) {
 
 ## Best practices
 
+### When you need `as const`
+
+**Shortcut:** if you write `fieldType` using the `CustomFieldType` enum (e.g. `CustomFieldType.integer`), you never need `as const`. Enum values are already fixed literals and don't widen. The rest of this section only matters if you type `fieldType` as a raw string literal like `"integer"`.
+
+For raw string literals, `as const` is only required when you assign the specs (or the whole options object) to a **variable** before passing them to `definePlugin()` or `withCustomFields()`. Written **inline** in the call, you don't need it.
+
+**Why:** each spec's `fieldType` needs to stay a literal (`"integer"`, `"string"`) for the type system to work. A raw string literal passed inline is kept literal for you by the function. But stored in a variable first, TypeScript infers the variable's type on its own and widens the raw literal `"integer"` to `string`. A widened `fieldType` can no longer determine the field's `value` type, so `value` falls back to `unknown`. (This only affects fields that rely on the default value type. Fields that pass an explicit `value` schema keep their type either way, but it's simplest to apply `as const` whenever you hoist raw-literal specs. Enum values, as noted above, never widen.)
+
+You typically hoist specs into a variable to reuse them, for example to feed `typeof customFields` into the `ToCommon` / `FromCommon` transform helper types.
+
+```ts
+// OK (inline, no `as const` needed):
+definePlugin({
+  schemas: { Opportunity: { customFields: { legacyId: { fieldType: "integer" } } } },
+});
+
+// Needs `as const` (specs hoisted into a variable):
+const customFields = { legacyId: { fieldType: "integer" } } as const;
+definePlugin({ schemas: { Opportunity: { customFields } } });
+```
+
+If you hoist the specs and forget `as const`, the call still fails to compile. The message is TypeScript's built-in one: the widened `fieldType` (now `string`) is no longer a valid `CustomFieldType`. Adding `as const` resolves it.
+
+```ts
+const customFields = { legacyId: { fieldType: "integer" } }; // no `as const`
+definePlugin({ schemas: { Opportunity: { customFields } } });
+// Error: Type '{ fieldType: string; ... }' is not assignable to type 'CustomFieldSpec'.
+//        Type 'string' is not assignable to type '"string" | "number" | "integer" | ...'.
+```
+
+(Adding `as const` to an inline call is harmless, just unnecessary.)
+
 ### Export value schemas alongside your plugin
 
 When you define Zod schemas for complex `value` fields, export them as named exports from your package. Downstream consumers may need these schemas for use with utilities like `getCustomFieldValue()`:
@@ -688,8 +721,9 @@ The tables below list everything exported from `@common-grants/sdk/extensions`, 
 | [`SchemaOnly`](./types.ts)                           | interface | Compiled output for schema-only entries: `{ commonSchema, sourceSchema? }`. Produced when no transforms are configured.                                                                                                                           |                                                                         |
 | [`SchemaWithTransforms`](./types.ts)                 | interface | Compiled output for entries with transforms: `{ commonSchema, sourceSchema?, toCommon, fromCommon }`. Produced when `mappings` or explicit callables are provided.                                                                                |                                                                         |
 | [`SchemaMappings`](./types.ts)                       | interface | Declarative `{ toCommon?, fromCommon? }` mapping dicts. Stored inside `SchemaInput.mappings`.                                                                                                                                                     |                                                                         |
-| [`ToCommon`](./types.ts)                             | type      | Helper alias for `(source: TSource) => TransformResult<TCommon>`.                                                                                                                                                                                 |                                                                         |
-| [`FromCommon`](./types.ts)                           | type      | Helper alias for `(common: TCommon) => TransformResult<TSource>`.                                                                                                                                                                                 |                                                                         |
+| [`TransformTypes`](./transform-helpers.ts)           | interface | Named argument for `ToCommon` / `FromCommon`: `{ model, sourceSchema, customFields? }`. `model` selects the base schema; the common type is resolved from `customFields`.                                                                         |                                                                         |
+| [`ToCommon`](./transform-helpers.ts)                 | type      | Helper type for a hand-written `toCommon`. Takes a `TransformTypes` arg; `source` is typed from `sourceSchema`, the return checked against the resolved common **input** type.                                                                    |                                                                         |
+| [`FromCommon`](./transform-helpers.ts)               | type      | Helper type for a hand-written `fromCommon`. Takes a `TransformTypes` arg; `common` is the resolved common **output** type, the return the source type.                                                                                           |                                                                         |
 
 ### Shared types
 

--- a/lib/ts-sdk/src/extensions/define-plugin.ts
+++ b/lib/ts-sdk/src/extensions/define-plugin.ts
@@ -204,9 +204,8 @@ export function definePlugin<const T extends PluginSchemasInput>(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fromCommon = built.fromCommon as any;
     } else if (hasCallables) {
-      // Explicit callables path: validate both directions. A transforms entry
-      // always carries a sourceSchema (see SchemaInput), so fromCommon output is
-      // validated against it unconditionally, mirroring toCommon against commonSchema.
+      // Explicit callables path: validate each direction's output. toCommon is
+      // checked against the commonSchema and fromCommon against the sourceSchema
       if (toCommon !== undefined) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         toCommon = wrapWithSchemaValidation(toCommon as any, commonSchema as any) as any;

--- a/lib/ts-sdk/src/extensions/define-plugin.ts
+++ b/lib/ts-sdk/src/extensions/define-plugin.ts
@@ -29,14 +29,7 @@ import { buildTransforms } from "./transforms";
  * `toCommon` / `fromCommon` callables, an optional `sourceSchema`, and optional
  * `customFields` specs. Passed as `DefinePluginOptions.schemas`.
  */
-// Each schema entry can have its own source/common type pair, which only gets
-// checked when buildTransforms() is called. `any` lets the dictionary hold
-// entries with different type parameters; a stricter type would reject valid
-// plugin configs at the point they're stored here.
-export type PluginSchemasInput = Partial<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Record<ExtensibleSchemaName, SchemaInput<any, any>>
->;
+export type PluginSchemasInput = Partial<Record<ExtensibleSchemaName, SchemaInput>>;
 
 /**
  * Options for `definePlugin()`.
@@ -211,13 +204,14 @@ export function definePlugin<const T extends PluginSchemasInput>(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fromCommon = built.fromCommon as any;
     } else if (hasCallables) {
-      // Explicit callables path: wrap each callable with schema validation so the
-      // runtime guarantee matches the mappings path (both directions get validated).
+      // Explicit callables path: validate both directions. A transforms entry
+      // always carries a sourceSchema (see SchemaInput), so fromCommon output is
+      // validated against it unconditionally, mirroring toCommon against commonSchema.
       if (toCommon !== undefined) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         toCommon = wrapWithSchemaValidation(toCommon as any, commonSchema as any) as any;
       }
-      if (fromCommon !== undefined && sourceSchema !== undefined) {
+      if (fromCommon !== undefined) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         fromCommon = wrapWithSchemaValidation(fromCommon as any, sourceSchema as any) as any;
       }

--- a/lib/ts-sdk/src/extensions/index.ts
+++ b/lib/ts-sdk/src/extensions/index.ts
@@ -26,13 +26,13 @@ export type {
   SchemaInput,
   SchemaOnly,
   SchemaWithTransforms,
-  ToCommon,
-  FromCommon,
   PluginCapability,
   PluginMeta,
   TransformResult,
 } from "./types";
 export { TransformError } from "./types";
+// Helper types for annotating hand-written toCommon / fromCommon functions.
+export type { ToCommon, FromCommon, TransformTypes } from "./transform-helpers";
 export type { BuiltTransforms } from "./transforms";
 export { buildTransforms } from "./transforms";
 export type { TransformFromMappingOptions } from "../utils/transformation";

--- a/lib/ts-sdk/src/extensions/transform-helpers.ts
+++ b/lib/ts-sdk/src/extensions/transform-helpers.ts
@@ -1,0 +1,98 @@
+/**
+ * Helper types for annotating hand-written `toCommon` / `fromCommon` functions.
+ *
+ * A flat, multi-key `definePlugin({ schemas })` can't infer a per-entry common
+ * type to check an inline transform function, so authors annotate their
+ * functions with these helpers to recover full typing: `source` typed from
+ * `sourceSchema`, and the common side resolved from `model` + `customFields` —
+ * exactly the inputs `definePlugin()` itself uses. Authors pass the specs they
+ * already have, not a prebuilt common schema.
+ *
+ * @module @common-grants/sdk/extensions
+ */
+
+import { z } from "zod";
+import { EXTENSIBLE_SCHEMA_MAP } from "./types";
+import type { CustomFieldSpec, ExtensibleSchemaName, TransformResult } from "./types";
+import type { WithCustomFieldsResult } from "./with-custom-fields";
+
+/**
+ * The single named argument for {@link ToCommon} / {@link FromCommon}.
+ *
+ * `model` names the extensible schema being transformed; it selects the base
+ * schema from `EXTENSIBLE_SCHEMA_MAP`, so the common type is resolved per model
+ * rather than assuming one hardcoded base. `customFields` is the field specs
+ * (not a prebuilt common schema); omit it for the bare base schema.
+ *
+ * @example
+ * ```ts
+ * type OppTransform = {
+ *   model: "Opportunity";
+ *   sourceSchema: typeof GrantsGovOpportunity;
+ *   customFields: typeof customFields;
+ * };
+ * const toCommon: ToCommon<OppTransform> = source => ({ result: { ... }, errors: [] });
+ * ```
+ */
+export interface TransformTypes {
+  /** The extensible model this transform targets (selects the base schema). */
+  model: ExtensibleSchemaName;
+  /** The source-system Zod schema; `source` is typed as its inferred type. */
+  sourceSchema: z.ZodTypeAny;
+  /** The custom field specs declared on the entry (NOT a prebuilt common schema). */
+  customFields?: Record<string, CustomFieldSpec>;
+}
+
+/** The base Zod schema for the model named by `T["model"]`. */
+type BaseSchemaOf<T extends TransformTypes> = (typeof EXTENSIBLE_SCHEMA_MAP)[T["model"]];
+
+/**
+ * The common Zod schema for `T`, resolved exactly as `definePlugin()` builds it:
+ * the model's base schema, extended via `withCustomFields()` when `customFields`
+ * is present.
+ */
+type CommonSchemaOf<T extends TransformTypes> =
+  T["customFields"] extends Record<string, CustomFieldSpec>
+    ? WithCustomFieldsResult<BaseSchemaOf<T>, T["customFields"]>
+    : BaseSchemaOf<T>;
+
+/**
+ * Type for a hand-written `toCommon`.
+ *
+ * `source` is typed from `sourceSchema`; the return is checked against the
+ * resolved common type. Both directions use the same common type because the
+ * common date schemas accept either a string or a `Date` as input (they
+ * normalize internally), so the author can build and return real `Date` values.
+ *
+ * @example
+ * ```ts
+ * const toCommon: ToCommon<{
+ *   model: "Opportunity";
+ *   sourceSchema: typeof GrantsGovOpportunity;
+ *   customFields: typeof customFields;
+ * }> = source => ({ result: { ... }, errors: [] });
+ * ```
+ */
+export type ToCommon<T extends TransformTypes> = (
+  source: z.infer<T["sourceSchema"]>
+) => TransformResult<z.infer<CommonSchemaOf<T>>>;
+
+/**
+ * Type for a hand-written `fromCommon`.
+ *
+ * `common` is the resolved common type (what a consumer holds after `toCommon`
+ * ran — e.g. date fields as `Date`). The return is the source type inferred
+ * from `sourceSchema`.
+ *
+ * @example
+ * ```ts
+ * const fromCommon: FromCommon<{
+ *   model: "Opportunity";
+ *   sourceSchema: typeof GrantsGovOpportunity;
+ *   customFields: typeof customFields;
+ * }> = common => ({ result: { ... }, errors: [] });
+ * ```
+ */
+export type FromCommon<T extends TransformTypes> = (
+  common: z.infer<CommonSchemaOf<T>>
+) => TransformResult<z.infer<T["sourceSchema"]>>;

--- a/lib/ts-sdk/src/extensions/types.ts
+++ b/lib/ts-sdk/src/extensions/types.ts
@@ -305,41 +305,9 @@ export interface SchemaWithTransforms<TSource, TCommon> {
   fromCommon: (common: TCommon) => TransformResult<TSource>;
 }
 
-/**
- * Convenience type alias for a `toCommon` transform function.
- *
- * Annotate hand-written transform functions with this type to get full
- * compile-time checking on both the source input and the common output.
- * `TSource` comes from `z.infer<typeof sourceSchema>` and `TCommon` comes
- * from `z.infer<typeof extendedCommonSchema>` (the schema produced by
- * `withCustomFields()` when custom fields are declared).
- *
- * @example
- * ```ts
- * // Without custom fields — TCommon is z.infer<typeof OpportunityBaseSchema>
- * const toCommon: ToCommon<z.infer<typeof SourceSchema>, z.infer<typeof OpportunityBaseSchema>>
- *   = source => ({ result: { ... }, errors: [] });
- *
- * // With custom fields — TCommon is the extended schema type
- * const toCommon: ToCommon<z.infer<typeof SourceSchema>, z.infer<typeof ExtendedSchema>>
- *   = source => ({ result: { ... }, errors: [] });
- * ```
- */
-export type ToCommon<TSource, TCommon> = (source: TSource) => TransformResult<TCommon>;
-
-/**
- * Convenience type alias for a `fromCommon` transform function.
- *
- * Annotate hand-written transform functions with this type to get full
- * compile-time checking on both the common input and the source output.
- *
- * @example
- * ```ts
- * const fromCommon: FromCommon<z.infer<typeof SourceSchema>, z.infer<typeof OpportunityBaseSchema>>
- *   = common => ({ result: { ... }, errors: [] });
- * ```
- */
-export type FromCommon<TSource, TCommon> = (common: TCommon) => TransformResult<TSource>;
+// `ToCommon` / `FromCommon` helper types for hand-written transforms live in
+// ./transform-helpers (they depend on WithCustomFieldsResult, which would make
+// this foundation module circular).
 
 /**
  * Plugin identity and capability declaration.

--- a/lib/ts-sdk/src/extensions/types.ts
+++ b/lib/ts-sdk/src/extensions/types.ts
@@ -305,10 +305,6 @@ export interface SchemaWithTransforms<TSource, TCommon> {
   fromCommon: (common: TCommon) => TransformResult<TSource>;
 }
 
-// `ToCommon` / `FromCommon` helper types for hand-written transforms live in
-// ./transform-helpers (they depend on WithCustomFieldsResult, which would make
-// this foundation module circular).
-
 /**
  * Plugin identity and capability declaration.
  *

--- a/lib/ts-sdk/src/extensions/types.ts
+++ b/lib/ts-sdk/src/extensions/types.ts
@@ -232,41 +232,73 @@ export class TransformError extends Error {
 // ############################################################################
 
 /**
+ * Mappings authoring path: declarative `mappings` compiled by `buildTransforms()`
+ * inside `definePlugin()`. Requires a `sourceSchema`; forbids hand-written
+ * `toCommon` / `fromCommon`.
+ */
+export interface MappingsSchemaInput {
+  /** Custom fields to attach via `withCustomFields()`. */
+  customFields?: Record<string, CustomFieldSpec>;
+  /** Source-system Zod schema (the shape a source system returns). */
+  sourceSchema: z.ZodTypeAny;
+  /** Declarative mappings compiled into transforms by `definePlugin()`. */
+  mappings: SchemaMappings;
+  toCommon?: never;
+  fromCommon?: never;
+}
+
+/**
+ * Functions authoring path: hand-written `toCommon` / `fromCommon`. Requires a
+ * `sourceSchema` and both directions; forbids declarative `mappings`.
+ *
+ * The function slots are loose on the input side (`source: any`): a flat,
+ * multi-key `definePlugin()` cannot infer a per-entry common type to check an
+ * inline function, so the parameter falls to `any`. The slot still pins the
+ * `TransformResult` envelope (a function returning a non-`TransformResult` is
+ * rejected). Authors recover full typing with the `ToCommon` / `FromCommon`
+ * helper types, and the resolved consumer-facing types are always correct.
+ */
+export interface FunctionsSchemaInput {
+  /** Custom fields to attach via `withCustomFields()`. */
+  customFields?: Record<string, CustomFieldSpec>;
+  /** Source-system Zod schema (the shape a source system returns). */
+  sourceSchema: z.ZodTypeAny;
+  mappings?: never;
+  /** Map a source record to the common-schema shape. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  toCommon: (source: any) => TransformResult<unknown>;
+  /** Map a common-schema record back to the source shape. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fromCommon: (common: any) => TransformResult<unknown>;
+}
+
+/** Schema-only path: custom fields, no transforms. Forbids the other two paths. */
+export interface SchemaOnlyInput {
+  /** Custom fields to attach via `withCustomFields()`. */
+  customFields?: Record<string, CustomFieldSpec>;
+  sourceSchema?: never;
+  mappings?: never;
+  toCommon?: never;
+  fromCommon?: never;
+}
+
+/**
  * Author-provided input for a single extensible object, passed inside
  * `DefinePluginOptions.schemas`.
  *
- * Exactly one of `mappings` or explicit callables (`toCommon` / `fromCommon`)
- * may be present — providing both is a compile-time and runtime error.
+ * An exclusive choice between three paths:
+ * - {@link MappingsSchemaInput}: `sourceSchema` + declarative `mappings`.
+ * - {@link FunctionsSchemaInput}: `sourceSchema` + hand-written `toCommon` and
+ *   `fromCommon` (both required).
+ * - {@link SchemaOnlyInput}: `customFields` only, no transforms.
  *
- * `sourceSchema` is the optional Zod schema for the source system format.
- * `customFields` declares any extra fields this object exposes beyond the base
- * CommonGrants schema; `definePlugin()` applies them via `withCustomFields()`.
- *
- * `commonSchema` is intentionally absent here. It is injected by `definePlugin()`
- * during compilation, resolved from the generated model classes produced by the
- * code generator. Plugin config files cannot import from `generated/` (it is the
- * input to generation).
- *
- * When `mappings` is provided, `definePlugin()` auto-invokes `buildTransforms()`
- * at call time and wraps the result with schema validation against the compiled
- * common schema. When explicit callables are provided, `definePlugin()` wraps them
- * with the same schema validation so both paths give the same runtime guarantee.
+ * Both transform paths require a `sourceSchema`, so a transform can always be
+ * validated against the source shape. Supplying both `mappings` and functions,
+ * a single transform direction, or a transform without a `sourceSchema`, is a
+ * compile error (the `?: never` slots). `commonSchema` is intentionally absent;
+ * `definePlugin()` derives it from `customFields` during compilation.
  */
-export type SchemaInput<TSource = unknown, TCommon = unknown> =
-  | {
-      sourceSchema?: z.ZodType<TSource>;
-      customFields?: Record<string, CustomFieldSpec>;
-      mappings: SchemaMappings;
-      toCommon?: never;
-      fromCommon?: never;
-    }
-  | {
-      sourceSchema?: z.ZodType<TSource>;
-      customFields?: Record<string, CustomFieldSpec>;
-      mappings?: never;
-      toCommon?: (source: TSource) => TransformResult<TCommon>;
-      fromCommon?: (common: TCommon) => TransformResult<TSource>;
-    };
+export type SchemaInput = MappingsSchemaInput | FunctionsSchemaInput | SchemaOnlyInput;
 
 /**
  * Compiled output for a schema-only entry — no transforms configured.

--- a/lib/ts-sdk/src/schemas/zod/types.ts
+++ b/lib/ts-sdk/src/schemas/zod/types.ts
@@ -42,14 +42,31 @@ const ensureUTC = (date: string) => {
   );
 };
 
-/** Schema for UTC datetime fields */
-export const UTCDateTimeSchema = z.string().datetime().transform(ensureUTC);
+/**
+ * Accept a `Date` as input by normalizing it to a string before the string
+ * validators run, so a caller can pass either an ISO string or a `Date`. The
+ * string path keeps its strict validation unchanged; `toStr` renders a `Date`
+ * in the format the inner schema expects. Output is still a `Date`.
+ */
+const acceptDate =
+  (toStr: (d: Date) => string) =>
+  (val: unknown): unknown =>
+    val instanceof Date ? toStr(val) : val;
 
-/** Schema for ISO date format: YYYY-MM-DD (parsed into a Date object at midnight UTC) */
-export const ISODateSchema = z
-  .string()
-  .date()
-  .transform(str => new Date(str));
+/** Schema for UTC datetime fields (accepts an ISO string or a `Date`; outputs a `Date`) */
+export const UTCDateTimeSchema = z.preprocess(
+  acceptDate(d => d.toISOString()),
+  z.string().datetime().transform(ensureUTC)
+);
+
+/** Schema for ISO date format: YYYY-MM-DD (accepts a YYYY-MM-DD string or a `Date`; outputs a `Date`) */
+export const ISODateSchema = z.preprocess(
+  acceptDate(d => d.toISOString().slice(0, 10)),
+  z
+    .string()
+    .date()
+    .transform(str => new Date(str))
+);
 
 /** Schema for ISO time format: HH:MM:SS with optional fractional seconds and timezone (RFC 3339 partial-time) */
 export const ISOTimeSchema = z.preprocess(val => {
@@ -61,8 +78,11 @@ export const ISOTimeSchema = z.preprocess(val => {
   return val;
 }, z.string().time());
 
-/** Schema for offset datetime fields (ISO 8601 with timezone offset, parsed into a Date object) */
-export const OffsetDateTimeSchema = z
-  .string()
-  .datetime({ offset: true })
-  .transform(str => new Date(str));
+/** Schema for offset datetime fields (accepts an ISO 8601 offset string or a `Date`; outputs a `Date`) */
+export const OffsetDateTimeSchema = z.preprocess(
+  acceptDate(d => d.toISOString()),
+  z
+    .string()
+    .datetime({ offset: true })
+    .transform(str => new Date(str))
+);

--- a/lib/ts-sdk/src/schemas/zod/types.ts
+++ b/lib/ts-sdk/src/schemas/zod/types.ts
@@ -44,9 +44,10 @@ const ensureUTC = (date: string) => {
 
 /**
  * Accept a `Date` as input by normalizing it to a string before the string
- * validators run, so a caller can pass either an ISO string or a `Date`. The
- * string path keeps its strict validation unchanged; `toStr` renders a `Date`
- * in the format the inner schema expects. Output is still a `Date`.
+ * validators run, so a caller can pass either an ISO string or a `Date`. A
+ * string goes straight to the inner schema's strict validation; a `Date` is
+ * rendered by `toStr` into the string format the inner schema expects. Output
+ * is a `Date`.
  */
 const acceptDate =
   (toStr: (d: Date) => string) =>


### PR DESCRIPTION
### Summary

Updates `ToCommon`/`FromCommon` helper types so that plugin authors don't need a fully resolved `CommonSchema` in order to annotate their custom `toCommon()` and `fromCommon()` functions.

- Fixes #888 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- **Accepts `Date` as input to datetime types**
  - Adds a pre-processing step to date types (e.g. `IsoDateSchema`) so that both string (`"2024-12-01"`) and date inputs (`Date(2024, 12, 1)`) are accepted
  - This allows us to wrap the `toCommon()` function with an extra `commonSchema.safeParse()` check (which ensures that the function returns a valid type) even if the `toCommon()` function already returns a `Date()` type for fields like `createdAt` and `lastModifiedAt`
- **Updates `ToCommon`/`FromCommon` helper types**
  - Provides a `TransformTypes` with named inputs `{ model, sourceSchema, cusomFields }` that replaces the positional args in `ToCommon` and `FromCommon`
  - This allows plugin authors to simply provide `ToCommon` and `FromCommon` the same custom field definitions they're providing to `definePlugin()` instead of having to generate a fully resolved `commonSchema` just for the signature
- **Improves examples and docs**
  - Updates `examples/transforms.ts` to use `definePlugin()` with the `mapping` option rather than invoking `buildTransforms()` directly (since this happens behind the scenes)
  - Adds a few other transformation examples (e.g. providing custom transform functions, demonstrating compile-time checks, etc.)
  - Adds extra explanation around when and why `as const` is required to the README.
- **Requires `sourceSchema` when `mappings` or `toCommon`/`frommCommon` is provided:** This allows us to always validate the output `fromCommon()` matches `sourceSchema` and avoids propagating undefined checks on `sourceSchema` when a schema supports transformations.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Most of these are pretty neutral changes that just improve type inference and/or help plugin authors avoid having to generate their own `CommonSchema` to annotate custom transformation functions.

But the bigger change to the interface that's worth discussing is the shift to requiring `sourceSchema` when defining transformations (either via `mappings` or `toCommon`/`fromCommon`). Personally I think this is expected behavior: If a plugin is going to provide transformations, we should know what it's transforming to/from, and the workaround for plugin authors if they don't want to have to provide an explicit source schema is `z.object({}).passthrough()`. But we can talk through this further if y'all disagree.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="909" height="390" alt="Screenshot 2026-06-15 at 6 52 39 PM" src="https://github.com/user-attachments/assets/2f081dc3-e39d-41bd-8365-941747166281" />

