### PR TITLE
Fix stale PluginError references in transforms comments/docs

### DIFF
--- a/lib/python-sdk/common_grants_sdk/extensions/README.md
+++ b/lib/python-sdk/common_grants_sdk/extensions/README.md
@@ -48,7 +48,7 @@ Here are some key concepts that are used to define custom fields and plugins tha
 | **`Plugin`**            | A dataclass assembled by the code generator. `.schemas` is a container object where each attribute (e.g. `.schemas.Opportunity`) is an `ObjectSchemas` instance providing the model class (`.common`), transform callables (`.to_common`, `.from_common`), and native type (`.native`). `.extensions` holds the serializable extension declarations.                                               |
 | **`PluginExtensionsMeta`**        | Optional metadata attached to a plugin: `name`, `version`, `source_system`, and `capabilities` (e.g. `["customFields", "transforms"]`).                                                                     |
 | **`build_transforms()`**| Compiles a pair of mapping dicts into `(to_common, from_common)` callables. Each callable accepts a data dict **or a Pydantic model instance** and returns a `TransformResult`.                                                              |
-| **`TransformResult`**   | A dataclass `(result: dict, errors: list[PluginError])` returned by each transform callable. Errors are non-fatal — a partial result is always returned alongside any errors.                               |
+| **`TransformResult`**   | A dataclass `(result: dict, errors: list[TransformError])` returned by each transform callable. Errors are non-fatal — a partial result is always returned alongside any errors.                               |
 | **`ObjectSchemasInput`**| Bundles `custom_fields`, `to_common`, and `from_common` for a single object type. Passed to `define_plugin()` via the `schemas` parameter.                                                               |
 
 

--- a/lib/ts-sdk/__tests__/extensions/transformation.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/transformation.spec.ts
@@ -109,7 +109,7 @@ describe("switchOnValue", () => {
     // which let a typo'd mapping like `{ match: "literal-where-spec-belongs" }`
     // produce missing fields with no error trail. New contract: throw, so the
     // walker wraps as `HandlerError` and the boundary materializes a
-    // `PluginError` with `handler: "match"`.
+    // `TransformError` with `handler: "match"`.
     expect(() => switchOnValue({ status: "posted" }, "garbage")).toThrow(/spec must be an object/);
     expect(() => switchOnValue({ status: "posted" }, null)).toThrow(/spec must be an object/);
     expect(() => switchOnValue({ status: "posted" }, 42)).toThrow(/spec must be an object/);

--- a/lib/ts-sdk/src/extensions/transforms.ts
+++ b/lib/ts-sdk/src/extensions/transforms.ts
@@ -159,7 +159,7 @@ export interface BuiltTransforms<TSource, TCommon> {
  *
  * - Handler failures (a registered handler throws): the mapping walk
  *   short-circuits on the first failure, so `errors` carries exactly one
- *   `PluginError` even when several fields would have failed.
+ *   `TransformError` even when several fields would have failed.
  * - Zod-validation failures (`commonSchema` or `sourceSchema` provided): every
  *   `ZodIssue` is flattened into a separate `TransformError`, so `errors` carries
  *   the full set.

--- a/lib/ts-sdk/src/utils/transformation.ts
+++ b/lib/ts-sdk/src/utils/transformation.ts
@@ -196,8 +196,8 @@ export function stringToNumber(data: unknown, fieldPath: unknown): number | null
   if (Number.isFinite(f)) return f;
   // Don't embed the source value in the error message — it could be PII when
   // transforming applicant data. The handler name and cause flow into
-  // `PluginError` separately for programmatic reasoning. Adopters who need
-  // the offending value can still read it from `PluginError.sourceValue`
+  // `TransformError` separately for programmatic reasoning. Adopters who need
+  // the offending value can still read it from `TransformError.sourceValue`
   // (which carries its own PII warning).
   throw new Error("stringToNumber: cannot convert source value to a number");
 }


### PR DESCRIPTION
### Summary

- #916 renamed the transforms structured error from `PluginError` to `TransformError`, but left a handful of stale references behind in comments and one doc table. This updates them to match the type that's actually thrown.
- Comment/doc-only; no code or behavior change.
- Time to review: ~2 min.

### Changes proposed

> 5 stale `PluginError` → `TransformError` references in transforms-side comments and docs.

- `lib/ts-sdk/src/extensions/transforms.ts` — error-aggregation doc comment.
- `lib/ts-sdk/src/utils/transformation.ts` — two comments on `stringToNumber`'s error fields.
- `lib/ts-sdk/__tests__/extensions/transformation.spec.ts` — a test comment.
- `lib/python-sdk/common_grants_sdk/extensions/README.md` — the `TransformResult.errors` type in the concepts table.

### Context for reviewers

- The transforms code already throws `TransformError`; these were the only leftover references the rename missed. Verified no live `PluginError` (class, throw, or import) remains anywhere on the branch.
- Targets `HOLD-transforms` because these files live on that branch (the transforms work is not yet on `main`); the fix flows to `main` with #906.

### Additional information

N/A; comment and doc text only.
