### PR TITLE
fix(ts-sdk): guard date schemas against invalid Date input

### DIFF
--- a/lib/ts-sdk/__tests__/schemas/zod/types.spec.ts
+++ b/lib/ts-sdk/__tests__/schemas/zod/types.spec.ts
@@ -170,6 +170,14 @@ describe("ISODate Schema", () => {
     expect(parsed.getUTCDate()).toBe(15);
   });
 
+  it("returns a validation error (not a thrown RangeError) for an invalid Date", () => {
+    // Regression: an Invalid Date is still `instanceof Date`, so toISOString()
+    // throws a RangeError inside preprocess that escapes safeParse. The guard
+    // routes an invalid Date to the string validator so safeParse stays total.
+    expect(() => ISODateSchema.safeParse(new Date("not a date"))).not.toThrow();
+    expect(ISODateSchema.safeParse(new Date("not a date")).success).toBe(false);
+  });
+
   it("should raise an error for an invalid ISODate", () => {
     // Must be in YYYY-MM-DD format
     expect(() => ISODateSchema.parse("01-01-2025")).toThrow();
@@ -325,6 +333,11 @@ describe("OffsetDateTime Schema", () => {
 
   it("accepts a Date object (normalized to an ISO string, then parsed back to a Date)", () => {
     expect(OffsetDateTimeSchema.parse(new Date("2025-01-01T00:00:00Z"))).toBeInstanceOf(Date);
+  });
+
+  it("returns a validation error (not a thrown RangeError) for an invalid Date", () => {
+    expect(() => OffsetDateTimeSchema.safeParse(new Date("not a date"))).not.toThrow();
+    expect(OffsetDateTimeSchema.safeParse(new Date("not a date")).success).toBe(false);
   });
 
   it("should raise an error for an invalid OffsetDateTime", () => {

--- a/lib/ts-sdk/src/schemas/zod/types.ts
+++ b/lib/ts-sdk/src/schemas/zod/types.ts
@@ -45,14 +45,16 @@ const ensureUTC = (date: string) => {
 /**
  * Accept a `Date` as input by normalizing it to a string before the string
  * validators run, so a caller can pass either an ISO string or a `Date`. A
- * string goes straight to the inner schema's strict validation; a `Date` is
- * rendered by `toStr` into the string format the inner schema expects. Output
- * is a `Date`.
+ * string goes straight to the inner schema's strict validation; a valid `Date`
+ * is rendered by `toStr` into the string format the inner schema expects. An
+ * invalid `Date` is passed through unchanged so the inner validator rejects it,
+ * rather than throwing a `RangeError` out of `toISOString()` and escaping
+ * `safeParse`. Output is a `Date`.
  */
 const acceptDate =
   (toStr: (d: Date) => string) =>
   (val: unknown): unknown =>
-    val instanceof Date ? toStr(val) : val;
+    val instanceof Date && !isNaN(val.getTime()) ? toStr(val) : val;
 
 /** Schema for UTC datetime fields (accepts an ISO string or a `Date`; outputs a `Date`) */
 export const UTCDateTimeSchema = z.preprocess(


### PR DESCRIPTION
### Summary

- Follow-up to #916: an invalid `Date` passed to the new date schemas throws a `RangeError` past `safeParse` instead of coming back as a validation error.
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- **Guard `acceptDate` against an invalid `Date`.** It called `toStr` (`.toISOString()`) on any `Date` instance, but an invalid `Date` (e.g. `new Date("garbage")`) is still `instanceof Date`, so `toISOString()` threw a `RangeError` from inside `z.preprocess`. That escapes `safeParse`, which is meant to be total, so an invalid date in a transform's output crashes instead of landing in `TransformResult.errors`. The guard (`!isNaN(val.getTime())`) routes an invalid `Date` to the string validator, which rejects it as a normal validation error.
- **Regression tests** for `ISODateSchema` and `OffsetDateTimeSchema` asserting `safeParse(new Date("not a date"))` returns `success: false` rather than throwing.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

- Verified with the SDK toolchain: `pnpm typespec` + `pnpm test` (28 passed), `tsc --noEmit` clean, `eslint` / `prettier` clean. The two new tests fail against the pre-fix code with `RangeError: Invalid time value` and pass with the guard, so they discriminate.
- No changeset: the affected `acceptDate` code is unreleased (lives only on `HOLD-transforms`) and #916 added none, so this rides under the existing `transforms-poc-typescript.md` when the bucket merges. Happy to add one if per-fix granularity is preferred.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Before vs after, against the SDK's own zod (`ISODateSchema`):

```
=== current (HOLD-transforms) ===
  invalid Date  new Date('garbage'):  THREW past safeParse -> RangeError: Invalid time value
=== with guard ===
  invalid Date  new Date('garbage'):  safeParse returned error -> Expected string, received date
```

A valid string (`"2024-12-01"`) and a valid `Date` parse fine either way.
