### PR TITLE
refactor(py-sdk): remove `routes` and `schemas` args from `Client`

### DIFF
--- a/lib/python-sdk/common_grants_sdk/client/client.py
+++ b/lib/python-sdk/common_grants_sdk/client/client.py
@@ -1,11 +1,12 @@
 """HTTP client for the CommonGrants API.
 
 ``BaseClient`` is the transport plumbing (auth headers, paginated GET/POST). The
-generic ``Client`` layers the typed resource facade on top: it binds a plugin's
-route filters (``FiltersT``) and Opportunity schema (``ItemT``) so
+generic ``Client`` layers the typed resource facade on top. Scope it to a plugin
+with ``plugin.get_client(...)``: that binds the plugin's route filters
+(``FiltersT``) and Opportunity schema (``ItemT``) so
 ``client.opportunities.search(filters=...)`` is typed and responses parse with the
-plugin's custom fields by default. Construct one directly, or via
-``plugin.get_client(...)``.
+plugin's custom fields by default. Constructing ``Client`` directly gives an
+unscoped client (standard filters only, base ``OpportunityBase`` rows).
 """
 
 from __future__ import annotations

--- a/lib/python-sdk/common_grants_sdk/client/client.py
+++ b/lib/python-sdk/common_grants_sdk/client/client.py
@@ -196,15 +196,17 @@ class Client(BaseClient, Generic[FiltersT, ItemT]):
     """Typed resource facade over :class:`BaseClient`.
 
     Binds a plugin's route filters and Opportunity schema, exposing the typed
-    ``opportunities`` resource. Prefer ``plugin.get_client(...)`` over constructing
-    this directly.
+    ``opportunities`` resource. Construct one via ``plugin.get_client(...)``: that
+    binds the plugin's registered filters (``FiltersT``) and Opportunity schema
+    (``ItemT``) so ``opportunities.search`` is typed and responses parse with the
+    plugin's custom fields. Constructing ``Client`` directly leaves those generics
+    unbound (standard filters only, base ``OpportunityBase`` rows).
     """
 
     def __init__(
         self,
         config: Optional[Config] = None,
         auth: Optional[Auth] = None,
-        routes: Optional[PluginRoutes[Any]] = None,
         schemas: Optional[PluginSchemas[Any]] = None,
     ):
         """Initialize the client.
@@ -212,25 +214,28 @@ class Client(BaseClient, Generic[FiltersT, ItemT]):
         Args:
             config: Optional Config instance.
             auth: Optional Auth instance.
-            routes: Optional typed ``PluginRoutes`` carrier (fixed plugin config).
-                Bound and validated once here; used to classify registered custom
-                filters in ``opportunities.search``.
             schemas: Optional ``PluginSchemas``; its Opportunity common model
                 becomes the default parse schema for ``opportunities`` responses.
-
-        Raises:
-            FilterError: If ``routes`` registers a filter whose value type is not a
-                filter value model.
         """
         super().__init__(config=config, auth=auth)
-        self.routes: PluginRoutes[Any] = (
-            routes
-            if routes is not None
-            else PluginRoutes(opportunities=ResourceRoutes())
-        )
-        validate_routes(self.routes)
+        self._routes: PluginRoutes[Any] = PluginRoutes(opportunities=ResourceRoutes())
         self.schemas = schemas
         self._opportunity_schema: type[OpportunityBase] = _resolve_opportunity_schema(
             schemas
         )
         self.opportunities: Opportunities[FiltersT, ItemT] = Opportunities(client=self)
+
+    def _bind_routes(self, routes: PluginRoutes[Any]) -> None:
+        """Scope this client to a plugin's registered custom filters.
+
+        Internal hook called by ``plugin.get_client``: it validates the route
+        registration and stores it for ``opportunities.search`` to classify
+        registered custom filters. Build scoped clients via ``get_client`` rather
+        than calling this directly.
+
+        Raises:
+            FilterError: If ``routes`` registers a filter whose value type is not a
+                filter value model.
+        """
+        validate_routes(routes)
+        self._routes = routes

--- a/lib/python-sdk/common_grants_sdk/client/client.py
+++ b/lib/python-sdk/common_grants_sdk/client/client.py
@@ -207,21 +207,18 @@ class Client(BaseClient, Generic[FiltersT, ItemT]):
         self,
         config: Optional[Config] = None,
         auth: Optional[Auth] = None,
-        schemas: Optional[PluginSchemas[Any]] = None,
     ):
         """Initialize the client.
 
         Args:
             config: Optional Config instance.
             auth: Optional Auth instance.
-            schemas: Optional ``PluginSchemas``; its Opportunity common model
-                becomes the default parse schema for ``opportunities`` responses.
         """
         super().__init__(config=config, auth=auth)
         self._routes: PluginRoutes[Any] = PluginRoutes(opportunities=ResourceRoutes())
-        self.schemas = schemas
+        self._schemas: Optional[PluginSchemas[Any]] = None
         self._opportunity_schema: type[OpportunityBase] = _resolve_opportunity_schema(
-            schemas
+            None
         )
         self.opportunities: Opportunities[FiltersT, ItemT] = Opportunities(client=self)
 
@@ -239,3 +236,13 @@ class Client(BaseClient, Generic[FiltersT, ItemT]):
         """
         validate_routes(routes)
         self._routes = routes
+
+    def _bind_schemas(self, schemas: Optional[PluginSchemas[Any]]) -> None:
+        """Bind a plugin's schema extensions as the default parse schemas.
+
+        Internal hook called by ``plugin.get_client``: the Opportunity common
+        model becomes the default schema ``opportunities`` responses parse into.
+        Build scoped clients via ``get_client`` rather than calling this directly.
+        """
+        self._schemas = schemas
+        self._opportunity_schema = _resolve_opportunity_schema(schemas)

--- a/lib/python-sdk/common_grants_sdk/client/opportunities.py
+++ b/lib/python-sdk/common_grants_sdk/client/opportunities.py
@@ -148,7 +148,7 @@ class Opportunities(Generic[FiltersT, ItemT]):
         filters_body: dict[str, Any] = {}
         if filters:
             classified = classify_filters(
-                self.client.routes, "opportunities", "search", filters
+                self.client._routes, "opportunities", "search", filters
             )
             strict_error = next((e for e in classified.errors if e.strict), None)
             if strict_error is not None:

--- a/lib/python-sdk/common_grants_sdk/extensions/filters.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/filters.py
@@ -297,9 +297,10 @@ def _registered_filter_models(route_td: Any) -> dict[str, type[BaseModel]]:
     ``route_td`` is the TypedDict class an author put in the route slot (e.g.
     ``OppSearchFilters``), or ``None``. Returns ``{filterName: value model}`` for
     every key the author declared beyond the standard ``OpportunityFilters`` keys.
-    Non-model annotations are skipped here; ``validate_routes`` (run at ``Client``
-    construction) rejects them, so a caller who invokes ``classify_filters`` directly
-    on unvalidated routes gets silent skipping rather than a raise.
+    Non-model annotations are skipped here; ``validate_routes`` (run when
+    ``plugin.get_client`` binds routes) rejects them, so a caller who invokes
+    ``classify_filters`` directly on unvalidated routes gets silent skipping rather
+    than a raise.
     """
     if route_td is None:
         return {}

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -110,7 +110,7 @@ class Plugin(Generic[SchemasT, FiltersT]):
         """Return a client pre-scoped with this plugin's routes and schemas.
 
         Consumers call ``plugin.get_client(config)`` instead of constructing a
-        client and passing ``routes=`` / ``schemas=`` by hand. The returned
+        client and binding the plugin's schemas/routes by hand. The returned
         client types ``opportunities.search(filters=...)`` by the plugin's
         registered filters and parses responses with its Opportunity schema.
         """
@@ -120,12 +120,9 @@ class Plugin(Generic[SchemasT, FiltersT]):
 
         # self.schemas/self.routes are opaque here (SchemasT); the overloads above
         # carry the precise Client[FiltersT, ItemT] the caller sees.
-        return Client(
-            config=config,
-            auth=auth,
-            routes=cast("Any", self.routes),
-            schemas=cast("Any", self.schemas),
-        )
+        client = Client(config=config, auth=auth, schemas=cast("Any", self.schemas))
+        client._bind_routes(cast("Any", self.routes))
+        return client
 
 
 def define_plugin(

--- a/lib/python-sdk/common_grants_sdk/extensions/plugin.py
+++ b/lib/python-sdk/common_grants_sdk/extensions/plugin.py
@@ -120,7 +120,8 @@ class Plugin(Generic[SchemasT, FiltersT]):
 
         # self.schemas/self.routes are opaque here (SchemasT); the overloads above
         # carry the precise Client[FiltersT, ItemT] the caller sees.
-        client = Client(config=config, auth=auth, schemas=cast("Any", self.schemas))
+        client = Client(config=config, auth=auth)
+        client._bind_schemas(cast("Any", self.schemas))
         client._bind_routes(cast("Any", self.routes))
         return client
 

--- a/lib/python-sdk/examples/consumer_search_with_filters.py
+++ b/lib/python-sdk/examples/consumer_search_with_filters.py
@@ -8,12 +8,13 @@ The full downstream flow an adopter writes against the SDK:
            passing the carrier as ``define_plugin(routes=...)`` → ``plugin.routes``, a
            ``PluginRoutes`` carrier. The typed dict also narrows the call-site filter
            dict per key.
-  CONSUMER constructs the client with the registered routes
-           (``Client(config, routes=plugin.routes)``), builds a filter dict with the
-           ``f.*`` builders, and calls ``client.opportunities.search(search=..., filters=...)``.
-           The client runs ``classify_filters`` to build the three-bucket request body
-           (default named fields + ``customFilters`` record), POSTs it, and returns
-           typed ``OpportunityBase`` rows.
+  CONSUMER gets a pre-scoped client from ``plugin.get_client(config)`` (routes and
+           schemas already bound), builds a filter dict with the ``f.*`` builders, and
+           calls ``client.opportunities.search(search=..., filters=...)``. The client
+           runs ``classify_filters`` to build the three-bucket request body (default
+           named fields + ``customFilters`` record), POSTs it, and returns typed
+           ``OpportunityBase`` rows. Because ``get_client`` binds the plugin's registered
+           ``OppSearchFilters``, ``search(filters=...)`` narrows to it per key.
 
 The ``f.*`` builders return the precise filter model per value type
 (``f.in_([...])`` -> ``StringArrayFilter``, ``f.gte(3)`` -> ``NumberComparisonFilter``),
@@ -33,7 +34,6 @@ from __future__ import annotations
 
 from typing_extensions import assert_type
 
-from common_grants_sdk.client import Client
 from common_grants_sdk.client.config import Config
 from common_grants_sdk.extensions import (
     PluginMeta,
@@ -84,8 +84,9 @@ def demo() -> None:
     config = Config(
         base_url="http://localhost:8000", api_key="two_orgs_user_key", timeout=5.0
     )
-    # Routes are bound to the client once at construction (not per search call).
-    client = Client(config, routes=plugin.routes)
+    # get_client binds the plugin's routes and schemas: search(filters=...) is typed
+    # by OppSearchFilters and responses parse with the plugin's Opportunity schema.
+    client = plugin.get_client(config)
 
     # A filter dict built with the f.* helpers. The builders return the precise
     # per-key models, so each value narrows to exactly the type OppSearchFilters

--- a/lib/python-sdk/examples/custom_filters.py
+++ b/lib/python-sdk/examples/custom_filters.py
@@ -54,7 +54,7 @@ class OppSearchFilters(OpportunityFilters, total=False):
     fundingProgram: StringComparison
 
 
-routes: PluginRoutes = PluginRoutes(
+routes: PluginRoutes[OppSearchFilters] = PluginRoutes(
     opportunities=ResourceRoutes(search=OppSearchFilters)
 )
 

--- a/lib/python-sdk/pyrightconfig.json
+++ b/lib/python-sdk/pyrightconfig.json
@@ -1,5 +1,9 @@
 {
-  "include": ["common_grants_sdk", "examples/typed_custom_filters.py"],
+  "include": [
+    "common_grants_sdk",
+    "examples/typed_custom_filters.py",
+    "examples/consumer_search_with_filters.py"
+  ],
   "exclude": ["tests", "**/__pycache__", "generated"],
   "typeCheckingMode": "basic",
   "pythonVersion": "3.11"

--- a/lib/python-sdk/pyrightconfig.json
+++ b/lib/python-sdk/pyrightconfig.json
@@ -1,10 +1,14 @@
 {
-  "include": [
-    "common_grants_sdk",
-    "examples/typed_custom_filters.py",
-    "examples/consumer_search_with_filters.py"
+  "include": ["common_grants_sdk", "examples"],
+  "exclude": [
+    "tests",
+    "**/__pycache__",
+    "generated",
+    "examples/typed_custom_filters_failures.py",
+    "**/node_modules",
+    "**/.*",
+    ".venv"
   ],
-  "exclude": ["tests", "**/__pycache__", "generated"],
   "typeCheckingMode": "basic",
   "pythonVersion": "3.11"
 }

--- a/lib/python-sdk/tests/client/test_client.py
+++ b/lib/python-sdk/tests/client/test_client.py
@@ -12,8 +12,16 @@ from common_grants_sdk.client.config import Config
 from common_grants_sdk.client.exceptions import APIError
 from common_grants_sdk.schemas.pydantic.pagination import PaginatedResultsInfo
 from common_grants_sdk.schemas.pydantic.responses import Paginated
-from common_grants_sdk.extensions import PluginRoutes, ResourceRoutes
+from common_grants_sdk.extensions import (
+    PluginMeta,
+    PluginRoutes,
+    PluginSchemas,
+    ResourceRoutes,
+    define_plugin,
+    schema,
+)
 from common_grants_sdk.extensions.types import FilterError
+from common_grants_sdk.schemas.pydantic.models import OpportunityBase
 from common_grants_sdk.schemas.pydantic.filters.opportunity import (
     OpportunityFilters,
     StringArray,
@@ -34,8 +42,8 @@ class TestClient:
             assert client.auth == auth
             assert isinstance(client.opportunities, type(client.opportunities))
 
-    def test_client_initialization_validates_routes(self):
-        """Client validates routes at construction and raises on a bad declaration.
+    def test_get_client_validates_routes(self):
+        """get_client validates routes when binding and raises on a bad declaration.
 
         The typed carrier makes a misspelled resource/method a static error, so the
         only remaining runtime check is that a registered custom filter's value type
@@ -48,29 +56,31 @@ class TestClient:
             class BadFilters(OpportunityFilters, total=False):
                 region: int  # not a filter value model
 
+            plugin = define_plugin(
+                PluginSchemas(Opportunity=schema(common_schema=OpportunityBase)),
+                routes=PluginRoutes(opportunities=ResourceRoutes(search=BadFilters)),
+                meta=PluginMeta(name="t", source_system="t"),
+            )
             with pytest.raises(FilterError):
-                Client(
-                    config=config,
-                    routes=PluginRoutes(
-                        opportunities=ResourceRoutes(search=BadFilters)
-                    ),
-                )
+                plugin.get_client(config)
 
-    def test_client_initialization_accepts_valid_routes(self):
-        """A valid typed routes carrier is accepted at construction (no raise)."""
+    def test_get_client_accepts_valid_routes(self):
+        """A valid typed routes carrier binds through get_client (no raise)."""
         with patch("common_grants_sdk.client.client.httpx.Client"):
             config = Config(base_url="https://api.example.com", api_key="test-key")
 
             class OppSearchFilters(OpportunityFilters, total=False):
                 region: StringArray
 
-            client = Client(
-                config=config,
+            plugin = define_plugin(
+                PluginSchemas(Opportunity=schema(common_schema=OpportunityBase)),
                 routes=PluginRoutes(
                     opportunities=ResourceRoutes(search=OppSearchFilters)
                 ),
+                meta=PluginMeta(name="t", source_system="t"),
             )
-            assert client.routes.opportunities.search is OppSearchFilters
+            client = plugin.get_client(config)
+            assert client._routes.opportunities.search is OppSearchFilters
 
     def test_client_initialization_defaults_auth(self, monkeypatch):
         """Test client initialization with default auth from config."""

--- a/lib/python-sdk/tests/client/test_opportunities.py
+++ b/lib/python-sdk/tests/client/test_opportunities.py
@@ -18,7 +18,15 @@ from common_grants_sdk.client import (
 )
 from common_grants_sdk.client.config import Config
 from common_grants_sdk.client.exceptions import APIError
-from common_grants_sdk.extensions import FilterError, PluginRoutes, ResourceRoutes
+from common_grants_sdk.extensions import (
+    FilterError,
+    PluginMeta,
+    PluginRoutes,
+    PluginSchemas,
+    ResourceRoutes,
+    define_plugin,
+    schema,
+)
 from common_grants_sdk.schemas.pydantic.models import OpportunityBase
 from common_grants_sdk.schemas.pydantic.fields import CustomFieldType
 from common_grants_sdk.schemas.pydantic.filters.opportunity import (
@@ -36,6 +44,14 @@ class OppSearchFilters(OpportunityFilters, total=False):
 
 
 AGENCY_ROUTES = PluginRoutes(opportunities=ResourceRoutes(search=OppSearchFilters))
+
+# A plugin scoped to AGENCY_ROUTES: get_client() is the public path to a client
+# whose opportunities.search classifies the registered ``agency`` custom filter.
+AGENCY_PLUGIN = define_plugin(
+    PluginSchemas(Opportunity=schema(common_schema=OpportunityBase)),
+    routes=AGENCY_ROUTES,
+    meta=PluginMeta(name="test", source_system="test"),
+)
 
 
 @pytest.fixture
@@ -843,7 +859,7 @@ class TestOpportunitySearch:
         config = Config(
             base_url="https://api.example.com", api_key="test-key", timeout=10.0
         )
-        client = Client(config=config, auth=auth, routes=AGENCY_ROUTES)
+        client = AGENCY_PLUGIN.get_client(config, auth)
         client.http = mock_httpx_client
         client.opportunities.http = mock_httpx_client
 
@@ -903,7 +919,7 @@ class TestOpportunitySearch:
         config = Config(
             base_url="https://api.example.com", api_key="test-key", timeout=10.0
         )
-        client = Client(config=config, auth=auth, routes=AGENCY_ROUTES)
+        client = AGENCY_PLUGIN.get_client(config, auth)
         client.http = mock_httpx_client
         client.opportunities.http = mock_httpx_client
 
@@ -983,7 +999,7 @@ class TestOpportunitySearch:
         config = Config(
             base_url="https://api.example.com", api_key="test-key", timeout=10.0
         )
-        client = Client(config=config, auth=auth, routes=AGENCY_ROUTES)
+        client = AGENCY_PLUGIN.get_client(config, auth)
         client.http = mock_httpx_client
         client.opportunities.http = mock_httpx_client
 


### PR DESCRIPTION
### Summary

Removes the `routes` and `schemas` arguments from the `Client` to make `Plugin.get_client()` the single correct pattern for getting a `Client` that has been scoped with a plugin's custom filters and custom fields.

- Fixes #908 
- Time to review: 3 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Removes `routes` and `schemas` from the `Client` args, to avoid confusing SDK consumers about if/when they should use those params vs. `plugin.get_client()`
- Adds `Client._bind_routes()` and `Client._bind_schemas()` to replace `Client` args as the mechanism for adding runtime scoping and IDE-level type inference for custom fields and filters.
- Enforces type checking on `examples/` and fixes one other pyright issue on `examples/custom_filters.py`

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

There were a few main motivations for this change:

1. The previous pattern introduced a few potential error scenarios that this refactor removes:
    1. If an SDK consumer passes in `routes` with the wrong type annotation, e.g. `Plugin[Any]` they'll get a pyright error when they pass valid filters into `search()`
    2. Even if an SDK consumer passes `routes` and `schemas` into `Client` correctly, the responses won't get properly typed with custom fields.
2. We want to avoid confusing SDK consumers who aren't using or creating plugins, since `routes` and `schemas` are only relevant in the context of customizing the client's default behavior, which is better handled through plugins.
3. We also want to avoid confusing Plugin consumers, who should only have one correct way of accessing a scoped client, per [the Zen of Python](https://peps.python.org/pep-0020/)

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

This is one of the errors plugin consumers can get when they use `Client(routes=...)` instead of `plugin.get_client()`

<img width="918" height="334" alt="Screenshot 2026-07-06 at 9 28 28 AM" src="https://github.com/user-attachments/assets/78a59bb0-eabd-425d-89b4-865c96a03191" />

Switching to `plugin.get_client()` fixes this error.

<img width="650" height="435" alt="Screenshot 2026-07-06 at 11 24 48 AM" src="https://github.com/user-attachments/assets/f09138fd-5a4d-434c-baa5-a2ccf8f7c66e" />
