### PR TITLE
[Issue #942] Org ID ADR update

### DIFF
--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -38,7 +38,7 @@ The collection looks like this:
           "scope": "US",
           "kind": "government"
         },
-        "id": "98-7654321"
+        "id": "987654321"
       }
     }
   },
@@ -60,11 +60,11 @@ The collection looks like this:
         "kind": "government",
         "schema": "https://commongrants.org/registries/us-ein/schema.json"
       },
-      "id": "12-3456789",
+      "id": "123456789",
       "allIds": [
-        { "id": "12-3456789", "status": "active" },
-        { "id": "65-4321098", "status": "active" },
-        { "id": "11-1111111", "status": "archived" }
+        { "id": "123456789", "status": "active" },
+        { "id": "654321098", "status": "active" },
+        { "id": "111111111", "status": "archived" }
       ],
       "uri": "https://apps.irs.gov/app/eos/detailsPage?ein=123456789",
       "verifiedAt": "2026-03-15T00:00:00Z",
@@ -423,7 +423,7 @@ The same shape extends to other models with model-specific keys:
 List routes accept two new query parameters, `registry` and `id`, that together let consumers locate a record by any of its registered identifiers without knowing the local UUID:
 
 ```
-GET /organizations?registry=us:ein&id=12-3456789
+GET /organizations?registry=us:ein&id=123456789
 GET /opportunities?registry=us:assistance-listing&id=93.575
 GET /applications?registry=fluxx:app&id=app-98765
 ```
@@ -467,7 +467,7 @@ A pure UUID is best if:
 GET /organizations/01912a8b-7c3d-7890-abcd-ef1234567890
 
 # Cross-system lookup by registry-scoped identifier (here: the org's EIN)
-GET /organizations?registry=us:ein&id=12-3456789
+GET /organizations?registry=us:ein&id=123456789
 ```
 
 - **Pros**
@@ -520,11 +520,11 @@ A composite ID is best if:
 **Example**
 
 ```
-GET /organizations/us:ein:12-3456789
+GET /organizations/us:ein:123456789
 ```
 
 - **Pros**
-  - Readable: `us:ein:12-3456789` makes the registry and value visible in logs and URLs.
+  - Readable: `us:ein:123456789` makes the registry and value visible in logs and URLs.
   - One string carries both registry and value, so no separate field is needed.
 - **Cons**
   - Forces systems to pick one registry as canonical, which is arbitrary for orgs with multiple IDs.
@@ -565,10 +565,10 @@ A map is best if:
         "code": "us:ein",
         "url": "https://commongrants.org/registries/us-ein"
       },
-      "id": "12-3456789",
+      "id": "123456789",
       "allIds": [
-        { "id": "12-3456789", "status": "active" },
-        { "id": "98-7654321", "status": "active" }
+        { "id": "123456789", "status": "active" },
+        { "id": "987654321", "status": "active" }
       ]
     },
     "us:uei": {
@@ -584,8 +584,8 @@ A map is best if:
 
 ```ts
 const ein = org.identifiers["us:ein"];
-ein.id; // "12-3456789" (primary)
-ein.allIds.map((v) => v.id); // ["12-3456789", "98-7654321"] (every known ID)
+ein.id; // "123456789" (primary)
+ein.allIds.map((v) => v.id); // ["123456789", "987654321"] (every known ID)
 ```
 
 - **Pros**
@@ -611,8 +611,8 @@ A flat array is best if:
 ```json
 {
   "identifiers": [
-    { "scheme": "US-EIN", "id": "12-3456789" },
-    { "scheme": "US-EIN", "id": "98-7654321" },
+    { "scheme": "US-EIN", "id": "123456789" },
+    { "scheme": "US-EIN", "id": "987654321" },
     { "scheme": "US-SAM", "id": "AB0123456789" }
   ]
 }
@@ -666,7 +666,7 @@ Keying by the canonical code is best if:
         "code": "us:ein",
         "url": "https://commongrants.org/registries/us-ein"
       },
-      "id": "12-3456789"
+      "id": "123456789"
     },
     "us:uei": {
       "registry": {
@@ -723,7 +723,7 @@ A camelCase alias is best if:
         "code": "us:ein",
         "url": "https://commongrants.org/registries/us-ein"
       },
-      "id": "12-3456789"
+      "id": "123456789"
     },
     "uei": {
       "registry": {
@@ -801,7 +801,7 @@ The `registry` object holds a curated subset of the catalog entry: the fields th
       "kind": "government",
       "schema": "https://commongrants.org/registries/us-ein/schema.json"
     },
-    "id": "12-3456789",
+    "id": "123456789",
     "uri": "https://apps.irs.gov/app/eos/detailsPage?ein=123456789",
     "verifiedAt": "2026-03-15T00:00:00Z"
   }
@@ -851,7 +851,7 @@ A flat shape is best if:
   "us:ein": {
     "registry": "us:ein",
     "registryUrl": "https://commongrants.org/registries/us-ein",
-    "id": "12-3456789"
+    "id": "123456789"
   }
 }
 ```
@@ -891,7 +891,7 @@ Full decomposition is best if:
       "lookupUriTemplate": "https://apps.irs.gov/app/eos/detailsPage?ein={id}",
       "orgIdGuide": "US-EIN"
     },
-    "id": "12-3456789"
+    "id": "123456789"
   }
 }
 ```
@@ -939,11 +939,11 @@ An object array is best if:
       "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein"
     },
-    "id": "12-3456789",
+    "id": "123456789",
     "allIds": [
-      { "id": "12-3456789", "status": "active" },
-      { "id": "98-7654321", "status": "active" },
-      { "id": "11-1111111", "status": "archived" }
+      { "id": "123456789", "status": "active" },
+      { "id": "987654321", "status": "active" },
+      { "id": "111111111", "status": "archived" }
     ]
   }
 }
@@ -979,15 +979,15 @@ A flat array is best if:
       "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein"
     },
-    "id": "12-3456789",
-    "allIds": ["12-3456789", "98-7654321", "11-1111111"]
+    "id": "123456789",
+    "allIds": ["123456789", "987654321", "111111111"]
   }
 }
 ```
 
 - **Pros**
   - Simple array of strings, no object wrapper.
-  - Native `contains()` / `in` membership checks against `allIds` work directly: `"98-7654321" in ein.allIds`.
+  - Native `contains()` / `in` membership checks against `allIds` work directly: `"987654321" in ein.allIds`.
 - **Cons**
   - Can't tell which IDs are still valid and which are archived.
   - Can't tell the difference between a fiscal-sponsor case (two active EINs) and a rename history.
@@ -1035,7 +1035,7 @@ A reference with identifiers is best if:
           "scope": "US",
           "kind": "government"
         },
-        "id": "98-7654321"
+        "id": "987654321"
       }
     }
   }
@@ -1100,7 +1100,7 @@ A full summary is best if:
           "code": "us:ein",
           "url": "https://commongrants.org/registries/us-ein"
         },
-        "id": "98-7654321"
+        "id": "987654321"
       }
     },
     "addresses": {
@@ -1159,7 +1159,7 @@ CommonGrants mints one `namespace:type` code per registry and treats it as the s
       "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein"
     },
-    "id": "12-3456789"
+    "id": "123456789"
   },
   "us:uei": {
     "registry": {
@@ -1220,7 +1220,7 @@ Adopting org-id.guide codes directly is best if:
       "code": "US-EIN",
       "url": "https://commongrants.org/registries/us-ein"
     },
-    "id": "12-3456789"
+    "id": "123456789"
   },
   "US-SAM": {
     "registry": {

--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -17,7 +17,7 @@ The protocol adopts an identification system that supports both uniquely identif
 
 :::caution[Important: publicly available identifiers only]
 
-The `identifiers` collection is intended for identifiers that are already publicly available as part of public award data (e.g. EIN, UEI, CFDA, platform-assigned opportunity IDs). Sensitive or private identifiers (applicant PII, internal account IDs, personal contact identifiers) are out of scope for this collection. Adopters handling sensitive data should use a separate mechanism that keeps those IDs out of `identifiers` and off URL query parameters.
+The `identifiers` collection is intended for identifiers that are already publicly available as part of public award data (e.g. EIN, UEI, Assistance Listing ID, platform-assigned opportunity IDs). Sensitive or private identifiers (applicant PII, internal account IDs, personal contact identifiers) are out of scope for this collection. Adopters handling sensitive data should use a separate mechanism that keeps those IDs out of `identifiers` and off URL query parameters.
 
 :::
 
@@ -31,9 +31,9 @@ The collection looks like this:
     "id": "01912a8b-7c3d-7891-abcd-ef1234567891",
     "name": "Example Parent Foundation",
     "identifiers": {
-      "ein": {
+      "us:ein": {
         "registry": {
-          "code": "US-EIN",
+          "code": "us:ein",
           "url": "https://commongrants.org/registries/us-ein",
           "scope": "US",
           "kind": "government"
@@ -52,9 +52,9 @@ The collection looks like this:
       },
       "id": "01912a8b-7c3d-7890-abcd-ef1234567890"
     },
-    "ein": {
+    "us:ein": {
       "registry": {
-        "code": "US-EIN",
+        "code": "us:ein",
         "url": "https://commongrants.org/registries/us-ein",
         "scope": "US",
         "kind": "government",
@@ -70,9 +70,9 @@ The collection looks like this:
       "verifiedAt": "2026-03-15T00:00:00Z",
       "verifiedBy": "irs.gov"
     },
-    "uei": {
+    "us:uei": {
       "registry": {
-        "code": "US-UEI",
+        "code": "us:uei",
         "url": "https://commongrants.org/registries/us-uei",
         "scope": "US",
         "kind": "government"
@@ -80,7 +80,7 @@ The collection looks like this:
       "id": "AB0123456789"
     },
     "otherIds": {
-      "candidBridge": {
+      "candid:bridge": {
         "registry": {
           "code": "candid:bridge",
           "url": "https://commongrants.org/registries/candid-bridge",
@@ -98,41 +98,45 @@ The collection looks like this:
 At a glance, the key decisions for this identification system are:
 
 1. **Top-level ID:** A pure UUID on each resource, with the hosting system's own ID also surfaced inside the collection as `systemId`.
-2. **Collection structure:** A map keyed by short base-identifier aliases, with a catch-all `otherIds` map for extensions.
-3. **Map key format:** Model-defined camelCase aliases (`ein`, `uei`, `duns`), not raw registry codes.
+2. **Collection structure:** A map keyed by registry code, with a catch-all `otherIds` map for extensions.
+3. **Map key format:** The registry's canonical CommonGrants code (`us:ein`, `us:uei`, `xi:duns`), used as both the map key and `registry.code`.
 4. **Identifier metadata structure:** A nested hybrid shape. Registry-level facts (the same for every record in the registry) live in a nested `registry` object with required `code` and `url` (linking to the catalog entry) plus optional `scope`, `kind`, and `schema`. Instance-level facts (`id`, `allIds`, `uri`, `verifiedAt`, `verifiedBy`) stay at the top level. Richer registry metadata (issuer, human-readable name, lookup template, etc.) lives in the external CommonGrants registry catalog reachable through `registry.url`.
 5. **Multiple IDs per registry:** `id` for the primary, plus an optional `allIds` array of `{ id, status }` objects covering every known ID for this registry (the primary included), so consumers can do membership checks against `allIds` alone.
 6. **Parent organization:** `parent` carries `id`, `name`, and optionally an embedded `identifiers` collection. Parent identifiers do not leak into the child's collection.
-7. **Registry code format:** org-id.guide codes (`US-EIN`, `GB-CHC`) for well-known public registries, `namespace:type` (`grants.gov:org`, `candid:bridge`) for everything else.
-8. **Registry governance:** CommonGrants maintains a registry catalog that wraps org-id.guide where applicable and adds CommonGrants-specific metadata (schema URLs, kind, lookup templates). A documented promotion flow moves a registry from `otherIds` to a base identifier on the relevant model.
+7. **Registry code format:** A single uniform `namespace:type` code (`us:ein`, `xi:duns`, `grants.gov:org`) minted and owned by CommonGrants for every registry, used as both the map key and `registry.code`. The equivalent org-id.guide code (when one exists) is recorded as an `orgIdGuide` cross-reference in the catalog, not used as the code itself.
+8. **Registry governance:** CommonGrants maintains a registry catalog that assigns each registry its canonical code, cross-references org-id.guide where applicable, and adds CommonGrants-specific metadata (schema URLs, kind, lookup templates). A documented promotion flow moves a registry from `otherIds` to a base identifier on the relevant model.
 
 ### Consequences
 
 - **Positive consequences**
   - One reusable `Identifier` / `IdentifierCollection` pair across every core model, with model-specific keys on each extension.
   - Multiple IDs per registry are represented explicitly, with active, additional, and archived cases distinguishable.
-  - Consistent with existing patterns (`AddressCollection`, `customFields`) and compatible with open data standards that use org-id.guide codes.
+  - Consistent with existing patterns (`AddressCollection`, `customFields`).
   - Nesting the `registry` object visually groups registry-level facts and points to the catalog entry via `registry.url`, so consumers can always find the source of truth.
   - The optional `registry.schema` URI lets new identifier types define their own validation without protocol changes.
   - `systemId` makes each collection self-contained: a consumer can match across systems without inspecting the top-level `id` separately.
+  - Registry codes are CommonGrants-owned and uniform, so they stay stable across org-id.guide renames and apply the same rule to registries org-id.guide does not cover.
+  - The map key equals `registry.code`, so there is one canonical string per registry rather than a separate alias to maintain.
 - **Negative consequences**
   - Breaking change: existing `ein`, `uei`, and `duns` fields on `OrganizationBase` must migrate.
   - Top-level `id` is duplicated in `identifiers.systemId.id`.
   - When `allIds` is present, the primary `id` value is repeated as one of the entries (deliberate, so consumers only need to check one place for membership).
   - Registry-level fields inside `registry` partially duplicate the catalog entry at `registry.url`, so adopters must keep them in sync.
   - Two extension mechanisms (`otherIds` for new registries, `allIds` for multiple IDs in one registry) add complexity.
+  - Codes diverge from org-id.guide for some registries (e.g. `us:uei` where org-id.guide uses `US-SAM`), so interoperating with org-id.guide-coded data requires a catalog lookup against the `orgIdGuide` cross-reference.
+  - Codes are not valid identifiers for dot access, so consumers reach them with bracket notation (`identifiers["us:ein"]`).
 
 ### Identifier key hierarchy
 
 Each `IdentifierCollection` has two tiers of keys:
 
-- **Base identifiers** are defined by `@common-grants/core` at the root of each model's `IdentifierCollection` extension (e.g. `ein`, `uei`, `duns` on `OrgIdentifierCollection`). Each one has an identifier-specific JSON schema that extends the generic `Identifier` schema, plus a registered entry in the CommonGrants registry catalog. Every CommonGrants-compliant system is expected to recognize them for that model.
-- **`otherIds`** is a catch-all map for identifiers the protocol does not define. Adopters can publish any identifier here using any camelCase alias they choose (e.g. `candidBridge`, `statePortalId`). Entries need only conform to the generic `Identifier` schema. They may optionally be listed in the CommonGrants registry catalog, but the key itself is not reserved or validated by the protocol.
+- **Base identifiers** are defined by `@common-grants/core` at the root of each model's `IdentifierCollection` extension (e.g. `us:ein`, `us:uei`, `xi:duns` on `OrgIdentifierCollection`). Each one has an identifier-specific JSON schema that extends the generic `Identifier` schema, plus a registered entry in the CommonGrants registry catalog. Every CommonGrants-compliant system is expected to recognize them for that model.
+- **`otherIds`** is a catch-all map for identifiers the protocol does not define. Adopters can publish any identifier here keyed by its `namespace:type` code (e.g. `candid:bridge`, `fluxx:org`). Entries need only conform to the generic `Identifier` schema. They may optionally be listed in the CommonGrants registry catalog, but the key itself is not reserved or validated by the protocol.
 
 **When to use each:**
 
-- If the registry has a base identifier on the model, publish it under that key.
-- If it doesn't (yet), publish it under `otherIds` with a descriptive alias.
+- If the registry has a base identifier on the model, publish it under that code at the top level.
+- If it doesn't (yet), publish it under `otherIds`, still keyed by its `namespace:type` code.
 - Consumers that want to consume new identifier types early can read from both places during the transition.
 
 **Identifier lifecycle**
@@ -141,7 +145,7 @@ An identifier can move through two stages: getting listed in the CommonGrants re
 
 _Stage 1: Register in the catalog (community-driven)_
 
-Cataloging an `otherIds` entry turns a one-off extension into a shared ID registry with a consistent alias, scope, kind, schema, and lookup template, so other systems can discover and reuse it. The key still lives under `otherIds`; cataloging just makes it easier for multiple systems to use this registry. Anyone can submit an entry by opening a PR that adds a file to the CommonGrants-hosted catalog, and a maintainer reviews it for the basics: is the registry coherent and well-documented, does it have a named issuer, and can values be validated.
+Cataloging an `otherIds` entry turns a one-off extension into a shared ID registry with a consistent code, scope, kind, schema, and lookup template, so other systems can discover and reuse it. The key still lives under `otherIds`; cataloging just makes it easier for multiple systems to use this registry. Anyone can submit an entry by opening a PR that adds a file to the CommonGrants-hosted catalog, and a maintainer reviews it for the basics: is the registry coherent and well-documented, does it have a named issuer, and can values be validated.
 
 _Stage 2: Promote to a base identifier (maintainer-driven)_
 
@@ -157,11 +161,11 @@ See [Registry governance](#registry-governance) for the full rationale behind th
 
 - **[Top-level ID format](#top-level-id-format):** Should the top-level `id` be a plain UUID, a prefixed UUID, or a registry-scoped composite string?
 - **[Collection structure](#collection-structure):** Should the identifier collection be a flat array or a keyed map?
-- **[Map key format](#map-key-format):** If the collection is a map, should the keys be raw registry codes or short model-defined aliases?
+- **[Map key format](#map-key-format):** If the collection is a map, should the keys be the registry's canonical code or short model-defined aliases?
 - **[Identifier metadata structure](#identifier-metadata-structure):** How much registry metadata belongs on each identifier instance, and how much should live in an external catalog?
 - **[Multiple IDs per registry](#multiple-ids-per-registry):** How should the protocol represent multiple IDs that share the same registry, including archived versions?
 - **[Parent organization representation](#parent-organization-representation):** What should a parent organization reference carry?
-- **[Registry code format](#registry-code-format):** Should registry codes follow org-id.guide, a uniform namespaced format, or both?
+- **[Registry code format](#registry-code-format):** Should registry codes adopt org-id.guide's codes directly, or use a uniform CommonGrants-owned format with org-id.guide recorded as a cross-reference?
 - **[Registry governance](#registry-governance):** Who maintains the registry catalog, and how does a registry get promoted from `otherIds` to a base identifier?
 
 ### Decision drivers
@@ -179,11 +183,11 @@ See [Registry governance](#registry-governance) for the full rationale behind th
 
 - **Top-level ID format:** pure UUID, prefixed UUID, composite registry:id
 - **Collection structure:** flat array, keyed map
-- **Map key format:** raw registry code, camelCase alias
+- **Map key format:** canonical registry code, camelCase alias
 - **Identifier metadata structure:** flat single-string registry, hybrid, fully decomposed
 - **Multiple IDs per registry:** array of `{ id, status }` objects, flat array of strings
 - **Parent representation:** minimal reference, reference with identifiers, full summary
-- **Registry code format:** uniform namespaced, hybrid (org-id.guide + namespaced)
+- **Registry code format:** uniform CommonGrants-owned codes (org-id.guide as cross-reference), adopt org-id.guide codes directly
 - **Registry governance:** org-id.guide only, CommonGrants-managed only, hybrid with promotion flow
 
 ### Schema definitions
@@ -204,7 +208,7 @@ Identifier:
       properties:
         code:
           type: string
-          description: Registry code (e.g. "US-EIN", "grants.gov:org")
+          description: Canonical CommonGrants registry code, "namespace:type" (e.g. "us:ein", "grants.gov:org")
         url:
           type: string
           format: uri
@@ -298,11 +302,11 @@ OrgIdentifierCollection:
     - $ref: "#/components/schemas/IdentifierCollection"
     - type: object
       properties:
-        ein:
+        "us:ein":
           $ref: "#/components/schemas/Identifier"
-        uei:
+        "us:uei":
           $ref: "#/components/schemas/Identifier"
-        duns:
+        "xi:duns":
           $ref: "#/components/schemas/Identifier"
 ```
 
@@ -329,19 +333,19 @@ The same shape extends to other models with model-specific keys:
       },
       "id": "01912a8b-7c3d-7892-abcd-ef1234567892"
     },
-    "opportunityNumber": {
+    "grants.gov:opp-number": {
       "registry": {
-        "code": "grants.gov:opp",
-        "url": "https://commongrants.org/registries/grants-gov-opp",
+        "code": "grants.gov:opp-number",
+        "url": "https://commongrants.org/registries/grants-gov-opp-number",
         "scope": "grants.gov",
         "kind": "platform"
       },
       "id": "HHS-2026-ACF-OCC-YD-0001"
     },
-    "cfda": {
+    "us:assistance-listing": {
       "registry": {
-        "code": "US-CFDA",
-        "url": "https://commongrants.org/registries/us-cfda",
+        "code": "us:assistance-listing",
+        "url": "https://commongrants.org/registries/us-assistance-listing",
         "scope": "US",
         "kind": "government"
       },
@@ -368,7 +372,7 @@ The same shape extends to other models with model-specific keys:
       "id": "01912a8b-7c3d-7893-abcd-ef1234567893"
     },
     "otherIds": {
-      "grantsGovTracking": {
+      "grants.gov:tracking": {
         "registry": {
           "code": "grants.gov:tracking",
           "url": "https://commongrants.org/registries/grants-gov-tracking",
@@ -398,9 +402,9 @@ The same shape extends to other models with model-specific keys:
       },
       "id": "01912a8b-7c3d-7894-abcd-ef1234567894"
     },
-    "fain": {
+    "us:fain": {
       "registry": {
-        "code": "US-FAIN",
+        "code": "us:fain",
         "url": "https://commongrants.org/registries/us-fain",
         "scope": "US",
         "kind": "government"
@@ -419,12 +423,12 @@ The same shape extends to other models with model-specific keys:
 List routes accept two new query parameters, `registry` and `id`, that together let consumers locate a record by any of its registered identifiers without knowing the local UUID:
 
 ```
-GET /organizations?registry=US-EIN&id=12-3456789
-GET /opportunities?registry=US-CFDA&id=93.575
+GET /organizations?registry=us:ein&id=12-3456789
+GET /opportunities?registry=us:assistance-listing&id=93.575
 GET /applications?registry=fluxx:app&id=app-98765
 ```
 
-`registry` may be passed on its own as a filter (e.g. `?registry=US-CFDA` returns every record that has a CFDA entry). `id` on its own is meaningless without a registry to scope it to and SHOULD be rejected with a 400.
+`registry` may be passed on its own as a filter (e.g. `?registry=us:assistance-listing` returns every record that has an Assistance Listing entry). `id` on its own is meaningless without a registry to scope it to and SHOULD be rejected with a 400.
 
 ## Evaluation
 
@@ -463,7 +467,7 @@ A pure UUID is best if:
 GET /organizations/01912a8b-7c3d-7890-abcd-ef1234567890
 
 # Cross-system lookup by registry-scoped identifier (here: the org's EIN)
-GET /organizations?registry=US-EIN&id=12-3456789
+GET /organizations?registry=us:ein&id=12-3456789
 ```
 
 - **Pros**
@@ -516,11 +520,11 @@ A composite ID is best if:
 **Example**
 
 ```
-GET /organizations/US-EIN:12-3456789
+GET /organizations/us:ein:12-3456789
 ```
 
 - **Pros**
-  - Readable: `US-EIN:12-3456789` makes the registry and value visible in logs and URLs.
+  - Readable: `us:ein:12-3456789` makes the registry and value visible in logs and URLs.
   - One string carries both registry and value, so no separate field is needed.
 - **Cons**
   - Forces systems to pick one registry as canonical, which is arbitrary for orgs with multiple IDs.
@@ -548,7 +552,7 @@ _Should the identifier collection be a flat array or a keyed map?_
 A map is best if:
 
 - we want keyed access and per-registry schemas,
-- but we're willing to differ structurally from org-id.guide (while still using its codes).
+- but we're willing to differ structurally from org-id.guide's flat-array wire shape.
   :::
 
 **Example**
@@ -556,9 +560,9 @@ A map is best if:
 ```json
 {
   "identifiers": {
-    "ein": {
+    "us:ein": {
       "registry": {
-        "code": "US-EIN",
+        "code": "us:ein",
         "url": "https://commongrants.org/registries/us-ein"
       },
       "id": "12-3456789",
@@ -567,9 +571,9 @@ A map is best if:
         { "id": "98-7654321", "status": "active" }
       ]
     },
-    "uei": {
+    "us:uei": {
       "registry": {
-        "code": "US-UEI",
+        "code": "us:uei",
         "url": "https://commongrants.org/registries/us-uei"
       },
       "id": "AB0123456789"
@@ -579,7 +583,7 @@ A map is best if:
 ```
 
 ```ts
-const ein = org.identifiers.ein;
+const ein = org.identifiers["us:ein"];
 ein.id; // "12-3456789" (primary)
 ein.allIds.map((v) => v.id); // ["12-3456789", "98-7654321"] (every known ID)
 ```
@@ -590,7 +594,7 @@ ein.allIds.map((v) => v.id); // ["12-3456789", "98-7654321"] (every known ID)
   - Clear separation of primary vs. alternate values per registry.
   - `otherIds` gives a natural extension point for non-standard registries.
 - **Cons**
-  - Differs structurally from org-id.guide, even though codes are shared.
+  - Differs structurally from org-id.guide's wire shape.
   - `otherIds` nesting adds one level of indirection for extensions.
 
 #### Option 2: Flat array
@@ -609,7 +613,7 @@ A flat array is best if:
   "identifiers": [
     { "scheme": "US-EIN", "id": "12-3456789" },
     { "scheme": "US-EIN", "id": "98-7654321" },
-    { "scheme": "US-UEI", "id": "AB0123456789" }
+    { "scheme": "US-SAM", "id": "AB0123456789" }
   ]
 }
 ```
@@ -628,26 +632,85 @@ const ein = org.identifiers.find((i) => i.scheme === "US-EIN");
 
 ### Map key format
 
-_If the collection is a map, should the keys be raw registry codes or short model-defined aliases?_
+_If the collection is a map, should the keys be the registry's canonical code or short model-defined aliases?_
+
+This sub-decision is settled together with [Registry code format](#registry-code-format): the key is the registry's canonical CommonGrants code, the same `namespace:type` string that appears in `registry.code`.
 
 #### Side-by-side comparison
 
-| Criteria                                       | camelCase alias (rec.) | Registry code as key |
-| ---------------------------------------------- | :--------------------: | :------------------: |
-| Dot access in JS, Python, Go, Ruby             |           ✅           |          ❌          |
-| Consistent with existing CG map key convention |           ✅           |          ❌          |
-| Stable if registry codes are renamed           |           ✅           |          ❌          |
-| No duplication with inline `registry` field    |           ✅           |          ❌          |
-| Works cleanly in JSON Pointer / JSONPath       |           ✅           |          🟡          |
-| Self-describing without catalog lookup         |           🟡           |          ✅          |
+| Criteria                                           | Canonical code (rec.) | camelCase alias |
+| -------------------------------------------------- | :-------------------: | :-------------: |
+| One canonical string per registry (key == `code`)  |          ✅           |       ❌        |
+| No separate alias-to-code mapping to maintain      |          ✅           |       ❌        |
+| Self-describing without a catalog lookup           |          ✅           |       🟡        |
+| Stable across org-id.guide renames (CG owns codes) |          ✅           |       ✅        |
+| Consistent with existing CG camelCase map keys     |          ❌           |       ✅        |
+| Dot access in JS, Python, Go                       |          ❌           |       ✅        |
 
-#### Option 1: camelCase alias (recommended)
+#### Option 1: Canonical registry code as key (recommended)
 
 :::note[Bottom line]
-camelCase aliases are best if:
+Keying by the canonical code is best if:
 
-- we want idiomatic access in most programming languages and stable keys across registry renames,
-- but we're willing to maintain a small mapping from alias to registry code.
+- we want one canonical string per registry, identical to `registry.code`, with no alias layer to keep in sync,
+- but we're willing to use bracket notation for access and to depart from the camelCase convention other CommonGrants maps use.
+  :::
+
+**Example**
+
+```json
+{
+  "identifiers": {
+    "us:ein": {
+      "registry": {
+        "code": "us:ein",
+        "url": "https://commongrants.org/registries/us-ein"
+      },
+      "id": "12-3456789"
+    },
+    "us:uei": {
+      "registry": {
+        "code": "us:uei",
+        "url": "https://commongrants.org/registries/us-uei"
+      },
+      "id": "AB0123456789"
+    },
+    "otherIds": {
+      "candid:bridge": {
+        "registry": {
+          "code": "candid:bridge",
+          "url": "https://commongrants.org/registries/candid-bridge"
+        },
+        "id": "1234567"
+      }
+    }
+  }
+}
+```
+
+```ts
+const ein = org.identifiers["us:ein"];
+const candid = org.identifiers.otherIds["candid:bridge"];
+```
+
+- **Pros**
+  - The key is the registry's `registry.code`, so there is exactly one canonical string per registry instead of a key, an alias, and a code.
+  - Self-describing: the key names the registry directly, with no alias-to-code mapping to maintain.
+  - CommonGrants owns the code space, so keys stay stable even if the equivalent org-id.guide code is renamed (that lives in the catalog cross-reference).
+  - The same `namespace:type` rule covers base identifiers and `otherIds` uniformly.
+- **Cons**
+  - Changing the registry code also introduces a breaking change to the data model/API.
+  - Colon-and-dot keys force bracket notation in most languages (JS, Python, Go).
+  - Departs from the camelCase convention other CommonGrants maps use (`customFields`, `addresses`, `emails`).
+  - The code appears in both the key and `registry.code` inside the entry.
+
+#### Option 2: camelCase alias
+
+:::note[Bottom line]
+A camelCase alias is best if:
+
+- we want idiomatic dot access and consistency with other CommonGrants maps,
+- but we're willing to maintain a separate alias-to-code mapping and accept that the key and `registry.code` are different strings.
   :::
 
 **Example**
@@ -657,14 +720,14 @@ camelCase aliases are best if:
   "identifiers": {
     "ein": {
       "registry": {
-        "code": "US-EIN",
+        "code": "us:ein",
         "url": "https://commongrants.org/registries/us-ein"
       },
       "id": "12-3456789"
     },
     "uei": {
       "registry": {
-        "code": "US-UEI",
+        "code": "us:uei",
         "url": "https://commongrants.org/registries/us-uei"
       },
       "id": "AB0123456789"
@@ -690,57 +753,11 @@ const candid = org.identifiers.otherIds.candidBridge;
 - **Pros**
   - Dot access works in every major language, no bracket notation required.
   - Matches the existing CommonGrants map convention (`customFields`, `addresses`, `emails`).
-  - Aliases stay stable even if the underlying registry code changes.
   - Keys stay short and clean in JSON Pointer paths, logs, and query parameters.
-  - No duplication with the `registry.code` field inside each entry.
 - **Cons**
-  - Consumers need a small alias-to-registry-code mapping, maintained in the CommonGrants registry catalog.
+  - Introduces a third string per registry (key, alias, and `registry.code`), with an alias-to-code mapping that consumers must maintain.
+  - The key is not self-describing: `uei` does not name its registry without the catalog.
   - Aliases can shadow each other across scopes (e.g. an EIN-like ID in another jurisdiction), so the catalog must prevent collisions.
-
-#### Option 2: Registry code as key
-
-:::note[Bottom line]
-Keying by registry code is best if:
-
-- we want the key to be self-documenting without needing a catalog lookup,
-- but we're willing to require bracket notation and duplicate the code into the body.
-  :::
-
-**Example**
-
-```json
-{
-  "identifiers": {
-    "US-EIN": {
-      "registry": {
-        "code": "US-EIN",
-        "url": "https://commongrants.org/registries/us-ein"
-      },
-      "id": "12-3456789"
-    },
-    "US-UEI": {
-      "registry": {
-        "code": "US-UEI",
-        "url": "https://commongrants.org/registries/us-uei"
-      },
-      "id": "AB0123456789"
-    }
-  }
-}
-```
-
-```ts
-const ein = org.identifiers["US-EIN"];
-```
-
-- **Pros**
-  - Key tells you immediately which registry the entry refers to.
-  - No alias mapping needed: consumers can use org-id.guide codes directly.
-- **Cons**
-  - Uppercase and hyphenated keys force bracket notation in most languages (JS, Python, Go).
-  - Duplicates the registry code into both the key and the body (`registry.code`).
-  - Couples the key to the registry's naming: if org-id.guide renames a code, every consumer has to adapt.
-  - Inconsistent with the rest of the CommonGrants spec, where map keys are camelCase.
 
 ### Identifier metadata structure
 
@@ -776,9 +793,9 @@ The `registry` object holds a curated subset of the catalog entry: the fields th
 
 ```json
 {
-  "ein": {
+  "us:ein": {
     "registry": {
-      "code": "US-EIN",
+      "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein",
       "scope": "US",
       "kind": "government",
@@ -795,13 +812,14 @@ The CommonGrants registry catalog at `registry.url` carries the rest:
 
 ```yaml
 # commongrants.org/registries/us-ein.yaml
-code: US-EIN
+code: us:ein
 name: Employer Identification Number
 scope: US
 kind: government
 issuer: US Internal Revenue Service
 schema: https://commongrants.org/registries/us-ein/schema.json
 lookupUriTemplate: https://apps.irs.gov/app/eos/detailsPage?ein={id}
+orgIdGuide: US-EIN
 source: https://org-id.guide/list/US-EIN
 ```
 
@@ -830,8 +848,8 @@ A flat shape is best if:
 
 ```json
 {
-  "ein": {
-    "registry": "US-EIN",
+  "us:ein": {
+    "registry": "us:ein",
     "registryUrl": "https://commongrants.org/registries/us-ein",
     "id": "12-3456789"
   }
@@ -861,16 +879,17 @@ Full decomposition is best if:
 
 ```json
 {
-  "ein": {
+  "us:ein": {
     "registry": {
-      "code": "US-EIN",
+      "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein",
       "name": "Employer Identification Number",
       "scope": "US",
       "kind": "government",
       "issuer": "US Internal Revenue Service",
       "schema": "https://commongrants.org/registries/us-ein/schema.json",
-      "lookupUriTemplate": "https://apps.irs.gov/app/eos/detailsPage?ein={id}"
+      "lookupUriTemplate": "https://apps.irs.gov/app/eos/detailsPage?ein={id}",
+      "orgIdGuide": "US-EIN"
     },
     "id": "12-3456789"
   }
@@ -915,9 +934,9 @@ An object array is best if:
 
 ```json
 {
-  "ein": {
+  "us:ein": {
     "registry": {
-      "code": "US-EIN",
+      "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein"
     },
     "id": "12-3456789",
@@ -955,9 +974,9 @@ A flat array is best if:
 
 ```json
 {
-  "ein": {
+  "us:ein": {
     "registry": {
-      "code": "US-EIN",
+      "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein"
     },
     "id": "12-3456789",
@@ -1009,9 +1028,9 @@ A reference with identifiers is best if:
     "id": "01912a8b-7c3d-7891-abcd-ef1234567891",
     "name": "Example Parent Foundation",
     "identifiers": {
-      "ein": {
+      "us:ein": {
         "registry": {
-          "code": "US-EIN",
+          "code": "us:ein",
           "url": "https://commongrants.org/registries/us-ein",
           "scope": "US",
           "kind": "government"
@@ -1076,9 +1095,9 @@ A full summary is best if:
     "name": "Example Parent Foundation",
     "orgType": "private_foundation",
     "identifiers": {
-      "ein": {
+      "us:ein": {
         "registry": {
-          "code": "US-EIN",
+          "code": "us:ein",
           "url": "https://commongrants.org/registries/us-ein"
         },
         "id": "98-7654321"
@@ -1105,40 +1124,52 @@ A full summary is best if:
 
 ### Registry code format
 
-_Should registry codes follow org-id.guide, a uniform namespaced format, or both?_
+_Should registry codes adopt org-id.guide's codes directly, or use a uniform CommonGrants-owned format with org-id.guide recorded as a cross-reference?_
+
+Whatever the code looks like, it doubles as the map key (see [Map key format](#map-key-format)) and as the catalog filename. The catalog URL slug is a deterministic normalization of the code: lowercase, with `:` and `.` replaced by `-` (so `us:ein` resolves at `/registries/us-ein` and `grants.gov:org` at `/registries/grants-gov-org`), which keeps the slug filename-safe across operating systems.
 
 #### Side-by-side comparison
 
-| Criteria                                              | org-id.guide + namespaced (rec.) | Uniform `namespace:type` |
-| ----------------------------------------------------- | :------------------------------: | :----------------------: |
-| Zero-translation interop with open data standards     |                ✅                |            ❌            |
-| Recognizable to OCDS, 360Giving, IATI users           |                ✅                |            ❌            |
-| Visually distinguishes standard vs. system registries |                ✅                |            ❌            |
-| Covers non-standard system IDs                        |                ✅                |            ✅            |
-| Internal format consistency                           |                🟡                |            ✅            |
+| Criteria                                               | Uniform CG codes (rec.) | Adopt org-id.guide codes |
+| ------------------------------------------------------ | :---------------------: | :----------------------: |
+| One internally consistent format across all registries |           ✅            |            ❌            |
+| Covers registries org-id.guide does not list           |           ✅            |            🟡            |
+| Stable when org-id.guide renames or recodes a registry |           ✅            |            ❌            |
+| Readable, predictable codes (CG picks the token)       |           ✅            |            🟡            |
+| Zero-translation interop with org-id.guide-coded data  |           ❌            |            ✅            |
+| Recognizable to OCDS, 360Giving, IATI users            |           🟡            |            ✅            |
 
-#### Option 1: org-id.guide + namespaced (recommended)
+#### Option 1: Uniform CommonGrants codes, org-id.guide as cross-reference (recommended)
 
 :::note[Bottom line]
-The hybrid format is best if:
+A uniform CommonGrants-owned code is best if:
 
-- we want seamless interop with org-id.guide's existing ecosystem,
-- but we're willing to have two formats coexist for the sake of recognition.
+- we want one consistent, stable code format across every registry, including the ones org-id.guide does not cover,
+- but we're willing to record the org-id.guide code as a catalog cross-reference and translate through it when interoperating with org-id.guide-coded data.
   :::
+
+CommonGrants mints one `namespace:type` code per registry and treats it as the source of truth. The equivalent org-id.guide code, when one exists, is recorded in the catalog as `orgIdGuide` (and `source`), not used as the code itself. This matters because org-id.guide is neither internally uniform nor complete: it codes EIN as `US-EIN`, DUNS as the cross-national `XI-DUNS`, and the UEI under `US-SAM`, and it has no entry at all for FAIN or Assistance Listings. Adopting its codes directly can therefore never be internally consistent, since CommonGrants must mint codes for the uncovered registries regardless.
 
 **Example**
 
 ```json
 {
-  "ein": {
+  "us:ein": {
     "registry": {
-      "code": "US-EIN",
+      "code": "us:ein",
       "url": "https://commongrants.org/registries/us-ein"
     },
     "id": "12-3456789"
   },
+  "us:uei": {
+    "registry": {
+      "code": "us:uei",
+      "url": "https://commongrants.org/registries/us-uei"
+    },
+    "id": "AB0123456789"
+  },
   "otherIds": {
-    "fluxxOrg": {
+    "fluxx:org": {
       "registry": {
         "code": "fluxx:org",
         "url": "https://commongrants.org/registries/fluxx-org"
@@ -1149,38 +1180,52 @@ The hybrid format is best if:
 }
 ```
 
-- **Pros**
-  - Uses org-id.guide codes as-is, so existing open data systems interoperate without translation.
-  - Visually distinguishes standardized registries (`US-EIN`) from system-specific ones (`fluxx:org`).
-  - Anyone familiar with OCDS, 360Giving, or IATI recognizes the codes at a glance.
-- **Cons**
-  - Two formats coexist: uppercase-hyphenated and lowercase-colon.
-  - Camel-case alias keys help, but the registry field itself still requires bracket notation when used as an object key elsewhere.
+The matching catalog entry records the org-id.guide code as a cross-reference:
 
-#### Option 2: Uniform `namespace:type`
+```yaml
+# commongrants.org/registries/us-uei.yaml
+code: us:uei
+name: Unique Entity Identifier
+scope: US
+kind: government
+issuer: US General Services Administration (SAM.gov)
+orgIdGuide: US-SAM
+source: https://org-id.guide/list/US-SAM
+```
+
+- **Pros**
+  - One internally consistent format (`namespace:type`) for every registry, government or platform, listed in org-id.guide or not.
+  - CommonGrants owns the code space, so codes stay stable even when org-id.guide renames or recodes a registry.
+  - CommonGrants picks a readable token (`us:uei`) rather than inheriting an opaque one (`US-SAM`).
+  - The lowercase-colon form is visually distinct from org-id.guide codes, signalling "this is a CommonGrants code, resolve it through the catalog."
+- **Cons**
+  - Codes diverge from org-id.guide for some registries, so interoperating with org-id.guide-coded data requires a catalog lookup against `orgIdGuide`.
+  - Less immediately recognizable to someone who already knows the org-id.guide code.
+
+#### Option 2: Adopt org-id.guide codes directly
 
 :::note[Bottom line]
-A uniform format is best if:
+Adopting org-id.guide codes directly is best if:
 
-- we want one consistent code format across every registry,
-- but we're willing to translate every code from org-id.guide before interoperating.
+- we want zero-translation interop with org-id.guide and the open data standards built on it,
+- but we're willing to live with an inconsistent code format and codes that change when org-id.guide does.
   :::
 
 **Example**
 
 ```json
 {
-  "ein": {
+  "US-EIN": {
     "registry": {
-      "code": "us:ein",
+      "code": "US-EIN",
       "url": "https://commongrants.org/registries/us-ein"
     },
     "id": "12-3456789"
   },
-  "uei": {
+  "US-SAM": {
     "registry": {
-      "code": "us:uei",
-      "url": "https://commongrants.org/registries/us-uei"
+      "code": "US-SAM",
+      "url": "https://commongrants.org/registries/us-sam"
     },
     "id": "AB0123456789"
   }
@@ -1188,11 +1233,12 @@ A uniform format is best if:
 ```
 
 - **Pros**
-  - One format for everything.
-  - No need to decide when to use hyphens vs. colons.
+  - Zero translation when exchanging data with org-id.guide, OCDS, 360Giving, or IATI.
+  - Anyone familiar with those standards recognizes the codes at a glance.
 - **Cons**
-  - Requires a mapping table to interoperate with org-id.guide.
-  - Not recognizable to anyone already using OCDS, 360Giving, or IATI.
+  - No internally consistent format: `US-EIN`, `XI-DUNS`, and `US-SAM` follow no single rule, and FAIN and Assistance Listings have no org-id.guide code at all, so CommonGrants must mint codes for them anyway.
+  - Codes are not under CommonGrants control, so an upstream rename ripples into every key and stored reference.
+  - Inherits opaque codes (`US-SAM` for a UEI) that need a catalog lookup to understand.
 
 ### Registry governance
 
@@ -1200,14 +1246,14 @@ _Who maintains the registry catalog, and how does a registry get promoted from `
 
 #### Side-by-side comparison
 
-| Criteria                                             | Hybrid (rec.) | org-id.guide only | CG-managed only |
-| ---------------------------------------------------- | :-----------: | :---------------: | :-------------: |
-| Leverages existing open data taxonomy                |      ✅       |        ✅         |       ❌        |
-| CG-specific metadata (`schema`, `kind`, `alias`)     |      ✅       |        ❌         |       ✅        |
-| Covers non-standard system IDs (`fluxx:org`, etc.)   |      ✅       |        ❌         |       ✅        |
-| Promotion path independent of upstream release cycle |      ✅       |        🟡         |       ✅        |
-| Clear `otherIds` → base identifier flow              |      ✅       |        🟡         |       ✅        |
-| Low maintenance burden                               |      🟡       |        ✅         |       ❌        |
+| Criteria                                              | Hybrid (rec.) | org-id.guide only | CG-managed only |
+| ----------------------------------------------------- | :-----------: | :---------------: | :-------------: |
+| Leverages existing open data taxonomy                 |      ✅       |        ✅         |       ❌        |
+| CG-specific metadata (`schema`, `kind`, `orgIdGuide`) |      ✅       |        ❌         |       ✅        |
+| Covers non-standard system IDs (`fluxx:org`, etc.)    |      ✅       |        ❌         |       ✅        |
+| Promotion path independent of upstream release cycle  |      ✅       |        🟡         |       ✅        |
+| Clear `otherIds` → base identifier flow               |      ✅       |        🟡         |       ✅        |
+| Low maintenance burden                                |      🟡       |        ✅         |       ❌        |
 
 #### Option 1: Hybrid with promotion flow (recommended)
 
@@ -1220,18 +1266,18 @@ The hybrid approach is best if:
 
 **Shape of the CommonGrants registry catalog**
 
-Each catalog entry wraps an org-id.guide entry (when one exists) and adds CG-specific fields:
+Each catalog entry assigns the registry its canonical code, cross-references an org-id.guide entry (when one exists), and adds CG-specific fields:
 
 ```yaml
 # commongrants.org/registries/us-ein.yaml
-code: US-EIN
-alias: ein
+code: us:ein
 name: Employer Identification Number
 scope: US
 kind: government
 issuer: US Internal Revenue Service
 schema: https://commongrants.org/registries/us-ein/schema.json
 lookupUriTemplate: https://apps.irs.gov/app/eos/detailsPage?ein={id}
+orgIdGuide: US-EIN
 source: https://org-id.guide/list/US-EIN
 models: [Organization]
 ```
@@ -1242,7 +1288,7 @@ Any identifier that starts in `otherIds` can become a base identifier through th
 
 - **Pros**
   - Reuses org-id.guide codes where they exist, avoiding duplicated taxonomy work.
-  - Adds CG-specific metadata (schema, kind, alias) in one place.
+  - Adds CG-specific metadata (schema, kind, orgIdGuide) in one place.
   - Clear, documented path from ad-hoc use to first-class protocol support.
   - Parallels the way custom fields are promoted today.
 - **Cons**


### PR DESCRIPTION
### Summary

Update the Org ID ADR based on feedback from Fluxx.

- Fixes #915  
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Removes the hyphen (`-`) from examples of EIN  (e.g., `"12-3456789"` to `"123456789"). This was changed after Becker highlighted that the IRS provides EINs without the hyphen, it makes it simpler to validate, and inserting the hyphen is mostly a presentation concern
- Changes decision 3 (identifiers key) so that the key in `identifiers` to match the `registry.code` for that identifier instead of needing to maintain a separate camelCase alias. For example:
  ```json
  "identifiers": {
    "candid:bridge": {
      "id": "1234567",
      "registry": {
          "code": "candid:bridge",
          "url": "https://commongrants.org/registries/candid-bridge",
          "scope": "candid",
          "kind": "commercial"
      }
    }
  }
  ```
- Changes decision 7 (registry code format) from supporting both org-id.guide schemas (`"US-EIN"`) and a CommonGrants standardized code format (`"candid:bridge"`) to just supporting CommonGrants format, and adding a key for `orgIdGuide` in the CommonGrants ID registry entry. I changed this for a few reasons:
  - This keeps all identifier keys in a consistent format, as opposed to mixing `"US-EIN` and `"candid:bridge"`
  - This allows us to use more intuitive naming for our own registry codes. For example UEI is [`"US-SAM"` in org-id.guide](https://org-id.guide/list/US-SAM), and we can call it `"us:ein"` instead
  - This prevents breaking changes if the org-id.guide entry is changed for some reason.
  - It still provides a way of mapping CommonGrants ID registries to org-id.guide registries, without making CommonGrants dependent on that registry.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

- Review the updated ADR at: https://cg-pr-945.billy-daly.workers.dev/governance/adr/0023-org-ids/#decision
- Review the [feedback from Fluxx in Slack](https://agilesix.slack.com/archives/C0AP9UAJA7P/p1780950767031449)

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1440" height="900" alt="Screenshot 2026-06-24 at 2 54 38 PM" src="https://github.com/user-attachments/assets/b60632af-b1ca-4e38-8aa0-8d3f80f4889b" />
<img width="1440" height="900" alt="Screenshot 2026-06-24 at 2 55 15 PM" src="https://github.com/user-attachments/assets/f534ebec-78a3-484d-8734-99353f55caee" />
<img width="1440" height="900" alt="Screenshot 2026-06-24 at 2 54 57 PM" src="https://github.com/user-attachments/assets/4c852fc2-8b47-4b75-9799-42b2cf1c8571" />

