### PR TITLE
docs(sdk): add grants.gov custom-filters search examples (Py + TS)

### DIFF
--- a/lib/python-sdk/examples/grants_gov_custom_filters.py
+++ b/lib/python-sdk/examples/grants_gov_custom_filters.py
@@ -68,9 +68,9 @@ def main() -> None:
     # without a live endpoint: status stays top-level, the four customs land in
     # customFilters. classify_filters returns the body directly and raises
     # FilterError on a bad value (fail-fast) — these filters are all valid.
-    body = classify_filters(grants_gov.routes, "opportunities", "search", filters).model_dump(
-        by_alias=True, exclude_none=True, mode="json"
-    )
+    body = classify_filters(
+        grants_gov.routes, "opportunities", "search", filters
+    ).model_dump(by_alias=True, exclude_none=True, mode="json")
     print("Request body (default fields + customFilters):")
     print(json.dumps(body, indent=2), "\n")
 

--- a/lib/python-sdk/examples/grants_gov_custom_filters.py
+++ b/lib/python-sdk/examples/grants_gov_custom_filters.py
@@ -66,14 +66,13 @@ def main() -> None:
     # The request body the client will POST. Shown here (via classify_filters,
     # which get_client runs internally) so the customFilters split is visible
     # without a live endpoint: status stays top-level, the four customs land in
-    # customFilters.
-    classified = classify_filters(grants_gov.routes, "opportunities", "search", filters)
-    body = classified.result.model_dump(by_alias=True, exclude_none=True, mode="json")
+    # customFilters. classify_filters returns the body directly and raises
+    # FilterError on a bad value (fail-fast) — these filters are all valid.
+    body = classify_filters(grants_gov.routes, "opportunities", "search", filters).model_dump(
+        by_alias=True, exclude_none=True, mode="json"
+    )
     print("Request body (default fields + customFilters):")
     print(json.dumps(body, indent=2), "\n")
-    if classified.errors:
-        print(f"  FAIL  filter validation: {classified.errors}", file=sys.stderr)
-        sys.exit(1)
 
     # get_client binds the plugin's routes + schemas: search(filters=...) is typed
     # by the registered filters and rows parse as grants.gov opportunities.

--- a/lib/python-sdk/examples/grants_gov_custom_filters.py
+++ b/lib/python-sdk/examples/grants_gov_custom_filters.py
@@ -58,7 +58,7 @@ def main() -> None:
     filters = {
         "status": f.in_(["open", "forecasted"]),
         "agency": f.in_(["HHS", "USDA"]),
-        "applicantType": f.in_(["state_governments", "county_governments"]),
+        "applicantType": f.in_(["government_state", "government_county"]),
         "fundingInstrument": f.in_(["grant", "cooperative_agreement"]),
         "costSharing": f.eq(False),
     }

--- a/lib/python-sdk/examples/grants_gov_custom_filters.py
+++ b/lib/python-sdk/examples/grants_gov_custom_filters.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import json
 import sys
 
-from cg_grants_gov import grants_gov
+from cg_grants_gov import OppSearchFilters, grants_gov
 
 from common_grants_sdk.client.config import Config
 from common_grants_sdk.extensions import classify_filters, f
@@ -54,8 +54,9 @@ def main() -> None:
 
     # A consumer's flat filter dict: one default core filter + four grants.gov
     # customs. Each f.* builder returns the precise value model the registered
-    # filter expects.
-    filters = {
+    # filter expects; the OppSearchFilters annotation is what makes
+    # search(filters=...) typecheck against the plugin's registered filters.
+    filters: OppSearchFilters = {
         "status": f.in_(["open", "forecasted"]),
         "agency": f.in_(["HHS", "USDA"]),
         "applicantType": f.in_(["government_state", "government_county"]),

--- a/lib/python-sdk/examples/grants_gov_custom_filters.py
+++ b/lib/python-sdk/examples/grants_gov_custom_filters.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Custom-filter search against Simpler.Grants.gov, via the cg-grants-gov plugin.
+
+The downstream flow an adopter writes:
+
+  1. Import the plugin (``cg_grants_gov.grants_gov``). It already registers the
+     grants.gov search custom filters — agency, applicantType, fundingInstrument,
+     costSharing — so the consumer doesn't declare them.
+  2. Build a flat filter dict with the ``f.*`` builders: a default core filter
+     (``status``) plus the four registered customs.
+  3. ``plugin.get_client(config)`` returns a client with the plugin's routes and
+     schemas bound, so ``opportunities.search(filters=...)`` is typed by the
+     registered filters and rows parse as grants.gov opportunities.
+
+The client classifies the flat dict into the three-bucket request body — the
+default filter stays a top-level field, the four customs go under
+``customFilters`` — and POSTs it. How a deployment applies custom filters is its
+own concern; this example shows the body the SDK builds and the typed results.
+
+Run against a CommonGrants endpoint on http://localhost:8080:
+
+    poetry run python examples/grants_gov_custom_filters.py [searchTerm]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+from cg_grants_gov import grants_gov
+
+from common_grants_sdk.client.config import Config
+from common_grants_sdk.extensions import classify_filters, f
+
+# =============================================================================
+# Config
+# =============================================================================
+
+search_term = sys.argv[1] if len(sys.argv) > 1 else "education"
+api_key = "two_org_user_key"
+base_url = "http://localhost:8080"
+config = Config(base_url=base_url, api_key=api_key, timeout=5.0)
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+def main() -> None:
+    print("=== Grants.gov Custom-Filter Search ===")
+    print(f"Search term: {search_term!r}")
+    print(f"Base URL:    {base_url}\n")
+
+    # A consumer's flat filter dict: one default core filter + four grants.gov
+    # customs. Each f.* builder returns the precise value model the registered
+    # filter expects.
+    filters = {
+        "status": f.in_(["open", "forecasted"]),
+        "agency": f.in_(["HHS", "USDA"]),
+        "applicantType": f.in_(["state_governments", "county_governments"]),
+        "fundingInstrument": f.in_(["grant", "cooperative_agreement"]),
+        "costSharing": f.eq(False),
+    }
+
+    # The request body the client will POST. Shown here (via classify_filters,
+    # which get_client runs internally) so the customFilters split is visible
+    # without a live endpoint: status stays top-level, the four customs land in
+    # customFilters.
+    classified = classify_filters(grants_gov.routes, "opportunities", "search", filters)
+    body = classified.result.model_dump(by_alias=True, exclude_none=True, mode="json")
+    print("Request body (default fields + customFilters):")
+    print(json.dumps(body, indent=2), "\n")
+    if classified.errors:
+        print(f"  FAIL  filter validation: {classified.errors}", file=sys.stderr)
+        sys.exit(1)
+
+    # get_client binds the plugin's routes + schemas: search(filters=...) is typed
+    # by the registered filters and rows parse as grants.gov opportunities.
+    client = grants_gov.get_client(config)
+    response = client.opportunities.search(search=search_term, filters=filters)
+
+    print(f"{len(response.items)} opportunit(y/ies) matched:")
+    for opp in response.items:
+        print(f"  - {opp.title} [{opp.status.value}] ({opp.id})")
+    if response.errors:
+        print(f"\n{len(response.errors)} row(s) failed to parse:")
+        for err in response.errors:
+            print(f"  - {err}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ts-sdk/examples/grants-gov-custom-filters.ts
+++ b/lib/ts-sdk/examples/grants-gov-custom-filters.ts
@@ -34,7 +34,7 @@ const baseUrl = "http://localhost:8080";
 const filters = {
   status: F.in(["open", "forecasted"]),
   agency: F.in(["HHS", "USDA"]),
-  applicantType: F.in(["state_governments", "county_governments"]),
+  applicantType: F.in(["government_state", "government_county"]),
   fundingInstrument: F.in(["grant", "cooperative_agreement"]),
   costSharing: F.eq(false),
 };

--- a/lib/ts-sdk/examples/grants-gov-custom-filters.ts
+++ b/lib/ts-sdk/examples/grants-gov-custom-filters.ts
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
   // getClient binds the plugin's routes + schemas: search({ filters }) is typed
   // by the registered filters and rows parse as grants.gov opportunities.
   const client = plugin.getClient({ baseUrl, auth: Auth.apiKey("two_org_user_key") });
-  const result = await client.opportunities.search({ search: searchTerm, filters });
+  const result = await client.opportunities.search({ query: searchTerm, filters });
 
   console.log(`${result.items.length} opportunit(y/ies) matched:`);
   for (const opp of result.items) {

--- a/lib/ts-sdk/examples/grants-gov-custom-filters.ts
+++ b/lib/ts-sdk/examples/grants-gov-custom-filters.ts
@@ -1,0 +1,67 @@
+/**
+ * Custom-filter search against Simpler.Grants.gov, via the cg-grants-gov plugin.
+ *
+ * The downstream flow an adopter writes:
+ *
+ *   1. Import the plugin (`@common-grants/cg-grants-gov`). It already registers
+ *      the grants.gov search custom filters — agency, applicantType,
+ *      fundingInstrument, costSharing — so the consumer doesn't declare them.
+ *   2. Build a flat filter dict with the `F.*` builders: a default core filter
+ *      (`status`) plus the four registered customs.
+ *   3. `plugin.getClient(config)` returns a client with the plugin's routes and
+ *      schemas bound, so `opportunities.search({ filters })` is typed by the
+ *      registered filters and rows parse as grants.gov opportunities.
+ *
+ * The client classifies the flat dict into the three-bucket request body — the
+ * default filter stays a top-level field, the four customs go under
+ * `customFilters` — and POSTs it. A wrong-typed filter throws `FilterError`
+ * before any request (fail-fast).
+ *
+ * Run against a CommonGrants endpoint on http://localhost:8080:
+ *
+ *   pnpm example:grants-gov-custom-filters [searchTerm]
+ */
+
+import plugin from "@common-grants/cg-grants-gov";
+import { Auth } from "@common-grants/sdk/client";
+import { classifyFilters, F } from "@common-grants/sdk/extensions";
+
+const searchTerm = process.argv[2] ?? "education";
+const baseUrl = "http://localhost:8080";
+
+// A consumer's flat filter dict: one default core filter + four grants.gov
+// customs. Each F.* builder returns the value model the registered filter expects.
+const filters = {
+  status: F.in(["open", "forecasted"]),
+  agency: F.in(["HHS", "USDA"]),
+  applicantType: F.in(["state_governments", "county_governments"]),
+  fundingInstrument: F.in(["grant", "cooperative_agreement"]),
+  costSharing: F.eq(false),
+};
+
+async function main(): Promise<void> {
+  console.log("=== Grants.gov Custom-Filter Search ===");
+  console.log(`Search term: ${searchTerm}`);
+  console.log(`Base URL:    ${baseUrl}\n`);
+
+  // The request body the client will POST (classifyFilters runs inside search);
+  // shown here so the customFilters split is visible without a live endpoint:
+  // status stays top-level, the four customs land under customFilters.
+  const routes = plugin.routes;
+  if (!routes) throw new Error("plugin registered no custom filter routes");
+  const body = classifyFilters(routes, "opportunities", "search", filters);
+  console.log("Request body (default fields + customFilters):");
+  console.log(JSON.stringify(body, null, 2), "\n");
+
+  // getClient binds the plugin's routes + schemas: search({ filters }) is typed
+  // by the registered filters and rows parse as grants.gov opportunities.
+  const client = plugin.getClient({ baseUrl, auth: Auth.apiKey("two_org_user_key") });
+  const result = await client.opportunities.search({ search: searchTerm, filters });
+
+  console.log(`${result.items.length} opportunit(y/ies) matched:`);
+  for (const opp of result.items) {
+    console.log(`  - ${opp.title} [${opp.status.value}] (${opp.id})`);
+  }
+}
+
+void main();

--- a/lib/ts-sdk/package.json
+++ b/lib/ts-sdk/package.json
@@ -84,7 +84,8 @@
     "example:server": "tsx examples/mock-api-server.ts",
     "example:transforms": "tsx examples/transforms.ts",
     "example:custom-filters": "tsx examples/custom-filters.ts",
-    "example:grants-gov": "tsx examples/grants-gov-transforms.ts"
+    "example:grants-gov": "tsx examples/grants-gov-transforms.ts",
+    "example:grants-gov-custom-filters": "tsx examples/grants-gov-custom-filters.ts"
   },
   "dependencies": {
     "zod": "catalog:"


### PR DESCRIPTION
### Summary

- Adds end-to-end "custom filters from Simpler.Grants.gov" search examples for both SDKs, consuming the plugin's registered filter routes — the filters counterpart to the shipped transforms examples.
- Closes #902, closes #904.
- Time to review: 5 minutes

### Changes proposed

- `lib/python-sdk/examples/grants_gov_custom_filters.py` — imports the `grants.gov` plugin, classifies a filter set through its registered routes into the three-bucket wire body, and runs a search via the SDK client.
- `lib/ts-sdk/examples/grants-gov-custom-filters.ts` — the TypeScript counterpart, plus an `example:grants-gov-custom-filters` pnpm script.

### Context for reviewers

Mirrors the existing `grants_gov_transforms.py` / `grants-gov-transforms.ts` examples (#900) one-for-one — same structure, same "consume the real plugin" shape. The Python example uses the SDK's fail-fast `classify_filters` (returns the classified body directly, raises `FilterError` on a bad value).

Targets `HOLD-filters` because the examples need the SDK's filters API, which rides #918 to main.

Verified locally against the `HOLD-filters` SDK build and the plugin's registered filter routes (#901 / #903).

**Release ordering:** the examples import the published plugin, so the `cg-grants-gov` / `@common-grants/cg-grants-gov` pins bump to the plugin's filters release at merge time. CI stays red until the plugin publishes; verified locally in the meantime.

### Additional information

Filter set exercised: `agency`, `applicantType`, `fundingInstrument`, `costSharing` — matching the plugin registration and the Simpler.Grants.gov deployment's honored customFilters.

