### PR TITLE
feat!(core): add identifier models to core library and website

### DIFF
--- a/lib/changelog-emitter/src/utils/index.ts
+++ b/lib/changelog-emitter/src/utils/index.ts
@@ -22,6 +22,32 @@ export function getVersionString(version: Version): string {
 }
 
 /**
+ * Deduplicate a list of versions by their version string.
+ *
+ * A model or property defined via `is`/`extends` on a versioned base inherits
+ * the base's `@added`/`@removed` decorators in addition to its own, so
+ * `getAddedOnVersions`/`getRemovedOnVersions` can report the same version more
+ * than once. An entity can only be added or removed once per version, so
+ * collapse the duplicates while preserving order.
+ *
+ * @param versions - The versions to deduplicate
+ * @returns The versions with duplicate version strings removed
+ */
+export function dedupeVersions(versions: readonly Version[]): Version[] {
+  const seen = new Set<string>();
+  const result: Version[] = [];
+  for (const version of versions) {
+    const versionString = getVersionString(version);
+    if (seen.has(versionString)) {
+      continue;
+    }
+    seen.add(versionString);
+    result.push(version);
+  }
+  return result;
+}
+
+/**
  * Get or create a changes array for a specific schema and version.
  * If changes for the version already exist, return that array.
  * Otherwise, create a new empty array and return it.

--- a/lib/changelog-emitter/src/utils/model.ts
+++ b/lib/changelog-emitter/src/utils/model.ts
@@ -10,6 +10,7 @@ import {
   getOrCreateChanges,
   getNameAtVersion,
   getVersionString,
+  dedupeVersions,
 } from "./index.js";
 import { Log } from "./logging.js";
 import { TargetType } from "../types.js";
@@ -113,7 +114,7 @@ function logModelAdditions(
   const renamedFromData = getRenamedFrom(context.program, model);
 
   if (modelAddedVersions && modelAddedVersions.length > 0) {
-    for (const version of modelAddedVersions) {
+    for (const version of dedupeVersions(modelAddedVersions)) {
       const changes = getOrCreateChanges(modelLogs, getVersionString(version));
       const modelNameAtVersion = getNameAtVersion(
         model.name,
@@ -152,7 +153,7 @@ function logModelRemovals(
   const renamedFromData = getRenamedFrom(context.program, model);
 
   if (modelRemovedVersions && modelRemovedVersions.length > 0) {
-    for (const version of modelRemovedVersions) {
+    for (const version of dedupeVersions(modelRemovedVersions)) {
       const changes = getOrCreateChanges(modelLogs, getVersionString(version));
       const modelNameAtVersion = getNameAtVersion(
         model.name,
@@ -217,7 +218,7 @@ function logModelPropertyAdditions(
   const renamedFromData = getRenamedFrom(context.program, property);
 
   if (propertyAddedVersions && propertyAddedVersions.length > 0) {
-    for (const version of propertyAddedVersions) {
+    for (const version of dedupeVersions(propertyAddedVersions)) {
       const changes = getOrCreateChanges(modelLogs, getVersionString(version));
       const propertyNameAtVersion = getNameAtVersion(
         property.name,
@@ -244,7 +245,7 @@ function logModelPropertyRemovals(
   const renamedFromData = getRenamedFrom(context.program, property);
 
   if (propertyRemovedVersions && propertyRemovedVersions.length > 0) {
-    for (const version of propertyRemovedVersions) {
+    for (const version of dedupeVersions(propertyRemovedVersions)) {
       const changes = getOrCreateChanges(modelLogs, getVersionString(version));
       const propertyNameAtVersion = getNameAtVersion(
         property.name,

--- a/lib/changelog-emitter/test/models.test.ts
+++ b/lib/changelog-emitter/test/models.test.ts
@@ -75,6 +75,38 @@ describe("Models - Log @added()", () => {
     });
   });
 
+  it("should log a single entry when a model is `is` a versioned template", async () => {
+    // A model defined via `is` on a versioned template inherits the template's
+    // @added in addition to its own, so the version can be reported twice. The
+    // model is still added only once, so the log should collapse to one entry.
+    const code = `
+    @versioned(Versions)
+    namespace Service {
+      enum Versions {
+        v1,
+        v2,
+      }
+
+      @added(Versions.v2)
+      model Base<Id extends string = string> {
+        id?: Id;
+      }
+
+      @added(Versions.v2)
+      model ${USER_MODEL} is Base<string>;
+    }
+    `;
+
+    await emitAndValidate(code, {
+      Base: {
+        [V1_VERSION]: [Log.added(MODEL_TYPE, "Base")],
+      },
+      [USER_MODEL]: {
+        [V2_VERSION]: [Log.added(MODEL_TYPE, USER_MODEL)],
+      },
+    });
+  });
+
   it("should exclude versions that have no changes", async () => {
     const code = `
       @versioned(Versions)

--- a/lib/core/lib/core/fields/identifier.tsp
+++ b/lib/core/lib/core/fields/identifier.tsp
@@ -25,15 +25,12 @@ enum IdentifierStatus {
 @Versioning.added(CommonGrants.Versions.v0_4)
 model IdentifierT<Id extends string = string, Code extends string = string> {
   /** Registry-level facts shared by every record in this registry. */
-  registry: {
+  registry?: {
     /** Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`). */
-    code: Code;
+    code?: Code;
 
     /** Link to the catalog entry for this registry. */
     url?: url;
-
-    /** JSON schema for validating the identifier format. */
-    schema?: url;
   };
 
   /** The primary identifier string, when the registry has a single canonical value.
@@ -51,17 +48,6 @@ model IdentifierT<Id extends string = string, Code extends string = string> {
     /** Whether the identifier is currently valid or retired. */
     status: IdentifierStatus;
   }>;
-
-  /** Link to this record in the registry's lookup service. */
-  uri?: url;
-
-  /** When this identifier was last verified. */
-  verifiedAt?: utcDateTime;
-
-  /** Reference to the system, service, or process that verified the identifier
-   * (e.g. `irs.gov`, `system:manual-review`).
-   */
-  verifiedBy?: string;
 }
 
 /** An identifier issued to a record by a registry.

--- a/lib/core/lib/core/fields/identifier.tsp
+++ b/lib/core/lib/core/fields/identifier.tsp
@@ -85,13 +85,13 @@ model Identifier is IdentifierT<string, string>;
 model SystemId is IdentifierT<Types.uuid>;
 
 // #########################################################
-// Identifiers
+// Identifier Collection
 // #########################################################
 
 /** A collection of identifiers associated with a record. */
 @example(Examples.Identifier.collection)
 @Versioning.added(CommonGrants.Versions.v0_4)
-model Identifiers {
+model IdentifierCollection {
   /** The hosting system's own identifier for this record. */
   systemId?: SystemId;
 

--- a/lib/core/lib/core/fields/identifier.tsp
+++ b/lib/core/lib/core/fields/identifier.tsp
@@ -1,0 +1,146 @@
+namespace CommonGrants.Fields;
+
+// #########################################################
+// Identifier
+// #########################################################
+
+/** The lifecycle status of an identifier value. */
+@Versioning.added(CommonGrants.Versions.v0_4)
+enum IdentifierStatus {
+  /** The identifier is currently valid. */
+  active,
+
+  /** The identifier is retired and no longer current. */
+  archived,
+}
+
+/** An identifier issued to a record by a registry.
+ *
+ * Template used to define concrete identifier schemas. `Id` constrains the
+ * identifier value (e.g. `employerTaxId`); `Code` pins `registry.code` to a
+ * specific registry (e.g. `"org:us:ein"`). Both default to a plain string, so
+ * `Identifier` is the generic form and named instantiations (e.g. `OrgIdEin`)
+ * are the registry-specific forms.
+ */
+@Versioning.added(CommonGrants.Versions.v0_4)
+model IdentifierT<Id extends string = string, Code extends string = string> {
+  /** Registry-level facts shared by every record in this registry. */
+  registry: {
+    /** Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`). */
+    code: Code;
+
+    /** Link to the catalog entry for this registry. */
+    url?: url;
+
+    /** JSON schema for validating the identifier format. */
+    schema?: url;
+  };
+
+  /** The primary identifier string, when the registry has a single canonical value.
+   *
+   * May be omitted for registries with no natural primary; consumers should read
+   * `allIds` in that case.
+   */
+  id?: Id;
+
+  /** Every known identifier for this record in this registry, including archived values. */
+  allIds?: Array<{
+    /** The identifier string. */
+    id: Id;
+
+    /** Whether the identifier is currently valid or retired. */
+    status: IdentifierStatus;
+  }>;
+
+  /** Link to this record in the registry's lookup service. */
+  uri?: url;
+
+  /** When this identifier was last verified. */
+  verifiedAt?: utcDateTime;
+
+  /** Reference to the system, service, or process that verified the identifier
+   * (e.g. `irs.gov`, `system:manual-review`).
+   */
+  verifiedBy?: string;
+}
+
+/** An identifier issued to a record by a registry.
+ *
+ * Accepts any string value and any registry code. Model-specific collections use
+ * registry-typed instantiations of `IdentifierT` (e.g. `OrgIdEin`) for their base
+ * identifiers, and this generic form for extension identifiers under `otherIds`.
+ */
+@example(Examples.Identifier.ein)
+@example(Examples.Identifier.multiValue)
+@Versioning.added(CommonGrants.Versions.v0_4)
+model Identifier is IdentifierT<string, string>;
+
+/** The hosting system's own identifier for a record.
+ *
+ * The identifier value is the record's UUID within the hosting system; the
+ * registry code names that system (e.g. `org:grants.gov:system`).
+ */
+@example(Examples.Identifier.systemId)
+@Versioning.added(CommonGrants.Versions.v0_4)
+model SystemId is IdentifierT<Types.uuid>;
+
+// #########################################################
+// Identifiers
+// #########################################################
+
+/** A collection of identifiers associated with a record. */
+@example(Examples.Identifier.collection)
+@Versioning.added(CommonGrants.Versions.v0_4)
+model Identifiers {
+  /** The hosting system's own identifier for this record. */
+  systemId?: SystemId;
+
+  /** Additional identifiers keyed by their registry code, for registries the
+   * protocol does not define as a base identifier on the model.
+   */
+  otherIds?: Record<Identifier>;
+}
+
+// #########################################################
+// Examples
+// #########################################################
+
+namespace Examples.Identifier {
+  const ein = #{
+    registry: #{
+      code: "org:us:ein",
+      url: "https://commongrants.org/registries/org-us-ein",
+    },
+    id: "123456789",
+  };
+
+  const multiValue = #{
+    registry: #{
+      code: "org:us:ein",
+      url: "https://commongrants.org/registries/org-us-ein",
+    },
+    id: "123456789",
+    allIds: #[
+      #{ id: "123456789", status: IdentifierStatus.active },
+      #{ id: "987654321", status: IdentifierStatus.archived }
+    ],
+  };
+
+  const systemId = #{
+    registry: #{
+      code: "org:grants.gov:system",
+      url: "https://commongrants.org/registries/org-grants-gov-system",
+    },
+    id: "01912a8b-7c3d-7890-abcd-ef1234567890",
+  };
+
+  const collection = #{
+    systemId: systemId,
+    otherIds: #{
+      `org:candid:bridge`: #{
+        registry: #{ code: "org:candid:bridge" },
+        id: "1234567",
+      },
+    },
+  };
+}

--- a/lib/core/lib/core/fields/index.tsp
+++ b/lib/core/lib/core/fields/index.tsp
@@ -3,6 +3,7 @@ import "./metadata.tsp";
 import "./money.tsp";
 import "./event.tsp";
 import "./address.tsp";
+import "./identifier.tsp";
 import "./name.tsp";
 import "./phone.tsp";
 import "./pcs.tsp";

--- a/lib/core/lib/core/models/organization.tsp
+++ b/lib/core/lib/core/models/organization.tsp
@@ -16,13 +16,20 @@ model OrganizationBase {
   orgType?: Fields.PCSOrgType;
 
   /** The organization's Employer Identification Number (EIN), a unique identifier assigned by the IRS. */
+  @Versioning.removed(CommonGrants.Versions.v0_4)
   ein?: Types.employerTaxId;
 
   /** The organization's Unique Entity Identifier (UEI) from SAM.gov, used for federal contracting. */
+  @Versioning.removed(CommonGrants.Versions.v0_4)
   uei?: Types.samUEI;
 
   /** The organization's Data Universal Numbering System (DUNS) number, a unique identifier for businesses. */
+  @Versioning.removed(CommonGrants.Versions.v0_4)
   duns?: Types.duns;
+
+  /** Identifiers associated with the organization, keyed by registry code. */
+  @Versioning.added(CommonGrants.Versions.v0_4)
+  identifiers?: OrgIds;
 
   /** Collection of physical addresses associated with the organization. */
   addresses?: Fields.AddressCollection;
@@ -44,6 +51,42 @@ model OrganizationBase {
 
   /** Custom fields for the organization. */
   customFields?: Record<Fields.CustomField>;
+}
+
+// #########################################################
+// Organization identifiers
+// #########################################################
+
+/** An organization's Employer Identification Number (EIN), assigned by the IRS. */
+@example(Examples.OrgId.ein)
+@Versioning.added(CommonGrants.Versions.v0_4)
+model OrgIdEin is Fields.IdentifierT<Types.employerTaxId, "org:us:ein">;
+
+/** An organization's Unique Entity Identifier (UEI) from SAM.gov. */
+@example(Examples.OrgId.uei)
+@Versioning.added(CommonGrants.Versions.v0_4)
+model OrgIdUei is Fields.IdentifierT<Types.samUEI, "org:us:uei">;
+
+/** An organization's Data Universal Numbering System (DUNS) number. */
+@example(Examples.OrgId.duns)
+@Versioning.added(CommonGrants.Versions.v0_4)
+model OrgIdDuns is Fields.IdentifierT<Types.duns, "org:xi:duns">;
+
+/** A collection of identifiers associated with an organization.
+ *
+ * Extends the generic identifier collection with the base identifiers CommonGrants
+ * defines for organizations. Additional registries can be published under `otherIds`.
+ */
+@Versioning.added(CommonGrants.Versions.v0_4)
+model OrgIds extends Fields.IdentifierCollection {
+  /** The organization's Employer Identification Number (EIN), assigned by the IRS. */
+  `org:us:ein`?: OrgIdEin;
+
+  /** The organization's Unique Entity Identifier (UEI) from SAM.gov. */
+  `org:us:uei`?: OrgIdUei;
+
+  /** The organization's Data Universal Numbering System (DUNS) number. */
+  `org:xi:duns`?: OrgIdDuns;
 }
 
 // #########################################################
@@ -85,9 +128,22 @@ namespace Examples.Organization {
     id: "083b4567-e89d-42c8-a439-6c1234567890",
     name: "Example Organization",
     orgType: Fields.Examples.PCS.orgTypeTerm,
-    ein: "12-3456789",
-    uei: "AB1234567890",
-    duns: "123456789012",
+    identifiers: #{
+      `org:us:ein`: #{
+        registry: #{
+          code: "org:us:ein",
+          url: "https://commongrants.org/registries/org-us-ein",
+        },
+        id: "123456789",
+      },
+      `org:us:uei`: #{
+        registry: #{
+          code: "org:us:uei",
+          url: "https://commongrants.org/registries/org-us-uei",
+        },
+        id: "AB0123456789",
+      },
+    },
     addresses: Fields.Examples.Address.orgCollection,
     phones: Fields.Examples.Phone.orgCollection,
     emails: Fields.Examples.Email.orgCollection,
@@ -103,5 +159,31 @@ namespace Examples.Organization {
     instagram: "https://www.instagram.com/example",
     linkedin: "https://www.linkedin.com/company/example",
     otherSocials: #{ youtube: "https://www.youtube.com/example" },
+  };
+}
+
+namespace Examples.OrgId {
+  const ein = #{
+    registry: #{
+      code: "org:us:ein",
+      url: "https://commongrants.org/registries/org-us-ein",
+    },
+    id: "123456789",
+  };
+
+  const uei = #{
+    registry: #{
+      code: "org:us:uei",
+      url: "https://commongrants.org/registries/org-us-uei",
+    },
+    id: "AB0123456789",
+  };
+
+  const duns = #{
+    registry: #{
+      code: "org:xi:duns",
+      url: "https://commongrants.org/registries/org-xi-duns",
+    },
+    id: "123456789",
   };
 }

--- a/lib/core/lib/core/types.tsp
+++ b/lib/core/lib/core/types.tsp
@@ -37,22 +37,21 @@ scalar uuid extends string;
 @Versioning.added(CommonGrants.Versions.v0_2)
 scalar email extends string;
 
-/** An Employer Identification Number (EIN) issued by the IRS */
-@example("12-3456789")
-@pattern("^[0-9]{2}-[0-9]{7}$")
+/** An Employer Identification Number (EIN) issued by the IRS, normalized to nine digits */
+@example("123456789")
+@pattern("^[0-9]{9}$")
 @Versioning.added(CommonGrants.Versions.v0_2)
 scalar employerTaxId extends string;
 
 /** A Unique Entity Identifier (UEI) issued by SAM.gov */
-@example("12ABC34DEF56")
-@pattern("^[A-z0-9]{12}$")
+@example("AB0123456789")
+@pattern("^[A-HJ-NP-Z0-9]{12}$")
 @Versioning.added(CommonGrants.Versions.v0_2)
 scalar samUEI extends string;
 
-/** A Data Universal Numbering System (DUNS) number */
+/** A Data Universal Numbering System (DUNS) number, normalized to nine digits */
 @example("123456789")
-@example("12-345-6789")
-@example("123456789-1234")
+@pattern("^[0-9]{9}$")
 @Versioning.added(CommonGrants.Versions.v0_2)
 scalar duns extends string;
 

--- a/website/__tests__/lib/schema/version-generator.spec.ts
+++ b/website/__tests__/lib/schema/version-generator.spec.ts
@@ -37,6 +37,18 @@ const createTestSchemas = (): Map<string, JsonSchema> => {
     required: ["id", "name"],
   });
 
+  // Schema added in v0.2.0 with a `legacyCode` field removed in v0.3.0
+  schemas.set("Widget", {
+    $id: "Widget.yaml",
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      name: { type: "string" },
+      legacyCode: { type: "string" },
+    },
+    required: ["id", "legacyCode"],
+  });
+
   // Schema that references FormBase (to test $ref updates)
   schemas.set("Competition", {
     $id: "Competition.yaml",
@@ -89,6 +101,24 @@ const createTestChangelog = (): Changelog => ({
           action: Action.Added,
           targetKind: TargetType.ModelProperty,
           currTargetName: "version",
+        },
+      ],
+    },
+    Widget: {
+      "0.2.0": [
+        {
+          message: "Added `Widget` model",
+          action: Action.Added,
+          targetKind: TargetType.Model,
+          currTargetName: "Widget",
+        },
+      ],
+      "0.3.0": [
+        {
+          message: "Removed `legacyCode` field",
+          action: Action.Removed,
+          targetKind: TargetType.ModelProperty,
+          currTargetName: "legacyCode",
         },
       ],
     },
@@ -239,6 +269,35 @@ describe("Version Generator", () => {
       expect(formBaseV3?.properties).toHaveProperty("id");
       expect(formBaseV3?.properties).toHaveProperty("name");
       expect(formBaseV3?.properties).toHaveProperty("description");
+    });
+  });
+
+  // #############################################################################
+  // # Field removals
+  // #############################################################################
+
+  describe("Field removals", () => {
+    it("should include removed fields in versions before the removal", () => {
+      // legacyCode was removed from Widget in v0.3.0, so it exists in v0.2.0
+      const resultV2 = generateSchemaVersions("0.2.0", changelog, schemas);
+      const widgetV2 = resultV2.schemas.get("Widget") as JsonSchema;
+
+      expect(widgetV2?.properties).toHaveProperty("legacyCode");
+      expect(widgetV2?.required).toContain("legacyCode");
+    });
+
+    it("should exclude removed fields starting from the version they were removed", () => {
+      // legacyCode was removed from Widget in v0.3.0
+      const resultV3 = generateSchemaVersions("0.3.0", changelog, schemas);
+      const widgetV3 = resultV3.schemas.get("Widget") as JsonSchema;
+
+      // v0.3.0 should NOT have legacyCode, in properties or required
+      expect(widgetV3?.properties).not.toHaveProperty("legacyCode");
+      expect(widgetV3?.required ?? []).not.toContain("legacyCode");
+
+      // Other fields should remain
+      expect(widgetV3?.properties).toHaveProperty("id");
+      expect(widgetV3?.properties).toHaveProperty("name");
     });
   });
 

--- a/website/public/schemas/yaml/Identifier.yaml
+++ b/website/public/schemas/yaml/Identifier.yaml
@@ -1,0 +1,84 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: Identifier.yaml
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      code:
+        type: string
+        description: Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`).
+      url:
+        type: string
+        format: uri
+        description: Link to the catalog entry for this registry.
+      schema:
+        type: string
+        format: uri
+        description: JSON schema for validating the identifier format.
+    required:
+      - code
+    unevaluatedProperties:
+      not: {}
+    description: Registry-level facts shared by every record in this registry.
+  id:
+    type: string
+    description: |-
+      The primary identifier string, when the registry has a single canonical value.
+
+      May be omitted for registries with no natural primary; consumers should read
+      `allIds` in that case.
+  allIds:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: string
+          description: The identifier string.
+        status:
+          $ref: IdentifierStatus.yaml
+          description: Whether the identifier is currently valid or retired.
+      required:
+        - id
+        - status
+      unevaluatedProperties:
+        not: {}
+    description: Every known identifier for this record in this registry, including archived values.
+  uri:
+    type: string
+    format: uri
+    description: Link to this record in the registry's lookup service.
+  verifiedAt:
+    type: string
+    format: date-time
+    description: When this identifier was last verified.
+  verifiedBy:
+    type: string
+    description: |-
+      Reference to the system, service, or process that verified the identifier
+      (e.g. `irs.gov`, `system:manual-review`).
+required:
+  - registry
+unevaluatedProperties:
+  not: {}
+examples:
+  - registry:
+      code: org:us:ein
+      url: https://commongrants.org/registries/org-us-ein
+    id: "123456789"
+    allIds:
+      - id: "123456789"
+        status: active
+      - id: "987654321"
+        status: archived
+  - registry:
+      code: org:us:ein
+      url: https://commongrants.org/registries/org-us-ein
+    id: "123456789"
+description: |-
+  An identifier issued to a record by a registry.
+
+  Accepts any string value and any registry code. Model-specific collections use
+  registry-typed instantiations of `IdentifierT` (e.g. `OrgIdEin`) for their base
+  identifiers, and this generic form for extension identifiers under `otherIds`.

--- a/website/public/schemas/yaml/Identifier.yaml
+++ b/website/public/schemas/yaml/Identifier.yaml
@@ -12,12 +12,6 @@ properties:
         type: string
         format: uri
         description: Link to the catalog entry for this registry.
-      schema:
-        type: string
-        format: uri
-        description: JSON schema for validating the identifier format.
-    required:
-      - code
     unevaluatedProperties:
       not: {}
     description: Registry-level facts shared by every record in this registry.
@@ -45,21 +39,6 @@ properties:
       unevaluatedProperties:
         not: {}
     description: Every known identifier for this record in this registry, including archived values.
-  uri:
-    type: string
-    format: uri
-    description: Link to this record in the registry's lookup service.
-  verifiedAt:
-    type: string
-    format: date-time
-    description: When this identifier was last verified.
-  verifiedBy:
-    type: string
-    description: |-
-      Reference to the system, service, or process that verified the identifier
-      (e.g. `irs.gov`, `system:manual-review`).
-required:
-  - registry
 unevaluatedProperties:
   not: {}
 examples:

--- a/website/public/schemas/yaml/IdentifierCollection.yaml
+++ b/website/public/schemas/yaml/IdentifierCollection.yaml
@@ -1,0 +1,30 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: IdentifierCollection.yaml
+type: object
+properties:
+  systemId:
+    $ref: SystemId.yaml
+    description: The hosting system's own identifier for this record.
+  otherIds:
+    $ref: "#/$defs/RecordIdentifier"
+    description: |-
+      Additional identifiers keyed by their registry code, for registries the
+      protocol does not define as a base identifier on the model.
+examples:
+  - systemId:
+      registry:
+        code: org:grants.gov:system
+        url: https://commongrants.org/registries/org-grants-gov-system
+      id: 01912a8b-7c3d-7890-abcd-ef1234567890
+    otherIds:
+      org:candid:bridge:
+        registry:
+          code: org:candid:bridge
+        id: "1234567"
+description: A collection of identifiers associated with a record.
+$defs:
+  RecordIdentifier:
+    type: object
+    properties: {}
+    unevaluatedProperties:
+      $ref: Identifier.yaml

--- a/website/public/schemas/yaml/IdentifierStatus.yaml
+++ b/website/public/schemas/yaml/IdentifierStatus.yaml
@@ -1,0 +1,7 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: IdentifierStatus.yaml
+type: string
+enum:
+  - active
+  - archived
+description: The lifecycle status of an identifier value.

--- a/website/public/schemas/yaml/OrgIdDuns.yaml
+++ b/website/public/schemas/yaml/OrgIdDuns.yaml
@@ -1,0 +1,71 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: OrgIdDuns.yaml
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      code:
+        type: string
+        const: org:xi:duns
+        description: Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`).
+      url:
+        type: string
+        format: uri
+        description: Link to the catalog entry for this registry.
+      schema:
+        type: string
+        format: uri
+        description: JSON schema for validating the identifier format.
+    required:
+      - code
+    unevaluatedProperties:
+      not: {}
+    description: Registry-level facts shared by every record in this registry.
+  id:
+    $ref: duns.yaml
+    description: |-
+      The primary identifier string, when the registry has a single canonical value.
+
+      May be omitted for registries with no natural primary; consumers should read
+      `allIds` in that case.
+  allIds:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          $ref: duns.yaml
+          description: The identifier string.
+        status:
+          $ref: IdentifierStatus.yaml
+          description: Whether the identifier is currently valid or retired.
+      required:
+        - id
+        - status
+      unevaluatedProperties:
+        not: {}
+    description: Every known identifier for this record in this registry, including archived values.
+  uri:
+    type: string
+    format: uri
+    description: Link to this record in the registry's lookup service.
+  verifiedAt:
+    type: string
+    format: date-time
+    description: When this identifier was last verified.
+  verifiedBy:
+    type: string
+    description: |-
+      Reference to the system, service, or process that verified the identifier
+      (e.g. `irs.gov`, `system:manual-review`).
+required:
+  - registry
+unevaluatedProperties:
+  not: {}
+examples:
+  - registry:
+      code: org:xi:duns
+      url: https://commongrants.org/registries/org-xi-duns
+    id: "123456789"
+description: An organization's Data Universal Numbering System (DUNS) number.

--- a/website/public/schemas/yaml/OrgIdDuns.yaml
+++ b/website/public/schemas/yaml/OrgIdDuns.yaml
@@ -13,12 +13,6 @@ properties:
         type: string
         format: uri
         description: Link to the catalog entry for this registry.
-      schema:
-        type: string
-        format: uri
-        description: JSON schema for validating the identifier format.
-    required:
-      - code
     unevaluatedProperties:
       not: {}
     description: Registry-level facts shared by every record in this registry.
@@ -46,21 +40,6 @@ properties:
       unevaluatedProperties:
         not: {}
     description: Every known identifier for this record in this registry, including archived values.
-  uri:
-    type: string
-    format: uri
-    description: Link to this record in the registry's lookup service.
-  verifiedAt:
-    type: string
-    format: date-time
-    description: When this identifier was last verified.
-  verifiedBy:
-    type: string
-    description: |-
-      Reference to the system, service, or process that verified the identifier
-      (e.g. `irs.gov`, `system:manual-review`).
-required:
-  - registry
 unevaluatedProperties:
   not: {}
 examples:

--- a/website/public/schemas/yaml/OrgIdEin.yaml
+++ b/website/public/schemas/yaml/OrgIdEin.yaml
@@ -1,0 +1,71 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: OrgIdEin.yaml
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      code:
+        type: string
+        const: org:us:ein
+        description: Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`).
+      url:
+        type: string
+        format: uri
+        description: Link to the catalog entry for this registry.
+      schema:
+        type: string
+        format: uri
+        description: JSON schema for validating the identifier format.
+    required:
+      - code
+    unevaluatedProperties:
+      not: {}
+    description: Registry-level facts shared by every record in this registry.
+  id:
+    $ref: employerTaxId.yaml
+    description: |-
+      The primary identifier string, when the registry has a single canonical value.
+
+      May be omitted for registries with no natural primary; consumers should read
+      `allIds` in that case.
+  allIds:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          $ref: employerTaxId.yaml
+          description: The identifier string.
+        status:
+          $ref: IdentifierStatus.yaml
+          description: Whether the identifier is currently valid or retired.
+      required:
+        - id
+        - status
+      unevaluatedProperties:
+        not: {}
+    description: Every known identifier for this record in this registry, including archived values.
+  uri:
+    type: string
+    format: uri
+    description: Link to this record in the registry's lookup service.
+  verifiedAt:
+    type: string
+    format: date-time
+    description: When this identifier was last verified.
+  verifiedBy:
+    type: string
+    description: |-
+      Reference to the system, service, or process that verified the identifier
+      (e.g. `irs.gov`, `system:manual-review`).
+required:
+  - registry
+unevaluatedProperties:
+  not: {}
+examples:
+  - registry:
+      code: org:us:ein
+      url: https://commongrants.org/registries/org-us-ein
+    id: "123456789"
+description: An organization's Employer Identification Number (EIN), assigned by the IRS.

--- a/website/public/schemas/yaml/OrgIdEin.yaml
+++ b/website/public/schemas/yaml/OrgIdEin.yaml
@@ -13,12 +13,6 @@ properties:
         type: string
         format: uri
         description: Link to the catalog entry for this registry.
-      schema:
-        type: string
-        format: uri
-        description: JSON schema for validating the identifier format.
-    required:
-      - code
     unevaluatedProperties:
       not: {}
     description: Registry-level facts shared by every record in this registry.
@@ -46,21 +40,6 @@ properties:
       unevaluatedProperties:
         not: {}
     description: Every known identifier for this record in this registry, including archived values.
-  uri:
-    type: string
-    format: uri
-    description: Link to this record in the registry's lookup service.
-  verifiedAt:
-    type: string
-    format: date-time
-    description: When this identifier was last verified.
-  verifiedBy:
-    type: string
-    description: |-
-      Reference to the system, service, or process that verified the identifier
-      (e.g. `irs.gov`, `system:manual-review`).
-required:
-  - registry
 unevaluatedProperties:
   not: {}
 examples:

--- a/website/public/schemas/yaml/OrgIdUei.yaml
+++ b/website/public/schemas/yaml/OrgIdUei.yaml
@@ -1,0 +1,71 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: OrgIdUei.yaml
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      code:
+        type: string
+        const: org:us:uei
+        description: Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`).
+      url:
+        type: string
+        format: uri
+        description: Link to the catalog entry for this registry.
+      schema:
+        type: string
+        format: uri
+        description: JSON schema for validating the identifier format.
+    required:
+      - code
+    unevaluatedProperties:
+      not: {}
+    description: Registry-level facts shared by every record in this registry.
+  id:
+    $ref: samUEI.yaml
+    description: |-
+      The primary identifier string, when the registry has a single canonical value.
+
+      May be omitted for registries with no natural primary; consumers should read
+      `allIds` in that case.
+  allIds:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          $ref: samUEI.yaml
+          description: The identifier string.
+        status:
+          $ref: IdentifierStatus.yaml
+          description: Whether the identifier is currently valid or retired.
+      required:
+        - id
+        - status
+      unevaluatedProperties:
+        not: {}
+    description: Every known identifier for this record in this registry, including archived values.
+  uri:
+    type: string
+    format: uri
+    description: Link to this record in the registry's lookup service.
+  verifiedAt:
+    type: string
+    format: date-time
+    description: When this identifier was last verified.
+  verifiedBy:
+    type: string
+    description: |-
+      Reference to the system, service, or process that verified the identifier
+      (e.g. `irs.gov`, `system:manual-review`).
+required:
+  - registry
+unevaluatedProperties:
+  not: {}
+examples:
+  - registry:
+      code: org:us:uei
+      url: https://commongrants.org/registries/org-us-uei
+    id: AB0123456789
+description: An organization's Unique Entity Identifier (UEI) from SAM.gov.

--- a/website/public/schemas/yaml/OrgIdUei.yaml
+++ b/website/public/schemas/yaml/OrgIdUei.yaml
@@ -13,12 +13,6 @@ properties:
         type: string
         format: uri
         description: Link to the catalog entry for this registry.
-      schema:
-        type: string
-        format: uri
-        description: JSON schema for validating the identifier format.
-    required:
-      - code
     unevaluatedProperties:
       not: {}
     description: Registry-level facts shared by every record in this registry.
@@ -46,21 +40,6 @@ properties:
       unevaluatedProperties:
         not: {}
     description: Every known identifier for this record in this registry, including archived values.
-  uri:
-    type: string
-    format: uri
-    description: Link to this record in the registry's lookup service.
-  verifiedAt:
-    type: string
-    format: date-time
-    description: When this identifier was last verified.
-  verifiedBy:
-    type: string
-    description: |-
-      Reference to the system, service, or process that verified the identifier
-      (e.g. `irs.gov`, `system:manual-review`).
-required:
-  - registry
 unevaluatedProperties:
   not: {}
 examples:

--- a/website/public/schemas/yaml/OrgIds.yaml
+++ b/website/public/schemas/yaml/OrgIds.yaml
@@ -1,0 +1,22 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: OrgIds.yaml
+type: object
+properties:
+  org:us:ein:
+    $ref: OrgIdEin.yaml
+    description: The organization's Employer Identification Number (EIN), assigned by the IRS.
+  org:us:uei:
+    $ref: OrgIdUei.yaml
+    description: The organization's Unique Entity Identifier (UEI) from SAM.gov.
+  org:xi:duns:
+    $ref: OrgIdDuns.yaml
+    description: The organization's Data Universal Numbering System (DUNS) number.
+allOf:
+  - $ref: IdentifierCollection.yaml
+unevaluatedProperties:
+  not: {}
+description: |-
+  A collection of identifiers associated with an organization.
+
+  Extends the generic identifier collection with the base identifiers CommonGrants
+  defines for organizations. Additional registries can be published under `otherIds`.

--- a/website/public/schemas/yaml/OrganizationBase.yaml
+++ b/website/public/schemas/yaml/OrganizationBase.yaml
@@ -20,6 +20,9 @@ properties:
   duns:
     $ref: duns.yaml
     description: The organization's Data Universal Numbering System (DUNS) number, a unique identifier for businesses.
+  identifiers:
+    $ref: OrgIds.yaml
+    description: Identifiers associated with the organization, keyed by registry code.
   addresses:
     $ref: AddressCollection.yaml
     description: Collection of physical addresses associated with the organization.
@@ -54,9 +57,17 @@ examples:
       class: Organization types
       description: Institutions with the primary purpose of providing in-patient physical and mental health services...
       code: EO000000
-    ein: 12-3456789
-    uei: AB1234567890
-    duns: "123456789012"
+    identifiers:
+      org:us:ein:
+        registry:
+          code: org:us:ein
+          url: https://commongrants.org/registries/org-us-ein
+        id: "123456789"
+      org:us:uei:
+        registry:
+          code: org:us:uei
+          url: https://commongrants.org/registries/org-us-uei
+        id: AB0123456789
     addresses:
       primary:
         street1: 456 Main St

--- a/website/public/schemas/yaml/ProposalBase.yaml
+++ b/website/public/schemas/yaml/ProposalBase.yaml
@@ -127,9 +127,17 @@ examples:
           class: Organization types
           description: Institutions with the primary purpose of providing in-patient physical and mental health services...
           code: EO000000
-        ein: 12-3456789
-        uei: AB1234567890
-        duns: "123456789012"
+        identifiers:
+          org:us:ein:
+            registry:
+              code: org:us:ein
+              url: https://commongrants.org/registries/org-us-ein
+            id: "123456789"
+          org:us:uei:
+            registry:
+              code: org:us:uei
+              url: https://commongrants.org/registries/org-us-uei
+            id: AB0123456789
         addresses:
           primary:
             street1: 456 Main St
@@ -195,9 +203,17 @@ examples:
             class: Organization types
             description: Institutions with the primary purpose of providing in-patient physical and mental health services...
             code: EO000000
-          ein: 12-3456789
-          uei: AB1234567890
-          duns: "123456789012"
+          identifiers:
+            org:us:ein:
+              registry:
+                code: org:us:ein
+                url: https://commongrants.org/registries/org-us-ein
+              id: "123456789"
+            org:us:uei:
+              registry:
+                code: org:us:uei
+                url: https://commongrants.org/registries/org-us-uei
+              id: AB0123456789
           addresses:
             primary:
               street1: 456 Main St
@@ -262,9 +278,17 @@ examples:
             class: Organization types
             description: Institutions with the primary purpose of providing in-patient physical and mental health services...
             code: EO000000
-          ein: 12-3456789
-          uei: AB1234567890
-          duns: "123456789012"
+          identifiers:
+            org:us:ein:
+              registry:
+                code: org:us:ein
+                url: https://commongrants.org/registries/org-us-ein
+              id: "123456789"
+            org:us:uei:
+              registry:
+                code: org:us:uei
+                url: https://commongrants.org/registries/org-us-uei
+              id: AB0123456789
           addresses:
             primary:
               street1: 456 Main St

--- a/website/public/schemas/yaml/SystemId.yaml
+++ b/website/public/schemas/yaml/SystemId.yaml
@@ -1,0 +1,74 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: SystemId.yaml
+type: object
+properties:
+  registry:
+    type: object
+    properties:
+      code:
+        type: string
+        description: Canonical CommonGrants registry code, `<schema>:<scope>:<prop>` (e.g. `org:us:ein`).
+      url:
+        type: string
+        format: uri
+        description: Link to the catalog entry for this registry.
+      schema:
+        type: string
+        format: uri
+        description: JSON schema for validating the identifier format.
+    required:
+      - code
+    unevaluatedProperties:
+      not: {}
+    description: Registry-level facts shared by every record in this registry.
+  id:
+    $ref: uuid.yaml
+    description: |-
+      The primary identifier string, when the registry has a single canonical value.
+
+      May be omitted for registries with no natural primary; consumers should read
+      `allIds` in that case.
+  allIds:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          $ref: uuid.yaml
+          description: The identifier string.
+        status:
+          $ref: IdentifierStatus.yaml
+          description: Whether the identifier is currently valid or retired.
+      required:
+        - id
+        - status
+      unevaluatedProperties:
+        not: {}
+    description: Every known identifier for this record in this registry, including archived values.
+  uri:
+    type: string
+    format: uri
+    description: Link to this record in the registry's lookup service.
+  verifiedAt:
+    type: string
+    format: date-time
+    description: When this identifier was last verified.
+  verifiedBy:
+    type: string
+    description: |-
+      Reference to the system, service, or process that verified the identifier
+      (e.g. `irs.gov`, `system:manual-review`).
+required:
+  - registry
+unevaluatedProperties:
+  not: {}
+examples:
+  - registry:
+      code: org:grants.gov:system
+      url: https://commongrants.org/registries/org-grants-gov-system
+    id: 01912a8b-7c3d-7890-abcd-ef1234567890
+description: |-
+  The hosting system's own identifier for a record.
+
+  The identifier value is the record's UUID within the hosting system; the
+  registry code names that system (e.g. `org:grants.gov:system`).

--- a/website/public/schemas/yaml/SystemId.yaml
+++ b/website/public/schemas/yaml/SystemId.yaml
@@ -12,12 +12,6 @@ properties:
         type: string
         format: uri
         description: Link to the catalog entry for this registry.
-      schema:
-        type: string
-        format: uri
-        description: JSON schema for validating the identifier format.
-    required:
-      - code
     unevaluatedProperties:
       not: {}
     description: Registry-level facts shared by every record in this registry.
@@ -45,21 +39,6 @@ properties:
       unevaluatedProperties:
         not: {}
     description: Every known identifier for this record in this registry, including archived values.
-  uri:
-    type: string
-    format: uri
-    description: Link to this record in the registry's lookup service.
-  verifiedAt:
-    type: string
-    format: date-time
-    description: When this identifier was last verified.
-  verifiedBy:
-    type: string
-    description: |-
-      Reference to the system, service, or process that verified the identifier
-      (e.g. `irs.gov`, `system:manual-review`).
-required:
-  - registry
 unevaluatedProperties:
   not: {}
 examples:

--- a/website/public/schemas/yaml/duns.yaml
+++ b/website/public/schemas/yaml/duns.yaml
@@ -2,7 +2,6 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: duns.yaml
 type: string
 examples:
-  - 123456789-1234
-  - 12-345-6789
   - "123456789"
-description: A Data Universal Numbering System (DUNS) number
+pattern: ^[0-9]{9}$
+description: A Data Universal Numbering System (DUNS) number, normalized to nine digits

--- a/website/public/schemas/yaml/employerTaxId.yaml
+++ b/website/public/schemas/yaml/employerTaxId.yaml
@@ -2,6 +2,6 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: employerTaxId.yaml
 type: string
 examples:
-  - 12-3456789
-pattern: ^[0-9]{2}-[0-9]{7}$
-description: An Employer Identification Number (EIN) issued by the IRS
+  - "123456789"
+pattern: ^[0-9]{9}$
+description: An Employer Identification Number (EIN) issued by the IRS, normalized to nine digits

--- a/website/public/schemas/yaml/samUEI.yaml
+++ b/website/public/schemas/yaml/samUEI.yaml
@@ -2,6 +2,6 @@ $schema: https://json-schema.org/draft/2020-12/schema
 $id: samUEI.yaml
 type: string
 examples:
-  - 12ABC34DEF56
-pattern: ^[A-z0-9]{12}$
+  - AB0123456789
+pattern: ^[A-HJ-NP-Z0-9]{12}$
 description: A Unique Entity Identifier (UEI) issued by SAM.gov

--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -13,7 +13,7 @@ _How should the protocol represent the set of identifiers associated with an org
 
 ## Decision
 
-The protocol adopts an identification system that supports both uniquely identifying a record _within_ a given system and matching records _across_ multiple systems. To do this, it replaces the hardcoded `ein`, `uei`, and `duns` fields on `OrganizationBase` with a generic `identifiers` collection. The same `IdentifierCollection` collection will be reused across other core models, with each model extending it with its own base identifiers.
+The protocol adopts an identification system that supports both uniquely identifying a record _within_ a given system and matching records _across_ multiple systems. To do this, it replaces the hardcoded `ein`, `uei`, and `duns` fields on `OrganizationBase` with a generic `identifiers` collection. The same `IdentifierCollection` field will be reused across other core models, with each model extending it with its own base identifiers.
 
 :::caution[Important: publicly available identifiers only]
 

--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -13,7 +13,7 @@ _How should the protocol represent the set of identifiers associated with an org
 
 ## Decision
 
-The protocol adopts an identification system that supports both uniquely identifying a record _within_ a given system and matching records _across_ multiple systems. To do this, it replaces the hardcoded `ein`, `uei`, and `duns` fields on `OrganizationBase` with a generic `identifiers` collection. The same `Identifiers` collection will be reused across other core models, with each model extending it with its own base identifiers.
+The protocol adopts an identification system that supports both uniquely identifying a record _within_ a given system and matching records _across_ multiple systems. To do this, it replaces the hardcoded `ein`, `uei`, and `duns` fields on `OrganizationBase` with a generic `identifiers` collection. The same `IdentifierCollection` collection will be reused across other core models, with each model extending it with its own base identifiers.
 
 :::caution[Important: publicly available identifiers only]
 
@@ -99,7 +99,7 @@ At a glance, the key decisions for this identification system are:
 ### Consequences
 
 - **Positive consequences**
-  - One reusable `Identifier` / `Identifiers` pair across every core model, with model-specific keys on each extension.
+  - One reusable `Identifier` / `IdentifierCollection` pair across every core model, with model-specific keys on each extension.
   - Multiple IDs per registry are represented explicitly, with active, additional, and archived cases distinguishable.
   - Consistent with existing patterns (`AddressCollection`, `customFields`).
   - Nesting the `registry` object visually groups registry-level facts and points to the catalog entry via `registry.url`, so consumers can always find the source of truth.
@@ -119,9 +119,9 @@ At a glance, the key decisions for this identification system are:
 
 ### Identifier key hierarchy
 
-Each `Identifiers` collection has two tiers of keys:
+Each `IdentifierCollection` collection has two tiers of keys:
 
-- **Base identifiers** are defined by `@common-grants/core` at the root of each model's `Identifiers` extension (e.g. `org:us:ein`, `org:us:uei`, `org:xi:duns` on `OrgIds`). Each one has an identifier-specific JSON schema that extends the generic `Identifier` schema, plus a registered entry in the CommonGrants registry catalog. Every CommonGrants-compliant system is expected to recognize them for that model.
+- **Base identifiers** are defined by `@common-grants/core` at the root of each model's `IdentifierCollection` extension (e.g. `org:us:ein`, `org:us:uei`, `org:xi:duns` on `OrgIds`). Each one has an identifier-specific JSON schema that extends the generic `Identifier` schema, plus a registered entry in the CommonGrants registry catalog. Every CommonGrants-compliant system is expected to recognize them for that model.
 - **`otherIds`** is a catch-all map for identifiers the protocol does not define. Adopters can publish any identifier here keyed by its `<schema>:<scope>:<prop>` code (e.g. `org:candid:bridge`, `org:fluxx:system`). Entries need only conform to the generic `Identifier` schema. They may optionally be listed in the CommonGrants registry catalog, but the key itself is not reserved or validated by the protocol.
 
 **When to use each:**
@@ -140,7 +140,7 @@ Cataloging an `otherIds` entry turns a one-off extension into a shared ID regist
 
 _Stage 2: Promote to a base identifier (maintainer-driven)_
 
-A registry that has seen enough adoption can later be promoted out of `otherIds` and into a base identifier slot on one or more models. Because base identifiers add reserved keys to a model's `Identifiers` extension, promotion ships as a minor release of `@common-grants/core` and becomes part of the protocol every compliant system is expected to recognize. That release requirement is what makes this stage maintainer-driven for now.
+A registry that has seen enough adoption can later be promoted out of `otherIds` and into a base identifier slot on one or more models. Because base identifiers add reserved keys to a model's `IdentifierCollection` extension, promotion ships as a minor release of `@common-grants/core` and becomes part of the protocol every compliant system is expected to recognize. That release requirement is what makes this stage maintainer-driven for now.
 
 :::note
 The exact promotion mechanics (criteria, RFC process, community ownership) will be defined in a future version of the contributor guide. The important point here is that the path exists and that any cataloged registry is a candidate for it.
@@ -256,10 +256,10 @@ Identifier:
 </details>
 
 <details>
-<summary>Identifiers</summary>
+<summary>IdentifierCollection</summary>
 
 ```yaml
-Identifiers:
+IdentifierCollection:
   type: object
   properties:
     systemId:
@@ -280,7 +280,7 @@ Identifiers:
 ```yaml
 OrgIds:
   allOf:
-    - $ref: "#/components/schemas/Identifiers"
+    - $ref: "#/components/schemas/IdentifierCollection"
     - type: object
       properties:
         "org:us:ein":

--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -13,7 +13,7 @@ _How should the protocol represent the set of identifiers associated with an org
 
 ## Decision
 
-The protocol adopts an identification system that supports both uniquely identifying a record _within_ a given system and matching records _across_ multiple systems. To do this, it replaces the hardcoded `ein`, `uei`, and `duns` fields on `OrganizationBase` with a generic `identifiers` collection. The same `IdentifierCollection` field will be reused across other core models, with each model extending it with its own base identifiers.
+The protocol adopts an identification system that supports both uniquely identifying a record _within_ a given system and matching records _across_ multiple systems. To do this, it replaces the hardcoded `ein`, `uei`, and `duns` fields on `OrganizationBase` with a generic `identifiers` collection. The same `Identifiers` collection will be reused across other core models, with each model extending it with its own base identifiers.
 
 :::caution[Important: publicly available identifiers only]
 
@@ -34,9 +34,7 @@ The collection looks like this:
       "org:us:ein": {
         "registry": {
           "code": "org:us:ein",
-          "url": "https://commongrants.org/registries/org-us-ein",
-          "scope": "US",
-          "kind": "government"
+          "url": "https://commongrants.org/registries/org-us-ein"
         },
         "id": "987654321"
       }
@@ -46,9 +44,7 @@ The collection looks like this:
     "systemId": {
       "registry": {
         "code": "org:grants.gov:system",
-        "url": "https://commongrants.org/registries/org-grants-gov-system",
-        "scope": "grants.gov",
-        "kind": "platform"
+        "url": "https://commongrants.org/registries/org-grants-gov-system"
       },
       "id": "01912a8b-7c3d-7890-abcd-ef1234567890"
     },
@@ -56,8 +52,6 @@ The collection looks like this:
       "registry": {
         "code": "org:us:ein",
         "url": "https://commongrants.org/registries/org-us-ein",
-        "scope": "US",
-        "kind": "government",
         "schema": "https://commongrants.org/registries/org-us-ein/schema.json"
       },
       "id": "123456789",
@@ -73,9 +67,7 @@ The collection looks like this:
     "org:us:uei": {
       "registry": {
         "code": "org:us:uei",
-        "url": "https://commongrants.org/registries/org-us-uei",
-        "scope": "US",
-        "kind": "government"
+        "url": "https://commongrants.org/registries/org-us-uei"
       },
       "id": "AB0123456789"
     },
@@ -83,9 +75,7 @@ The collection looks like this:
       "org:candid:bridge": {
         "registry": {
           "code": "org:candid:bridge",
-          "url": "https://commongrants.org/registries/org-candid-bridge",
-          "scope": "candid",
-          "kind": "commercial"
+          "url": "https://commongrants.org/registries/org-candid-bridge"
         },
         "id": "1234567",
         "uri": "https://www.guidestar.org/profile/1234567"
@@ -100,7 +90,7 @@ At a glance, the key decisions for this identification system are:
 1. **Top-level ID:** A pure UUID on each resource, with the hosting system's own ID also surfaced inside the collection as `systemId`.
 2. **Collection structure:** A map keyed by registry code, with a catch-all `otherIds` map for extensions.
 3. **Map key format:** The registry's canonical three-part CommonGrants code, `<schema>:<scope>:<prop>` (`org:us:ein`, `org:us:uei`, `org:xi:duns`), used as both the map key and `registry.code`.
-4. **Identifier metadata structure:** A nested hybrid shape. Registry-level facts (the same for every record in the registry) live in a nested `registry` object with required `code` and `url` (linking to the catalog entry) plus optional `scope`, `kind`, and `schema`. Instance-level facts (`id`, `allIds`, `uri`, `verifiedAt`, `verifiedBy`) stay at the top level. Richer registry metadata (issuer, human-readable name, lookup template, etc.) lives in the external CommonGrants registry catalog reachable through `registry.url`.
+4. **Identifier metadata structure:** A nested hybrid shape, kept deliberately small on the wire. Registry-level facts live in a nested `registry` object with a required `code` plus optional `url` (linking to the catalog entry) and `schema`. Instance-level facts (`id`, `allIds`, `uri`, `verifiedAt`, `verifiedBy`) stay at the top level, and `id` itself is optional. Richer registry metadata (scope, kind, issuer, human-readable name, lookup template, etc.) lives entirely in the external CommonGrants registry catalog reachable through `registry.url`, rather than being duplicated inline on every record.
 5. **Multiple IDs per registry:** `id` for the primary, plus an optional `allIds` array of `{ id, status }` objects covering every known ID for this registry (the primary included), so consumers can do membership checks against `allIds` alone.
 6. **Parent organization:** `parent` carries `id`, `name`, and optionally an embedded `identifiers` collection. Parent identifiers do not leak into the child's collection.
 7. **Registry code format:** A single uniform three-part `<schema>:<scope>:<prop>` code (`org:us:ein`, `org:xi:duns`, `org:grants.gov:system`) minted and owned by CommonGrants for every registry, used as both the map key and `registry.code`. `schema` is the CommonGrants model the identifier applies to (`org`, `opp`, `app`, `awd`), `scope` is the jurisdiction or namespace (`us`, `xi`, `grants.gov`), and `prop` is the identifier property (`ein`, `uei`, or `system` for a platform's own record ID). The equivalent org-id.guide code (when one exists) is recorded as an `orgIdGuide` cross-reference in the catalog, not used as the code itself.
@@ -109,7 +99,7 @@ At a glance, the key decisions for this identification system are:
 ### Consequences
 
 - **Positive consequences**
-  - One reusable `Identifier` / `IdentifierCollection` pair across every core model, with model-specific keys on each extension.
+  - One reusable `Identifier` / `Identifiers` pair across every core model, with model-specific keys on each extension.
   - Multiple IDs per registry are represented explicitly, with active, additional, and archived cases distinguishable.
   - Consistent with existing patterns (`AddressCollection`, `customFields`).
   - Nesting the `registry` object visually groups registry-level facts and points to the catalog entry via `registry.url`, so consumers can always find the source of truth.
@@ -129,9 +119,9 @@ At a glance, the key decisions for this identification system are:
 
 ### Identifier key hierarchy
 
-Each `IdentifierCollection` has two tiers of keys:
+Each `Identifiers` collection has two tiers of keys:
 
-- **Base identifiers** are defined by `@common-grants/core` at the root of each model's `IdentifierCollection` extension (e.g. `org:us:ein`, `org:us:uei`, `org:xi:duns` on `OrgIdentifierCollection`). Each one has an identifier-specific JSON schema that extends the generic `Identifier` schema, plus a registered entry in the CommonGrants registry catalog. Every CommonGrants-compliant system is expected to recognize them for that model.
+- **Base identifiers** are defined by `@common-grants/core` at the root of each model's `Identifiers` extension (e.g. `org:us:ein`, `org:us:uei`, `org:xi:duns` on `OrgIds`). Each one has an identifier-specific JSON schema that extends the generic `Identifier` schema, plus a registered entry in the CommonGrants registry catalog. Every CommonGrants-compliant system is expected to recognize them for that model.
 - **`otherIds`** is a catch-all map for identifiers the protocol does not define. Adopters can publish any identifier here keyed by its `<schema>:<scope>:<prop>` code (e.g. `org:candid:bridge`, `org:fluxx:system`). Entries need only conform to the generic `Identifier` schema. They may optionally be listed in the CommonGrants registry catalog, but the key itself is not reserved or validated by the protocol.
 
 **When to use each:**
@@ -150,7 +140,7 @@ Cataloging an `otherIds` entry turns a one-off extension into a shared ID regist
 
 _Stage 2: Promote to a base identifier (maintainer-driven)_
 
-A registry that has seen enough adoption can later be promoted out of `otherIds` and into a base identifier slot on one or more models. Because base identifiers add reserved keys to a model's `IdentifierCollection` extension, promotion ships as a minor release of `@common-grants/core` and becomes part of the protocol every compliant system is expected to recognize. That release requirement is what makes this stage maintainer-driven for now.
+A registry that has seen enough adoption can later be promoted out of `otherIds` and into a base identifier slot on one or more models. Because base identifiers add reserved keys to a model's `Identifiers` extension, promotion ships as a minor release of `@common-grants/core` and becomes part of the protocol every compliant system is expected to recognize. That release requirement is what makes this stage maintainer-driven for now.
 
 :::note
 The exact promotion mechanics (criteria, RFC process, community ownership) will be defined in a future version of the contributor guide. The important point here is that the path exists and that any cataloged registry is a candidate for it.
@@ -204,8 +194,8 @@ Identifier:
       type: object
       description: |
         Registry-level facts that are the same for every record in this registry.
-        A subset of the corresponding catalog entry; consumers can fetch the full
-        entry via `registry.url`.
+        A minimal pointer to the corresponding catalog entry; consumers can fetch
+        the full entry (scope, kind, issuer, lookup template, etc.) via `registry.url`.
       properties:
         code:
           type: string
@@ -214,26 +204,17 @@ Identifier:
           type: string
           format: uri
           description: Link to the catalog entry for this registry
-        scope:
-          type: string
-          description: Jurisdiction or namespace the registry applies within (e.g. "US", "GB", "grants.gov")
-        kind:
-          type: string
-          enum: [government, commercial, platform, system]
-          description: |
-            Classification of the registry:
-            - government: issued by a government authority (EIN, UEI)
-            - commercial: issued by a commercial data provider (DUNS, Candid Bridge)
-            - platform: assigned by a CommonGrants-compliant system
-            - system: assigned by a non-CommonGrants system
         schema:
           type: string
           format: uri
           description: JSON schema for validating the identifier format
-      required: [code, url]
+      required: [code]
     id:
       type: string
-      description: Primary current identifier string
+      description: |
+        Primary current identifier string. Optional: may be omitted for registries
+        with no natural primary value (e.g. a program with multiple assistance
+        listing numbers), in which case consumers read `allIds`.
     allIds:
       type: array
       description: |
@@ -270,16 +251,15 @@ Identifier:
         field may be tightened during implementation.
   required:
     - registry
-    - id
 ```
 
 </details>
 
 <details>
-<summary>IdentifierCollection</summary>
+<summary>Identifiers</summary>
 
 ```yaml
-IdentifierCollection:
+Identifiers:
   type: object
   properties:
     systemId:
@@ -295,12 +275,12 @@ IdentifierCollection:
 </details>
 
 <details>
-<summary>OrgIdentifierCollection (model-specific extension)</summary>
+<summary>OrgIds (model-specific extension)</summary>
 
 ```yaml
-OrgIdentifierCollection:
+OrgIds:
   allOf:
-    - $ref: "#/components/schemas/IdentifierCollection"
+    - $ref: "#/components/schemas/Identifiers"
     - type: object
       properties:
         "org:us:ein":
@@ -328,27 +308,21 @@ The same shape extends to other models with model-specific keys:
     "systemId": {
       "registry": {
         "code": "opp:grants.gov:system",
-        "url": "https://commongrants.org/registries/opp-grants-gov-system",
-        "scope": "grants.gov",
-        "kind": "platform"
+        "url": "https://commongrants.org/registries/opp-grants-gov-system"
       },
       "id": "01912a8b-7c3d-7892-abcd-ef1234567892"
     },
     "opp:us:fon": {
       "registry": {
         "code": "opp:us:fon",
-        "url": "https://commongrants.org/registries/opp-us-fon",
-        "scope": "grants.gov",
-        "kind": "platform"
+        "url": "https://commongrants.org/registries/opp-us-fon"
       },
       "id": "HHS-2026-ACF-OCC-YD-0001"
     },
     "opp:us:aln": {
       "registry": {
         "code": "opp:us:aln",
-        "url": "https://commongrants.org/registries/opp-us-aln",
-        "scope": "US",
-        "kind": "government"
+        "url": "https://commongrants.org/registries/opp-us-aln"
       },
       "id": "93.575"
     }
@@ -366,9 +340,7 @@ The same shape extends to other models with model-specific keys:
     "systemId": {
       "registry": {
         "code": "app:fluxx:system",
-        "url": "https://commongrants.org/registries/app-fluxx-system",
-        "scope": "fluxx",
-        "kind": "system"
+        "url": "https://commongrants.org/registries/app-fluxx-system"
       },
       "id": "01912a8b-7c3d-7893-abcd-ef1234567893"
     },
@@ -376,9 +348,7 @@ The same shape extends to other models with model-specific keys:
       "app:grants.gov:tracking": {
         "registry": {
           "code": "app:grants.gov:tracking",
-          "url": "https://commongrants.org/registries/app-grants-gov-tracking",
-          "scope": "grants.gov",
-          "kind": "platform"
+          "url": "https://commongrants.org/registries/app-grants-gov-tracking"
         },
         "id": "GRANT12345678"
       }
@@ -397,18 +367,14 @@ The same shape extends to other models with model-specific keys:
     "systemId": {
       "registry": {
         "code": "awd:grants.gov:system",
-        "url": "https://commongrants.org/registries/awd-grants-gov-system",
-        "scope": "grants.gov",
-        "kind": "platform"
+        "url": "https://commongrants.org/registries/awd-grants-gov-system"
       },
       "id": "01912a8b-7c3d-7894-abcd-ef1234567894"
     },
     "awd:us:fain": {
       "registry": {
         "code": "awd:us:fain",
-        "url": "https://commongrants.org/registries/awd-us-fain",
-        "scope": "US",
-        "kind": "government"
+        "url": "https://commongrants.org/registries/awd-us-fain"
       },
       "id": "ABC12345"
     }

--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -51,18 +51,14 @@ The collection looks like this:
     "org:us:ein": {
       "registry": {
         "code": "org:us:ein",
-        "url": "https://commongrants.org/registries/org-us-ein",
-        "schema": "https://commongrants.org/registries/org-us-ein/schema.json"
+        "url": "https://commongrants.org/registries/org-us-ein"
       },
       "id": "123456789",
       "allIds": [
         { "id": "123456789", "status": "active" },
         { "id": "654321098", "status": "active" },
         { "id": "111111111", "status": "archived" }
-      ],
-      "uri": "https://apps.irs.gov/app/eos/detailsPage?ein=123456789",
-      "verifiedAt": "2026-03-15T00:00:00Z",
-      "verifiedBy": "irs.gov"
+      ]
     },
     "org:us:uei": {
       "registry": {
@@ -77,8 +73,7 @@ The collection looks like this:
           "code": "org:candid:bridge",
           "url": "https://commongrants.org/registries/org-candid-bridge"
         },
-        "id": "1234567",
-        "uri": "https://www.guidestar.org/profile/1234567"
+        "id": "1234567"
       }
     }
   }
@@ -90,7 +85,7 @@ At a glance, the key decisions for this identification system are:
 1. **Top-level ID:** A pure UUID on each resource, with the hosting system's own ID also surfaced inside the collection as `systemId`.
 2. **Collection structure:** A map keyed by registry code, with a catch-all `otherIds` map for extensions.
 3. **Map key format:** The registry's canonical three-part CommonGrants code, `<schema>:<scope>:<prop>` (`org:us:ein`, `org:us:uei`, `org:xi:duns`), used as both the map key and `registry.code`.
-4. **Identifier metadata structure:** A nested hybrid shape, kept deliberately small on the wire. Registry-level facts live in a nested `registry` object with a required `code` plus optional `url` (linking to the catalog entry) and `schema`. Instance-level facts (`id`, `allIds`, `uri`, `verifiedAt`, `verifiedBy`) stay at the top level, and `id` itself is optional. Richer registry metadata (scope, kind, issuer, human-readable name, lookup template, etc.) lives entirely in the external CommonGrants registry catalog reachable through `registry.url`, rather than being duplicated inline on every record.
+4. **Identifier metadata structure:** A nested hybrid shape, kept deliberately small on the wire. Registry-level facts live in a nested `registry` object holding the `code` plus an optional `url` linking to the catalog entry. Instance-level facts (`id`, `allIds`) stay at the top level. Every field is optional, so a payload carries only what a given system knows about a record. Richer registry metadata (scope, kind, issuer, human-readable name, lookup template, validation schema, etc.) lives entirely in the external CommonGrants registry catalog reachable through `registry.url`, rather than being duplicated inline on every record.
 5. **Multiple IDs per registry:** `id` for the primary, plus an optional `allIds` array of `{ id, status }` objects covering every known ID for this registry (the primary included), so consumers can do membership checks against `allIds` alone.
 6. **Parent organization:** `parent` carries `id`, `name`, and optionally an embedded `identifiers` collection. Parent identifiers do not leak into the child's collection.
 7. **Registry code format:** A single uniform three-part `<schema>:<scope>:<prop>` code (`org:us:ein`, `org:xi:duns`, `org:grants.gov:system`) minted and owned by CommonGrants for every registry, used as both the map key and `registry.code`. `schema` is the CommonGrants model the identifier applies to (`org`, `opp`, `app`, `awd`), `scope` is the jurisdiction or namespace (`us`, `xi`, `grants.gov`), and `prop` is the identifier property (`ein`, `uei`, or `system` for a platform's own record ID). The equivalent org-id.guide code (when one exists) is recorded as an `orgIdGuide` cross-reference in the catalog, not used as the code itself.
@@ -103,7 +98,7 @@ At a glance, the key decisions for this identification system are:
   - Multiple IDs per registry are represented explicitly, with active, additional, and archived cases distinguishable.
   - Consistent with existing patterns (`AddressCollection`, `customFields`).
   - Nesting the `registry` object visually groups registry-level facts and points to the catalog entry via `registry.url`, so consumers can always find the source of truth.
-  - The optional `registry.schema` URI lets new identifier types define their own validation without protocol changes.
+  - Per-registry validation schemas live in the catalog (reachable via `registry.url`), so new identifier types can define their own validation without bloating every payload or requiring protocol changes.
   - `systemId` makes each collection self-contained: a consumer can match across systems without inspecting the top-level `id` separately.
   - Registry codes are CommonGrants-owned and uniform, so they stay stable across org-id.guide renames and apply the same rule to registries org-id.guide does not cover.
   - The map key equals `registry.code`, so there is one canonical string per registry rather than a separate alias to maintain.
@@ -204,11 +199,6 @@ Identifier:
           type: string
           format: uri
           description: Link to the catalog entry for this registry
-        schema:
-          type: string
-          format: uri
-          description: JSON schema for validating the identifier format
-      required: [code]
     id:
       type: string
       description: |
@@ -234,23 +224,6 @@ Identifier:
             enum: [active, archived]
             description: Whether the identifier is currently valid or retired
         required: [id, status]
-    uri:
-      type: string
-      format: uri
-      description: Link to this record in the registry's lookup service
-    verifiedAt:
-      type: string
-      format: date-time
-      description: When this identifier was last verified
-    verifiedBy:
-      type: string
-      description: |
-        Reference to the system, service, or process that performed the verification
-        (e.g. "irs.gov", "candid.org", "system:manual-review"). Be mindful of PII such
-        as a human name or email address. The exact format and vocabulary for this
-        field may be tightened during implementation.
-  required:
-    - registry
 ```
 
 </details>
@@ -769,8 +742,7 @@ The `registry` object holds a curated subset of the catalog entry: the fields th
       "schema": "https://commongrants.org/registries/org-us-ein/schema.json"
     },
     "id": "123456789",
-    "uri": "https://apps.irs.gov/app/eos/detailsPage?ein=123456789",
-    "verifiedAt": "2026-03-15T00:00:00Z"
+    "uri": "https://apps.irs.gov/app/eos/detailsPage?ein=123456789"
   }
 }
 ```

--- a/website/src/content/docs/protocol/fields/identifiers.mdx
+++ b/website/src/content/docs/protocol/fields/identifiers.mdx
@@ -25,13 +25,13 @@ systemId:
       path: "lib/core/lib/core/fields/identifier.tsp"
       startLine: 78
       endLine: 85
-identifiers:
+identifierCollection:
   example:
     file:
-      path: "website/public/schemas/yaml/Identifiers.yaml"
+      path: "website/public/schemas/yaml/IdentifierCollection.yaml"
   jsonSchema:
     file:
-      path: "website/public/schemas/yaml/Identifiers.yaml"
+      path: "website/public/schemas/yaml/IdentifierCollection.yaml"
   typeSpec:
     file:
       path: "lib/core/lib/core/fields/identifier.tsp"
@@ -92,7 +92,7 @@ through their `systemId` field.
 
 <SchemaChangelog schema="SystemId" />
 
-## Identifiers
+## IdentifierCollection
 
 A collection of identifiers associated with a record, keyed by registry code. Includes the
 hosting system's own [SystemId](#systemid) under `systemId` and an `otherIds` extension
@@ -102,16 +102,16 @@ extend it with their base identifiers.
 
 ### Table
 
-<SchemaTable filePath={frontmatter.identifiers.jsonSchema.file.path} />
+<SchemaTable filePath={frontmatter.identifierCollection.jsonSchema.file.path} />
 
 ### Formats
 
 <SchemaFormatTabs
-  example={frontmatter.identifiers.example}
-  jsonSchema={frontmatter.identifiers.jsonSchema}
-  typeSpec={frontmatter.identifiers.typeSpec}
+  example={frontmatter.identifierCollection.example}
+  jsonSchema={frontmatter.identifierCollection.jsonSchema}
+  typeSpec={frontmatter.identifierCollection.typeSpec}
 />
 
 ### Changelog
 
-<SchemaChangelog schema="Identifiers" />
+<SchemaChangelog schema="IdentifierCollection" />

--- a/website/src/content/docs/protocol/fields/identifiers.mdx
+++ b/website/src/content/docs/protocol/fields/identifiers.mdx
@@ -12,7 +12,7 @@ identifier:
     file:
       path: "lib/core/lib/core/fields/identifier.tsp"
       startLine: 17
-      endLine: 76
+      endLine: 62
 systemId:
   example:
     file:
@@ -23,8 +23,8 @@ systemId:
   typeSpec:
     file:
       path: "lib/core/lib/core/fields/identifier.tsp"
-      startLine: 78
-      endLine: 85
+      startLine: 64
+      endLine: 71
 identifierCollection:
   example:
     file:
@@ -35,8 +35,8 @@ identifierCollection:
   typeSpec:
     file:
       path: "lib/core/lib/core/fields/identifier.tsp"
-      startLine: 91
-      endLine: 102
+      startLine: 77
+      endLine: 88
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/fields/identifiers.mdx
+++ b/website/src/content/docs/protocol/fields/identifiers.mdx
@@ -1,0 +1,117 @@
+---
+title: Identifiers
+description: Models for representing registry-issued identifiers on a record
+identifier:
+  example:
+    file:
+      path: "website/public/schemas/yaml/Identifier.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/Identifier.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/fields/identifier.tsp"
+      startLine: 17
+      endLine: 76
+systemId:
+  example:
+    file:
+      path: "website/public/schemas/yaml/SystemId.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/SystemId.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/fields/identifier.tsp"
+      startLine: 78
+      endLine: 85
+identifiers:
+  example:
+    file:
+      path: "website/public/schemas/yaml/Identifiers.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/Identifiers.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/fields/identifier.tsp"
+      startLine: 91
+      endLine: 102
+---
+
+import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";
+import SchemaTable from "@/components/SchemaTable.astro";
+import SchemaChangelog from "@/components/SchemaChangelog.astro";
+
+An identifier issued to a record by a registry, such as an organization's EIN or UEI.
+
+The base `Identifier` accepts any string value and any registry code. Model-specific
+identifiers (for example `OrgIdEin`) are named instantiations of the `IdentifierT<Id, Code>`
+template, which constrains the identifier value to a registry-specific format and pins
+`registry.code` to a specific registry while keeping the same shape as the base schema.
+Identifiers are keyed by their canonical CommonGrants registry code
+(`<schema>:<scope>:<prop>`, e.g. `org:us:ein`), which links to a catalog entry via
+`registry.url`.
+
+### Table
+
+<SchemaTable filePath={frontmatter.identifier.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.identifier.example}
+  jsonSchema={frontmatter.identifier.jsonSchema}
+  typeSpec={frontmatter.identifier.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="Identifier" />
+
+## SystemId
+
+The hosting system's own identifier for a record. It constrains the identifier value to a
+[uuid](/protocol/types/string#uuid), the record's UUID within the hosting system, while the
+`registry.code` names that system (e.g. `org:grants.gov:system`). Collections reference it
+through their `systemId` field.
+
+### Table
+
+<SchemaTable filePath={frontmatter.systemId.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.systemId.example}
+  jsonSchema={frontmatter.systemId.jsonSchema}
+  typeSpec={frontmatter.systemId.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="SystemId" />
+
+## Identifiers
+
+A collection of identifiers associated with a record, keyed by registry code. Includes the
+hosting system's own [SystemId](#systemid) under `systemId` and an `otherIds` extension
+point for registries the protocol does not define as a base identifier on the model.
+Model-specific collections (for example [OrgIds](/protocol/models/organization#orgids))
+extend it with their base identifiers.
+
+### Table
+
+<SchemaTable filePath={frontmatter.identifiers.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.identifiers.example}
+  jsonSchema={frontmatter.identifiers.jsonSchema}
+  typeSpec={frontmatter.identifiers.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="Identifiers" />

--- a/website/src/content/docs/protocol/fields/index.mdx
+++ b/website/src/content/docs/protocol/fields/index.mdx
@@ -35,6 +35,11 @@ Learn more about the standard fields defined by the CommonGrants protocol:
     description="A file attachment"
   />
   <LinkCard
+    title="Identifiers"
+    href="/protocol/fields/identifiers"
+    description="Registry-issued identifiers on a record"
+  />
+  <LinkCard
     title="System Metadata"
     href="/protocol/fields/metadata"
     description="System-managed metadata for records"

--- a/website/src/content/docs/protocol/filters/numeric.mdx
+++ b/website/src/content/docs/protocol/filters/numeric.mdx
@@ -33,8 +33,8 @@ numberRangeFilter:
   typeSpec:
     file:
       path: "lib/core/lib/core/filters/numeric.tsp"
-      startLine: 27
-      endLine: 39
+      startLine: 42
+      endLine: 54
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py"
@@ -55,8 +55,8 @@ numberArrayFilter:
   typeSpec:
     file:
       path: "lib/core/lib/core/filters/numeric.tsp"
-      startLine: 45
-      endLine: 54
+      startLine: 60
+      endLine: 69
   python:
     file:
       path: "lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/numeric.py"

--- a/website/src/content/docs/protocol/models/organization.mdx
+++ b/website/src/content/docs/protocol/models/organization.mdx
@@ -187,8 +187,8 @@ orgSocialLinks:
   typeSpec:
     file:
       path: "lib/core/lib/core/models/organization.tsp"
-      startLine: 80
-      endLine: 105
+      startLine: 96
+      endLine: 120
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/models/organization.mdx
+++ b/website/src/content/docs/protocol/models/organization.mdx
@@ -15,9 +15,29 @@ organizationBase:
           "code": "UC000000",
           "description": "Nonprofit organization"
         },
-        "ein": "19-1234567",
-        "uei": "ABCD123456789",
-        "duns": "123456789",
+        "identifiers": {
+          "org:us:ein": {
+            "registry": {
+              "code": "org:us:ein",
+              "url": "https://commongrants.org/registries/org-us-ein"
+            },
+            "id": "191234567"
+          },
+          "org:us:uei": {
+            "registry": {
+              "code": "org:us:uei",
+              "url": "https://commongrants.org/registries/org-us-uei"
+            },
+            "id": "ABCD12345678"
+          },
+          "org:xi:duns": {
+            "registry": {
+              "code": "org:xi:duns",
+              "url": "https://commongrants.org/registries/org-xi-duns"
+            },
+            "id": "123456789"
+          }
+        },
         "addresses": {
           "primary": {
             "street1": "456 Main St",
@@ -97,7 +117,55 @@ organizationBase:
     file:
       path: "lib/core/lib/core/models/organization.tsp"
       startLine: 5
-      endLine: 47
+      endLine: 54
+orgIds:
+  example:
+    file:
+      path: "website/public/schemas/yaml/OrgIds.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/OrgIds.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/models/organization.tsp"
+      startLine: 75
+      endLine: 90
+orgIdEin:
+  example:
+    file:
+      path: "website/public/schemas/yaml/OrgIdEin.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/OrgIdEin.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/models/organization.tsp"
+      startLine: 60
+      endLine: 63
+orgIdUei:
+  example:
+    file:
+      path: "website/public/schemas/yaml/OrgIdUei.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/OrgIdUei.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/models/organization.tsp"
+      startLine: 65
+      endLine: 68
+orgIdDuns:
+  example:
+    file:
+      path: "website/public/schemas/yaml/OrgIdDuns.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/OrgIdDuns.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/models/organization.tsp"
+      startLine: 70
+      endLine: 73
 orgSocialLinks:
   example:
     code: |
@@ -119,11 +187,12 @@ orgSocialLinks:
   typeSpec:
     file:
       path: "lib/core/lib/core/models/organization.tsp"
-      startLine: 53
-      endLine: 77
+      startLine: 80
+      endLine: 105
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";
+import SchemaTable from "@/components/SchemaTable.astro";
 import SchemaChangelog from "@/components/SchemaChangelog.astro";
 
 ## OrganizationBase
@@ -137,9 +206,7 @@ An organization that can apply to or host funding opportunities.
 | id           | [uuid](/protocol/types/string#uuid)                                                    | Yes      | The organization's unique identifier.                                        |
 | name         | [string](/protocol/types/string#string)                                                | Yes      | The organization's legal name as registered with relevant authorities.       |
 | orgType      | [PCSOrgType](/protocol/fields/pcs#pcsorgtype)                                          | No       | The organization's type within the Philanthropy Classification System (PCS). |
-| ein          | [employerTaxId](/protocol/types/string#employertaxid)                                  | No       | The organization's Employer Identification Number (EIN).                     |
-| uei          | [samUEI](/protocol/types/string#samuei)                                                | No       | The organization's Unique Entity Identifier (UEI).                           |
-| duns         | [duns](/protocol/types/string#duns)                                                    | No       | The organization's Data Universal Numbering System (DUNS) number.            |
+| identifiers  | [OrgIds](#orgids)                                                                      | No       | Identifiers associated with the organization, keyed by registry code.        |
 | addresses    | [AddressCollection](/protocol/fields/address#addresscollection)                        | No       | Collection of physical addresses associated with the organization.           |
 | phones       | [PhoneCollection](/protocol/fields/phone#phonecollection)                              | No       | Collection of phone numbers associated with the organization.                |
 | emails       | [EmailCollection](/protocol/fields/email#emailcollection)                              | No       | Collection of email addresses associated with the organization.              |
@@ -159,6 +226,95 @@ An organization that can apply to or host funding opportunities.
 ### Changelog
 
 <SchemaChangelog schema="OrganizationBase" />
+
+## OrgIds
+
+A collection of identifiers associated with an organization, keyed by registry code. It
+extends the generic [Identifiers](/protocol/fields/identifiers#identifiers) collection with
+the base identifiers CommonGrants defines for organizations. Additional registries can be
+published under `otherIds`.
+
+### Table
+
+<SchemaTable filePath={frontmatter.orgIds.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.orgIds.example}
+  jsonSchema={frontmatter.orgIds.jsonSchema}
+  typeSpec={frontmatter.orgIds.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="OrgIds" />
+
+## OrgIdEin
+
+An organization's Employer Identification Number (EIN), assigned by the IRS. It pins
+`registry.code` to `org:us:ein` and constrains the identifier value to the
+[employerTaxId](/protocol/types/string) format.
+
+### Table
+
+<SchemaTable filePath={frontmatter.orgIdEin.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.orgIdEin.example}
+  jsonSchema={frontmatter.orgIdEin.jsonSchema}
+  typeSpec={frontmatter.orgIdEin.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="OrgIdEin" />
+
+## OrgIdUei
+
+An organization's Unique Entity Identifier (UEI) from SAM.gov. It pins `registry.code` to
+`org:us:uei` and constrains the identifier value to the
+[samUEI](/protocol/types/string) format.
+
+### Table
+
+<SchemaTable filePath={frontmatter.orgIdUei.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.orgIdUei.example}
+  jsonSchema={frontmatter.orgIdUei.jsonSchema}
+  typeSpec={frontmatter.orgIdUei.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="OrgIdUei" />
+
+## OrgIdDuns
+
+An organization's Data Universal Numbering System (DUNS) number. It pins `registry.code` to
+`org:xi:duns` and constrains the identifier value to the
+[duns](/protocol/types/string) format.
+
+### Table
+
+<SchemaTable filePath={frontmatter.orgIdDuns.jsonSchema.file.path} />
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.orgIdDuns.example}
+  jsonSchema={frontmatter.orgIdDuns.jsonSchema}
+  typeSpec={frontmatter.orgIdDuns.typeSpec}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="OrgIdDuns" />
 
 ## OrgSocialLinks
 

--- a/website/src/content/docs/protocol/models/organization.mdx
+++ b/website/src/content/docs/protocol/models/organization.mdx
@@ -230,7 +230,7 @@ An organization that can apply to or host funding opportunities.
 ## OrgIds
 
 A collection of identifiers associated with an organization, keyed by registry code. It
-extends the generic [Identifiers](/protocol/fields/identifiers#identifiers) collection with
+extends the generic [IdentifierCollection](/protocol/fields/identifiers#identifiercollection) collection with
 the base identifiers CommonGrants defines for organizations. Additional registries can be
 published under `otherIds`.
 

--- a/website/src/content/docs/protocol/types/date.mdx
+++ b/website/src/content/docs/protocol/types/date.mdx
@@ -13,8 +13,8 @@ isoDate:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 84
-      endLine: 87
+      startLine: 82
+      endLine: 85
   typescript:
     file:
       path: "lib/ts-sdk/src/schemas/zod/types.ts"
@@ -30,8 +30,8 @@ isoTime:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 79
-      endLine: 82
+      startLine: 77
+      endLine: 80
   typescript:
     file:
       path: "lib/ts-sdk/src/schemas/zod/types.ts"
@@ -77,8 +77,8 @@ calendarYear:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 89
-      endLine: 93
+      startLine: 87
+      endLine: 91
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/content/docs/protocol/types/numeric.mdx
+++ b/website/src/content/docs/protocol/types/numeric.mdx
@@ -51,8 +51,8 @@ decimalString:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 64
-      endLine: 73
+      startLine: 62
+      endLine: 71
   typescript:
     file:
       path: "lib/ts-sdk/src/schemas/zod/types.ts"

--- a/website/src/content/docs/protocol/types/string.mdx
+++ b/website/src/content/docs/protocol/types/string.mdx
@@ -33,7 +33,7 @@ uuid:
     file:
       path: "lib/core/lib/core/types.tsp"
       startLine: 28
-      endLine: 31
+      endLine: 32
   typescript:
     file:
       path: "lib/ts-sdk/src/schemas/zod/types.ts"
@@ -49,8 +49,8 @@ email:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 33
-      endLine: 37
+      startLine: 34
+      endLine: 38
 employerTaxId:
   example:
     file:
@@ -61,8 +61,8 @@ employerTaxId:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 39
-      endLine: 43
+      startLine: 40
+      endLine: 44
 samUEI:
   example:
     file:
@@ -73,8 +73,8 @@ samUEI:
   typeSpec:
     file:
       path: "lib/core/lib/core/types.tsp"
-      startLine: 45
-      endLine: 49
+      startLine: 46
+      endLine: 50
 duns:
   example:
     file:
@@ -86,7 +86,7 @@ duns:
     file:
       path: "lib/core/lib/core/types.tsp"
       startLine: 52
-      endLine: 57
+      endLine: 56
 ---
 
 import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";

--- a/website/src/lib/schema/version-generator.ts
+++ b/website/src/lib/schema/version-generator.ts
@@ -260,26 +260,33 @@ function generateSchemaForVersion(
     versionedSchema.$id = `${nameInVersion}.yaml`;
   }
 
-  // Get fields that should be removed (added after target version)
+  // Determine which fields don't exist in the target version. The JSON Schema
+  // emitter ignores @typespec/versioning and emits a union of every field across
+  // all versions (see microsoft/typespec#2051, tracked here in HHS #370), so we
+  // reconstruct each version from the changelog: drop fields added after the
+  // target version, and drop fields removed at or before it.
   const fieldsToRemove = new Set<string>();
 
   if (schemaLogs) {
     for (const version of Object.keys(schemaLogs).sort()) {
-      if (compareVersions(version, targetVersion) > 0) {
-        const changes = schemaLogs[version];
-        for (const change of changes) {
-          if (
-            change.action === Action.Added &&
-            change.targetKind === TargetType.ModelProperty
-          ) {
-            fieldsToRemove.add(change.currTargetName || "");
-          }
+      const changes = schemaLogs[version];
+      const isAfterTarget = compareVersions(version, targetVersion) > 0;
+      const isAtOrBeforeTarget = compareVersions(version, targetVersion) <= 0;
+      for (const change of changes) {
+        if (change.targetKind !== TargetType.ModelProperty) {
+          continue;
+        }
+        if (isAfterTarget && change.action === Action.Added) {
+          fieldsToRemove.add(change.currTargetName || "");
+        }
+        if (isAtOrBeforeTarget && change.action === Action.Removed) {
+          fieldsToRemove.add(change.currTargetName || "");
         }
       }
     }
   }
 
-  // Remove fields that didn't exist yet
+  // Remove fields that didn't exist in this version
   if (versionedSchema.properties) {
     for (const fieldName of fieldsToRemove) {
       delete versionedSchema.properties[fieldName];

--- a/website/src/specs/forms/sf424-mandatory.tsp
+++ b/website/src/specs/forms/sf424-mandatory.tsp
@@ -503,7 +503,7 @@ model SF424Mandatory {
   orgName: QuestionOrgName;
 
   /** Employer Identification Number (EIN) of the applicant organization */
-  @example(#{ ein: "12-3456789" })
+  @example(#{ ein: "123456789" })
   @extension(
     "x-overrides",
     #{

--- a/website/src/specs/forms/sf424.tsp
+++ b/website/src/specs/forms/sf424.tsp
@@ -234,7 +234,7 @@ model SF424 {
   /** Primary applicant organization */
   @example(#{
     name: "Example Research Institute",
-    ein: "12-3456789",
+    ein: "123456789",
     uei: "ABC123DEF456",
     address: #{
       street1: "123 Research Way",

--- a/website/src/specs/question-bank/fiscal-sponsor/fiscal-sponsor-details.tsp
+++ b/website/src/specs/question-bank/fiscal-sponsor/fiscal-sponsor-details.tsp
@@ -16,8 +16,12 @@ namespace QuestionBank.FiscalSponsorDetails;
   "x-mapping-from-cg",
   #{
     name: #{ field: "organizations.otherOrgs.fiscalSponsor.name" },
-    ein: #{ field: "organizations.otherOrgs.fiscalSponsor.ein" },
-    uei: #{ field: "organizations.otherOrgs.fiscalSponsor.uei" },
+    ein: #{
+      field: "organizations.otherOrgs.fiscalSponsor.identifiers.org:us:ein.id",
+    },
+    uei: #{
+      field: "organizations.otherOrgs.fiscalSponsor.identifiers.org:us:uei.id",
+    },
     address: #{
       street1: #{
         field: "organizations.otherOrgs.fiscalSponsor.addresses.primary.street1",
@@ -62,8 +66,10 @@ namespace QuestionBank.FiscalSponsorDetails;
       otherOrgs: #{
         fiscalSponsor: #{
           name: #{ field: "name" },
-          ein: #{ field: "ein" },
-          uei: #{ field: "uei" },
+          identifiers: #{
+            `org:us:ein`: #{ id: #{ field: "ein" } },
+            `org:us:uei`: #{ id: #{ field: "uei" } },
+          },
           addresses: #{
             primary: #{
               street1: #{ field: "address.street1" },

--- a/website/src/specs/question-bank/fiscal-sponsor/fiscal-sponsor-ein.tsp
+++ b/website/src/specs/question-bank/fiscal-sponsor/fiscal-sponsor-ein.tsp
@@ -13,13 +13,21 @@ namespace QuestionBank.FiscalSponsorEin;
 @extension("x-entity", #[Entities.fiscalSponsor])
 @extension(
   "x-mapping-from-cg",
-  #{ ein: #{ field: "organizations.otherOrgs.fiscalSponsor.ein" } }
+  #{
+    ein: #{
+      field: "organizations.otherOrgs.fiscalSponsor.identifiers.org:us:ein.id",
+    },
+  }
 )
 @extension(
   "x-mapping-to-cg",
   #{
     organizations: #{
-      otherOrgs: #{ fiscalSponsor: #{ ein: #{ field: "ein" } } },
+      otherOrgs: #{
+        fiscalSponsor: #{
+          identifiers: #{ `org:us:ein`: #{ id: #{ field: "ein" } } },
+        },
+      },
     },
   }
 )
@@ -36,5 +44,5 @@ namespace QuestionBank.FiscalSponsorEin;
     ],
   }
 )
-@example(#{ ein: "98-7654321" })
+@example(#{ ein: "987654321" })
 model QuestionFiscalSponsorEin extends QuestionEin.QuestionEin {}

--- a/website/src/specs/question-bank/fiscal-sponsor/fiscal-sponsor-uei.tsp
+++ b/website/src/specs/question-bank/fiscal-sponsor/fiscal-sponsor-uei.tsp
@@ -13,13 +13,21 @@ namespace QuestionBank.FiscalSponsorUei;
 @extension("x-entity", #[Entities.fiscalSponsor])
 @extension(
   "x-mapping-from-cg",
-  #{ uei: #{ field: "organizations.otherOrgs.fiscalSponsor.uei" } }
+  #{
+    uei: #{
+      field: "organizations.otherOrgs.fiscalSponsor.identifiers.org:us:uei.id",
+    },
+  }
 )
 @extension(
   "x-mapping-to-cg",
   #{
     organizations: #{
-      otherOrgs: #{ fiscalSponsor: #{ uei: #{ field: "uei" } } },
+      otherOrgs: #{
+        fiscalSponsor: #{
+          identifiers: #{ `org:us:uei`: #{ id: #{ field: "uei" } } },
+        },
+      },
     },
   }
 )

--- a/website/src/specs/question-bank/generics/question-ein.tsp
+++ b/website/src/specs/question-bank/generics/question-ein.tsp
@@ -24,7 +24,7 @@ namespace QuestionBank.QuestionEin;
     ],
   }
 )
-@example(#{ ein: "12-3456789" })
+@example(#{ ein: "123456789" })
 model QuestionEin {
   /** Employer Identification Number */
   ein: employerTaxId;

--- a/website/src/specs/question-bank/primary-org/org-details.tsp
+++ b/website/src/specs/question-bank/primary-org/org-details.tsp
@@ -17,9 +17,9 @@ namespace QuestionBank.OrgDetails;
   "x-mapping-from-cg",
   #{
     name: #{ field: "organizations.primary.name" },
-    ein: #{ field: "organizations.primary.ein" },
-    uei: #{ field: "organizations.primary.uei" },
-    duns: #{ field: "organizations.primary.duns" },
+    ein: #{ field: "organizations.primary.identifiers.org:us:ein.id" },
+    uei: #{ field: "organizations.primary.identifiers.org:us:uei.id" },
+    duns: #{ field: "organizations.primary.identifiers.org:xi:duns.id" },
     mission: #{ field: "organizations.primary.mission" },
     yearFounded: #{ field: "organizations.primary.yearFounded" },
     address: #{
@@ -51,9 +51,11 @@ namespace QuestionBank.OrgDetails;
     organizations: #{
       primary: #{
         name: #{ field: "name" },
-        ein: #{ field: "ein" },
-        uei: #{ field: "uei" },
-        duns: #{ field: "duns" },
+        identifiers: #{
+          `org:us:ein`: #{ id: #{ field: "ein" } },
+          `org:us:uei`: #{ id: #{ field: "uei" } },
+          `org:xi:duns`: #{ id: #{ field: "duns" } },
+        },
         mission: #{ field: "mission" },
         yearFounded: #{ field: "yearFounded" },
         addresses: #{

--- a/website/src/specs/question-bank/primary-org/org-duns.tsp
+++ b/website/src/specs/question-bank/primary-org/org-duns.tsp
@@ -12,11 +12,17 @@ namespace QuestionBank.OrgDuns;
 @extension("x-entity", #[Entities.primaryOrg])
 @extension(
   "x-mapping-from-cg",
-  #{ duns: #{ field: "organizations.primary.duns" } }
+  #{ duns: #{ field: "organizations.primary.identifiers.org:xi:duns.id" } }
 )
 @extension(
   "x-mapping-to-cg",
-  #{ organizations: #{ primary: #{ duns: #{ field: "duns" } } } }
+  #{
+    organizations: #{
+      primary: #{
+        identifiers: #{ `org:xi:duns`: #{ id: #{ field: "duns" } } },
+      },
+    },
+  }
 )
 @extension(
   "x-ui-schema",

--- a/website/src/specs/question-bank/primary-org/org-ein.tsp
+++ b/website/src/specs/question-bank/primary-org/org-ein.tsp
@@ -12,11 +12,15 @@ namespace QuestionBank.OrgEin;
 @extension("x-entity", #[Entities.primaryOrg])
 @extension(
   "x-mapping-from-cg",
-  #{ ein: #{ field: "organizations.primary.ein" } }
+  #{ ein: #{ field: "organizations.primary.identifiers.org:us:ein.id" } }
 )
 @extension(
   "x-mapping-to-cg",
-  #{ organizations: #{ primary: #{ ein: #{ field: "ein" } } } }
+  #{
+    organizations: #{
+      primary: #{ identifiers: #{ `org:us:ein`: #{ id: #{ field: "ein" } } } },
+    },
+  }
 )
 @extension(
   "x-ui-schema",
@@ -31,7 +35,7 @@ namespace QuestionBank.OrgEin;
     ],
   }
 )
-@example(#{ ein: "12-3456789" })
+@example(#{ ein: "123456789" })
 model QuestionOrgEin {
   /** The organization's Employer Identification Number */
   ein: employerTaxId;

--- a/website/src/specs/question-bank/primary-org/org-uei.tsp
+++ b/website/src/specs/question-bank/primary-org/org-uei.tsp
@@ -12,11 +12,15 @@ namespace QuestionBank.OrgUei;
 @extension("x-entity", #[Entities.primaryOrg])
 @extension(
   "x-mapping-from-cg",
-  #{ uei: #{ field: "organizations.primary.uei" } }
+  #{ uei: #{ field: "organizations.primary.identifiers.org:us:uei.id" } }
 )
 @extension(
   "x-mapping-to-cg",
-  #{ organizations: #{ primary: #{ uei: #{ field: "uei" } } } }
+  #{
+    organizations: #{
+      primary: #{ identifiers: #{ `org:us:uei`: #{ id: #{ field: "uei" } } } },
+    },
+  }
 )
 @extension(
   "x-ui-schema",


### PR DESCRIPTION
### Summary

Adds `Identifier` and `IdentifierCollection` models; replaces `ein`, `duns`, and `uei` on `OrganizationBase` with new identifier entries; and updates the website docs for these models.

- Fixes #957 
- Time to review: 10 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Adds `Identifier`, `IdentifierCollection`, and `SystemId` models to `@common-grants/core` library following the pattern defined in [ADR-0023](https://commongrants.org/governance/adr/0023-org-ids/)
- Adds `identifiers` prop to `OrganizationBase` and moves ID-related props into that collection, matching the org-related IDs added in #979 
  - `OrganizationBase.ein` -> `OrganizationBase.identifiers[org:us:ein]`
  - `OrganizationBase.uei` -> `OrganizationBase.identifiers[org:us:uei]`
  - `OrganizationBase.duns` -> `OrganizationBase.identifiers[org:xi:duns]`
- Adds a `/protocol/fields/identifiers/` page for the new identifier fields and updates `/protocol/models/organization` to include the new org ID entries
- Fixes the question bank and Form library mappings to use the new identifiers models.
- Updates `version-generator.ts` to remove props marked with `@Versioning.removed()` in the JSON schemas that are auto-generated from TypeSpec since `@typespec/versioning` doesn't support this natively, and commits these auto-generated schemas.
- Simplified the `Identifier` schema proposed in ADR-0023 by removing:
  - `kind`, `scope`, and `schema` from `Identifer.registry`
  - Removing `uri`, `verifiedAt`, and `verifiedBy` from the root

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

#### Instructions to review

1. Go to the PR preview page: https://cg-pr-1000.billy-daly.workers.dev/
2. Review the website protocol docs:
    - [`/protocol/fields/`](https://cg-pr-1000.billy-daly.workers.dev/protocol/fields/) should include Identifiers
    - `[/protocol/fields/idenfitiers/`](https://cg-pr-1000.billy-daly.workers.dev/protocol/fields/identifiers/) should include the newly added identifier TypeSpec models
    - [`/protcol/models/organization/`](https://cg-pr-1000.billy-daly.workers.dev/protocol/models/organization/) should have the new org ID models, an updated `OrganizationBase` and a new entry in the changelog
3. Review the updated question bank and form mapping:
    - Check that [the Organization EIN](https://cg-pr-1000.billy-daly.workers.dev/question-bank/org-ein/) form data is mapped to the correct location
    - Check that [the Organization DUNS](https://cg-pr-1000.billy-daly.workers.dev/question-bank/org-duns/) form data is mapped to the correct location
    - Check that [the Organization UEI](https://cg-pr-1000.billy-daly.workers.dev/question-bank/org-uei/) form data is mapped to the right location.
    - Check the other versions of the same ID fields (e.g. Fiscal Sponsor EIN, UEI, and DUNS)

#### Notes

- I descoped adding an `identifiers` prop to `OpportunityBase` because it would break the property-based testing that we have set up in the TypeScript SDK unless we also implement in in the SDK.
- The fixes I added to support `@Versioning.removed()` in the JSON schema output _should_ probably be moved either into `lib/changelog-emitter` or in a new custom TypeSpec emitter in our `lib/` directory because multiple sections of this codebase use `@typespec/json-schema` and the resulting JSON schemas will include `ein`, `duns`, and `uei` properties unless they adopt a similar fix to the one this PR adds to `version-generator.ts` to remove them.
- I simplified the `Identifier` model a bit by removing some extra fields that we _may_ want to add in the future. But given the complexity of removing properties (as surfaced in this PR) I'd rather be more conservative with the fields we add in the initial release. The fields I removed are:
  - `kind`, `scope`, and `schema` since these can be looked up in the ID registry entry using `registry.url`
  - `uri`, `verifiedAt`, and `verifiedBy` because it's a lot to add a verification layer or external lookups to identifiers at this step.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

#### Fields page

<img width="1512" height="982" alt="Screenshot 2026-07-09 at 7 49 06 PM" src="https://github.com/user-attachments/assets/1ce28319-8c61-4439-8b4f-e13af1bd7f65" />

#### New identifiers field page

<img width="1512" height="982" alt="Screenshot 2026-07-09 at 8 11 35 PM" src="https://github.com/user-attachments/assets/7b1caec6-2ec2-43ac-a84c-f74f36ca6ca0" />

#### Updated organization model page

<img width="1512" height="982" alt="Screenshot 2026-07-09 at 8 12 35 PM" src="https://github.com/user-attachments/assets/99a58506-7a4f-4079-9cb2-9730c47076de" />

#### Update question bank and form mapping

<img width="1512" height="982" alt="Screenshot 2026-07-09 at 8 13 23 PM" src="https://github.com/user-attachments/assets/117ffd87-f44b-49c0-b5a0-34d451f8b189" />
