### PR TITLE
docs(adr): amend ADR-0012 + ADR-0022 to match the implemented custom-filters design

### DIFF
--- a/website/src/content/docs/governance/adr/0012-filtering.md
+++ b/website/src/content/docs/governance/adr/0012-filtering.md
@@ -28,14 +28,14 @@ API endpoints that support filtering should be POST operations that accept a `fi
 - The `filters` parameter MUST be included at the root of the request body.
 - Each filter MUST conform to the `Filter` schema, which contains:
 
-| Property    | Type | Required | Description                              |
-| ----------- | ---- | -------- | ---------------------------------------- |
-| `operation` | enum | Yes      | The operation to perform on the value    |
-| `value`     | any  | Yes      | The data to use for the filter operation |
+| Property   | Type | Required | Description                               |
+| ---------- | ---- | -------- | ----------------------------------------- |
+| `operator` | enum | Yes      | The operator to apply to the filter value |
+| `value`    | any  | Yes      | The data to use for the filter operation  |
 
-- Supported operations:
+- Supported operators:
 
-| Operation | Description              | Supported `value` types                      |
+| Operator  | Description              | Supported `value` types                      |
 | --------- | ------------------------ | -------------------------------------------- |
 | `eq`      | Equal to                 | string, number, boolean, date                |
 | `neq`     | Not equal to             | string, number, boolean, date                |
@@ -63,14 +63,14 @@ An example of a request body that includes a _standard_ filter:
   "filters": {
     "title": {
       "value": "example",
-      "operation": "like"
+      "operator": "like"
     },
     "closedDateRange": {
       "value": {
         "min": "2024-01-01",
         "max": "2024-01-31"
       },
-      "operation": "between"
+      "operator": "between"
     }
   }
 }
@@ -83,12 +83,12 @@ An example of a request body that includes both _standard_ and _custom_ filters:
   "filters": {
     "title": {
       "value": "example",
-      "operation": "like"
+      "operator": "like"
     },
     "customFilters": {
       "agency": {
         "value": ["Department of Transportation"],
-        "operation": "in"
+        "operator": "in"
       }
     }
   }

--- a/website/src/content/docs/governance/adr/0012-filtering.md
+++ b/website/src/content/docs/governance/adr/0012-filtering.md
@@ -31,7 +31,7 @@ API endpoints that support filtering should be POST operations that accept a `fi
 | Property   | Type | Required | Description                               |
 | ---------- | ---- | -------- | ----------------------------------------- |
 | `operator` | enum | Yes      | The operator to apply to the filter value |
-| `value`    | any  | Yes      | The data to use for the filter operation  |
+| `value`    | any  | Yes      | The value to use for the filter operation |
 
 - Supported operators:
 

--- a/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
+++ b/website/src/content/docs/governance/adr/0022-plugin-framework.mdx
@@ -31,7 +31,7 @@ We decided to:
 
 1. **Keep "plugin" as the unified term** for both the published npm/PyPI packages in the website catalog and the runtime SDK object. No change to `PluginSourceEntry` or `src/content/plugins/index.json`. The existing `definePlugin()` function is expanded to accept the full set of top-level fields described below.
 
-2. **Use functional grouping at the top level** with two keys — `meta` and `schemas` — rather than grouping by object name at the root. Client configuration, auth, and custom filters are deferred to future capabilities and are not part of the current Plugin shape.
+2. **Use functional grouping at the top level** with keys for `meta`, `schemas`, and `routes` — rather than grouping by object name at the root. Client configuration and auth are deferred to future capabilities and are not part of the current Plugin shape.
 
 3. **Use per-object grouping inside `schemas`** where it reflects real coupling: each object's source schema, CommonGrants schema, and bidirectional transforms are tightly coupled and change together.
 
@@ -46,6 +46,8 @@ We decided to:
 8. **Custom handlers are registered per utility call, not globally.** `buildTransforms()` accepts an optional `handlers` argument (`Map<string, Handler>`) for registering additional handler names. Per-call scoping keeps behavior explicit and testable; name collisions with the default set raise at `buildTransforms()` call time rather than silently shadowing them. The registry is a `Map` rather than a plain object so that handler-name lookup uses `Map.has()` — which does not walk the prototype chain — rather than `in` or own-property checks on a plain object.
 
 9. **Transformation errors carry structured context.** SDK-emitted transformation errors extend a single `PluginError` base carrying field path, handler name, source value, and underlying cause, enabling programmatic reasoning without parsing error text. The source value may contain PII when transforming applicant data; adopters are responsible for redacting it before logging or re-raising, and the SDK does not redact by default.
+
+10. **Declare custom filters per route, not per schema.** Custom filters are declared in a route-keyed `routes` map — `routes[resource][method].filters[name]` carries a `CustomFilterSpec`. Filters attach to resource methods rather than schemas because filter availability varies by method, and classification resolves a filter by resource + method — a schema-keyed map cannot express this. A filter's `filterType` determines its allowed operators (derived, not authored). The SDKs provide the route declaration in language-idiomatic typed forms.
 
 The resulting Plugin shape:
 
@@ -127,8 +129,14 @@ interface SchemaMappings {
   fromCommon?: Record<string, unknown>; // ADR-0017 mapping: CommonGrants → source
 }
 
-// Scalar types only — filters are query parameters, not schema fields
-type CustomFilterType = "string" | "number" | "integer" | "boolean";
+// filterType names a semantic filter type (e.g. "stringArray", "dateRange",
+// "moneyComparison"); each maps 1:1 to a base filter with auto-derived operators.
+// See the SDK for the enumerated set.
+type CustomFilterType =
+  | "stringComparison"
+  | "stringArray"
+  | "dateRange"
+  | "moneyComparison";
 
 interface CustomFilterSpec {
   filterType: CustomFilterType;
@@ -140,6 +148,9 @@ interface Plugin {
   schemas: Partial<
     Record<ExtensibleSchemaName, SchemaConfig<unknown, unknown>>
   >;
+  // Route-keyed custom filter declarations (Decision #10):
+  // resource → method → { filters: { name: CustomFilterSpec } }. Typed as PluginRoutes in the SDK.
+  routes?: PluginRoutes;
 }
 
 // Input object for definePlugin(). Using a named-options object makes it easy to add
@@ -149,6 +160,8 @@ interface DefinePluginOptions {
   // Plugin authors provide input schemas and transforms; definePlugin() compiles them
   // into the full SchemaConfig runtime type, extending the base schema with any customFields.
   schemas?: Partial<Record<ExtensibleSchemaName, SchemaInput>>;
+  // Route-keyed custom filter declarations, passed through to Plugin.routes unchanged.
+  routes?: PluginRoutes;
 }
 
 // Factory: all options are optional so adopters can start with only what they need
@@ -271,8 +284,10 @@ class ObjectSchemasInput(Generic[TSource, TCommon]):
     to_common: Callable[[TSource], TransformResult[TCommon]] | None = None
     from_common: Callable[[TCommon], TransformResult[TSource]] | None = None
 
-# Scalar types only — filters are query parameters, not schema fields
-CustomFilterType = Literal['string', 'number', 'integer', 'boolean']
+# filter_type names a semantic filter type (e.g. 'stringArray', 'dateRange',
+# 'moneyComparison'); each maps 1:1 to a base filter with auto-derived operators.
+# See the SDK for the enumerated set.
+CustomFilterType = Literal['stringComparison', 'stringArray', 'dateRange', 'moneyComparison']
 
 @dataclass
 class CustomFilterSpec:
@@ -558,7 +573,7 @@ print(grants_gov_plugin.meta.capabilities)    # ["customFields", "transforms"]
 ### Consequences
 
 - **Positive consequences**
-  - Top-level surface (`meta`, `schemas`) is short, closed, and stable — adding protocol objects adds a key under `schemas` only
+  - Top-level surface (`meta`, `schemas`, `routes`) is short, closed, and stable — adding protocol objects adds a key under `schemas` only
   - Per-object grouping inside `schemas` preserves the real coupling between source schema, CommonGrants schema, and bidirectional transforms — they share type signatures and change together
   - All per-object declarations (custom fields, source type, declarative mappings, and explicit callables) are co-located under `schemas.<Object>` — no split across multiple top-level keys
   - `toCommon`/`fromCommon` can be plain hand-written functions, generated via `buildTransforms()` and passed in `schemas`, or auto-generated by `definePlugin()` from mappings declared in `schemas.<Object>.mappings` — plugin authors are not required to use a declarative mapping format
@@ -568,7 +583,7 @@ print(grants_gov_plugin.meta.capabilities)    # ["customFields", "transforms"]
   - `customFields` is optional — the `customFields`-only config structure remains valid; existing plugin packages require only minimal code changes to adopt `definePlugin()`
   - All top-level Plugin fields are optional — adopters can start with only what they need and expand incrementally
 - **Negative consequences**
-  - Client configuration, auth, and custom filters are deferred to future capabilities — current Plugin shape does not support them
+  - Client configuration and auth are deferred to future capabilities — current Plugin shape does not support them
 
 ### Criteria
 


### PR DESCRIPTION
### Summary

- Fixes #898
- Aligns ADR-0012 and ADR-0022 with the custom-filters design implemented on `HOLD-filters`. ADR-0012's filter schema now uses `operator` (matching TypeSpec and both SDKs), and ADR-0022 records the route-keyed custom-filter declaration instead of deferring filters.
- Targets `HOLD-filters` (not `main`) so these doc corrections travel with the custom-filter implementation and land with it.
- Time to review: 5 minutes

### Changes proposed

**ADR-0012 (`0012-filtering.md`):** rename the filter schema field `operation` to `operator` across the schema table, the operator-enum heading, and the JSON examples. The canonical TypeSpec (`lib/core/lib/core/filters/base.tsp`) names the field `operator`. Uses of "operation" that mean the act of filtering (HTTP "POST operations", the `value` field's "filter operation" description, which TypeSpec keeps verbatim) are deliberately left unchanged.

**ADR-0022 (`0022-plugin-framework.mdx`):** custom filters are no longer deferred.

- Decision #2 and the Consequences section now treat `routes` as part of the Plugin shape (client config and auth stay deferred).
- New Decision #10 records the route-keyed declaration: `routes[resource][method].filters[name]` carries a `CustomFilterSpec`, keyed by resource and method because filter availability varies by method and a schema-keyed map cannot express that. Operators derive from `filterType`.
- `routes?` is added to the TypeScript `Plugin` / `DefinePluginOptions` interface sketch, and `CustomFilterType` is corrected (the prior `string | number | integer | boolean` list was stale), shown as representative values with a pointer to the SDK for the full set.

### Context for reviewers

- Verification: `prettier --check` and `cspell` pass on both files. MDX render / `astro check` runs in CI (`ci:website`).
- Altitude: the ADR records the route-keyed decision and defers implementation specifics (the full `PluginRoutes` / `RouteDeclarations` types, the complete `CustomFilterType` enum, the Python typed-route carriers) to the SDKs and the tracked custom-filter issues, per the repo convention that ADR-0022 captures decisions rather than implementation detail.
- One asymmetry to be aware of: on `HOLD-filters`, `routes` is held on the TypeScript plugin object but not yet the Python one (Python keys routes through standalone validation and classification; wiring it onto the Python plugin object is a separate in-flight change). The ADR stays above this by describing the route declaration as language-idiomatic rather than transcribing both interfaces.

### Additional information

N/A
