### PR TITLE
fix(py-sdk): ship PEP 561 py.typed marker

### DIFF
--- a/.changeset/python-sdk-py-typed.md
+++ b/.changeset/python-sdk-py-typed.md
@@ -1,0 +1,7 @@
+---
+"common-grants-sdk": patch
+---
+
+Ship a PEP 561 `py.typed` marker so downstream type checkers use the SDK's inline type annotations.
+
+The package is fully type-annotated but shipped no marker, so `mypy` treated every `common_grants_sdk` import as untyped (`import-untyped`, "missing library stubs or py.typed marker") and consumers got no type-checking from the SDK. Adding the marker brings the Python SDK to parity with the TypeScript SDK, which already ships its `.d.ts` types.

--- a/.github/workflows/ci-bump-version.yml
+++ b/.github/workflows/ci-bump-version.yml
@@ -71,7 +71,14 @@ jobs:
             exit 0
           else
             echo "found_py=true" >> $GITHUB_OUTPUT
-            echo "py_changelog=$PY_CHANGELOG" >> $GITHUB_OUTPUT
+            # Multiple changesets can bump common-grants-sdk (e.g. a feature +
+            # a fix landing in the same release), so PY_CHANGELOG may be
+            # multiline — write it via the heredoc form, not key=value.
+            {
+              echo "py_changelog<<EOF"
+              echo "$PY_CHANGELOG"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
           fi
 
       - name: Bump version for Python package


### PR DESCRIPTION
### Summary

- Ships a PEP 561 `py.typed` marker for `common-grants-sdk` so downstream type checkers use the SDK's inline annotations instead of treating every import as untyped.
- Fixes the `version` CI job so it handles more than one Python changeset per release (surfaced by adding this changeset alongside the filters one).
- Time to review: 3 minutes

### Changes proposed

- Add empty `lib/python-sdk/common_grants_sdk/py.typed` marker + a `common-grants-sdk` patch changeset.
- `ci-bump-version.yml`: write the (possibly multiline) `py_changelog` to `$GITHUB_OUTPUT` via the heredoc form instead of `key=value`.

### Context for reviewers

**py.typed** — the package is fully type-annotated but shipped no marker, so `mypy` reported `import-untyped` on every `common_grants_sdk` import and consumers got no type-checking from the SDK. Brings the Python SDK to parity with the TypeScript SDK (which ships its `.d.ts`). Verified the marker lands in the built wheel — Poetry includes it via the existing `packages` config, no `pyproject` change:

```
$ poetry build -f wheel && unzip -l dist/*.whl | grep py.typed
        0  ...  common_grants_sdk/py.typed
```

**CI fix** — the `version` job greps all changesets for `"common-grants-sdk":` and wrote the result to `$GITHUB_OUTPUT` as `key=value`. Once two changesets bump the package (the filters `minor` already on HOLD-filters + this `patch`), the grep result is multiline and GitHub Actions rejects the `key=value` write. The heredoc form handles any number of changesets. This job also runs on push to `main`, so the bug would otherwise have blocked the Python version bump/tag when HOLD-filters merges to main with both changesets present.

Targets `HOLD-filters` so py.typed ships in the same coordinated `common-grants-sdk` release as the filters API.

### Additional information

Empty marker file; the CI change is workflow-only. No runtime or API change.
