### PR TITLE
feat(sdk): describe plugin capabilities

### DIFF
--- a/.changeset/calm-plums-describe.md
+++ b/.changeset/calm-plums-describe.md
@@ -1,0 +1,5 @@
+---
+"@common-grants/sdk": minor
+---
+
+Add a stable, JSON-safe descriptor for inspecting plugin metadata, custom fields, transforms, and route filters at runtime.

--- a/lib/ts-sdk/__tests__/extensions/describe-plugin.spec.ts
+++ b/lib/ts-sdk/__tests__/extensions/describe-plugin.spec.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { CustomFieldType } from "@/constants";
+import {
+  definePlugin,
+  describePlugin,
+  PLUGIN_DESCRIPTOR_VERSION,
+  type TransformResult,
+} from "@/extensions";
+
+describe("describePlugin", () => {
+  it("describes structural plugin capabilities as JSON-safe data", () => {
+    const sourceSchema = z.object({ legacy_id: z.string() });
+    const toCommon = (): TransformResult<unknown> => ({ result: {}, errors: [] });
+    const fromCommon = (): TransformResult<unknown> => ({
+      result: { legacy_id: "123" },
+      errors: [],
+    });
+    const plugin = definePlugin({
+      meta: {
+        name: "California grants",
+        version: "0.1.0",
+        sourceSystem: "California Grants Portal",
+        capabilities: ["customFields", "customFilters", "transforms"],
+      },
+      schemas: {
+        Opportunity: {
+          sourceSchema,
+          customFields: {
+            legacyId: {
+              name: "Legacy identifier",
+              fieldType: CustomFieldType.string,
+              description: "California source identifier",
+            },
+          },
+          toCommon,
+          fromCommon,
+        },
+      },
+      routes: {
+        opportunities: {
+          search: {
+            filters: {
+              agency: {
+                filterType: "stringArray",
+                description: "California agency",
+              },
+            },
+          },
+        },
+      },
+    } as const);
+
+    const descriptor = describePlugin(plugin);
+
+    expect(descriptor).toEqual({
+      descriptorVersion: PLUGIN_DESCRIPTOR_VERSION,
+      plugin: {
+        name: "California grants",
+        version: "0.1.0",
+        sourceSystem: "California Grants Portal",
+      },
+      capabilities: {
+        declared: ["customFields", "customFilters", "transforms"],
+        observed: ["customFields", "customFilters", "transforms"],
+        status: "match",
+        declaredButNotObserved: [],
+        observedButNotDeclared: [],
+      },
+      schemas: [
+        {
+          name: "Opportunity",
+          customFields: [
+            {
+              key: "legacyId",
+              name: "Legacy identifier",
+              fieldType: "string",
+              description: "California source identifier",
+            },
+          ],
+          sourceSchema: true,
+          transforms: {
+            mode: "callable",
+            toCommon: true,
+            fromCommon: true,
+          },
+        },
+      ],
+      routes: [
+        {
+          resource: "opportunities",
+          method: "search",
+          filters: [
+            {
+              name: "agency",
+              filterType: "stringArray",
+              description: "California agency",
+            },
+          ],
+        },
+      ],
+    });
+    expect(JSON.parse(JSON.stringify(descriptor))).toEqual(descriptor);
+  });
+
+  it("reports observed capabilities that were not declared", () => {
+    const plugin = definePlugin({
+      schemas: {
+        Opportunity: {
+          customFields: {
+            legacyId: { fieldType: CustomFieldType.string },
+          },
+        },
+      },
+    } as const);
+
+    expect(describePlugin(plugin).capabilities).toEqual({
+      declared: [],
+      observed: ["customFields"],
+      status: "undeclared",
+      declaredButNotObserved: [],
+      observedButNotDeclared: ["customFields"],
+    });
+  });
+
+  it("reports capabilities that were declared but not observed", () => {
+    const plugin = definePlugin({
+      meta: {
+        name: "empty-plugin",
+        sourceSystem: "empty-source",
+        capabilities: ["customFields", "customFilters", "transforms"],
+      },
+    } as const);
+
+    expect(describePlugin(plugin).capabilities).toEqual({
+      declared: ["customFields", "customFilters", "transforms"],
+      observed: [],
+      status: "mismatch",
+      declaredButNotObserved: ["customFields", "customFilters", "transforms"],
+      observedButNotDeclared: [],
+    });
+  });
+
+  it("returns a stable empty descriptor for a plugin with no declarations", () => {
+    const descriptor = describePlugin(definePlugin({} as const));
+
+    expect(descriptor).toEqual({
+      descriptorVersion: PLUGIN_DESCRIPTOR_VERSION,
+      plugin: {
+        name: null,
+        version: null,
+        sourceSystem: null,
+      },
+      capabilities: {
+        declared: [],
+        observed: [],
+        status: "undeclared",
+        declaredButNotObserved: [],
+        observedButNotDeclared: [],
+      },
+      schemas: [
+        {
+          name: "Opportunity",
+          customFields: [],
+          sourceSchema: false,
+          transforms: {
+            mode: "none",
+            toCommon: false,
+            fromCommon: false,
+          },
+        },
+      ],
+      routes: [],
+    });
+  });
+
+  it("sorts schema fields and route declarations by their stable keys", () => {
+    const plugin = definePlugin({
+      schemas: {
+        Opportunity: {
+          customFields: {
+            zeta: { fieldType: CustomFieldType.string },
+            alpha: { fieldType: CustomFieldType.number },
+          },
+        },
+      },
+      routes: {
+        opportunities: {
+          search: {
+            filters: {
+              zeta: { filterType: "stringArray" },
+              alpha: { filterType: "numberComparison" },
+            },
+          },
+        },
+      },
+    } as const);
+
+    const descriptor = describePlugin(plugin);
+
+    expect(descriptor.schemas[0].customFields.map(field => field.key)).toEqual(["alpha", "zeta"]);
+    expect(descriptor.routes[0].filters.map(filter => filter.name)).toEqual(["alpha", "zeta"]);
+  });
+
+  it("distinguishes declarative transforms from callable transforms", () => {
+    const plugin = definePlugin({
+      schemas: {
+        Opportunity: {
+          sourceSchema: z.object({}),
+          mappings: {
+            toCommon: {},
+            fromCommon: {},
+          },
+        },
+      },
+    } as const);
+
+    expect(describePlugin(plugin).schemas[0].transforms).toEqual({
+      mode: "declarative",
+      toCommon: true,
+      fromCommon: true,
+    });
+  });
+});

--- a/lib/ts-sdk/src/extensions/describe-plugin.ts
+++ b/lib/ts-sdk/src/extensions/describe-plugin.ts
@@ -1,0 +1,170 @@
+/**
+ * JSON-safe introspection for compiled CommonGrants plugins.
+ *
+ * @module @common-grants/sdk/extensions
+ */
+
+import type { Plugin, PluginSchemasInput } from "./define-plugin";
+import type { PluginCapability, PluginRoutes } from "./types";
+
+/** Version of the serializable plugin descriptor contract. */
+export const PLUGIN_DESCRIPTOR_VERSION = 1 as const;
+
+export interface PluginDescriptorV1 {
+  descriptorVersion: typeof PLUGIN_DESCRIPTOR_VERSION;
+  plugin: {
+    name: string | null;
+    version: string | null;
+    sourceSystem: string | null;
+  };
+  capabilities: {
+    declared: PluginCapability[];
+    observed: PluginCapability[];
+    status: "match" | "mismatch" | "undeclared";
+    declaredButNotObserved: PluginCapability[];
+    observedButNotDeclared: PluginCapability[];
+  };
+  schemas: PluginSchemaDescriptor[];
+  routes: PluginRouteDescriptor[];
+}
+
+export interface PluginSchemaDescriptor {
+  name: string;
+  customFields: Array<{
+    key: string;
+    name: string | null;
+    fieldType: string;
+    description: string | null;
+  }>;
+  sourceSchema: boolean;
+  transforms: {
+    mode: "declarative" | "callable" | "none";
+    toCommon: boolean;
+    fromCommon: boolean;
+  };
+}
+
+export interface PluginRouteDescriptor {
+  resource: string;
+  method: string;
+  filters: Array<{
+    name: string;
+    filterType: string;
+    description: string | null;
+  }>;
+}
+
+const CAPABILITY_ORDER: PluginCapability[] = ["customFields", "customFilters", "transforms"];
+
+/**
+ * Returns a stable, JSON-safe description of a compiled CommonGrants plugin.
+ *
+ * The descriptor reports structural facts retained by `definePlugin()`. It does
+ * not serialize schemas or functions, execute transforms, or infer semantic
+ * behavior such as mapping correctness or information loss.
+ */
+export function describePlugin<T extends PluginSchemasInput, TRoutes extends PluginRoutes>(
+  plugin: Plugin<T, TRoutes>
+): PluginDescriptorV1 {
+  const schemas = Object.entries(plugin.schemas)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, rawSchema]) => {
+      const schema = rawSchema as {
+        sourceSchema?: unknown;
+        customFields?: Record<
+          string,
+          { name?: unknown; fieldType?: unknown; description?: unknown }
+        >;
+        mappings?: unknown;
+        toCommon?: unknown;
+        fromCommon?: unknown;
+      };
+      const hasToCommon = typeof schema.toCommon === "function";
+      const hasFromCommon = typeof schema.fromCommon === "function";
+
+      return {
+        name,
+        customFields: Object.entries(schema.customFields ?? {})
+          .sort(([left], [right]) => left.localeCompare(right))
+          .map(([key, spec]) => ({
+            key,
+            name: typeof spec.name === "string" ? spec.name : null,
+            fieldType: typeof spec.fieldType === "string" ? spec.fieldType : "unknown",
+            description: typeof spec.description === "string" ? spec.description : null,
+          })),
+        sourceSchema: schema.sourceSchema !== undefined,
+        transforms: {
+          mode:
+            schema.mappings !== undefined
+              ? ("declarative" as const)
+              : hasToCommon || hasFromCommon
+                ? ("callable" as const)
+                : ("none" as const),
+          toCommon: hasToCommon,
+          fromCommon: hasFromCommon,
+        },
+      };
+    });
+
+  const routes = describeRoutes(plugin.routes);
+  const declared = CAPABILITY_ORDER.filter(capability =>
+    plugin.meta?.capabilities?.includes(capability)
+  );
+  const observed = CAPABILITY_ORDER.filter(capability => {
+    if (capability === "customFields") {
+      return schemas.some(schema => schema.customFields.length > 0);
+    }
+    if (capability === "customFilters") {
+      return routes.some(route => route.filters.length > 0);
+    }
+    return schemas.some(schema => schema.transforms.toCommon || schema.transforms.fromCommon);
+  });
+  const declaredButNotObserved = declared.filter(capability => !observed.includes(capability));
+  const observedButNotDeclared = observed.filter(capability => !declared.includes(capability));
+
+  return {
+    descriptorVersion: PLUGIN_DESCRIPTOR_VERSION,
+    plugin: {
+      name: plugin.meta?.name ?? null,
+      version: plugin.meta?.version ?? null,
+      sourceSystem: plugin.meta?.sourceSystem ?? null,
+    },
+    capabilities: {
+      declared,
+      observed,
+      status:
+        declared.length === 0
+          ? "undeclared"
+          : declaredButNotObserved.length === 0 && observedButNotDeclared.length === 0
+            ? "match"
+            : "mismatch",
+      declaredButNotObserved,
+      observedButNotDeclared,
+    },
+    schemas,
+    routes,
+  };
+}
+
+function describeRoutes(routes: PluginRoutes | undefined): PluginRouteDescriptor[] {
+  if (!routes) return [];
+
+  const result: PluginRouteDescriptor[] = [];
+  for (const [resource, methods] of Object.entries(routes).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    for (const [method, declarations] of Object.entries(methods ?? {}).sort(([left], [right]) =>
+      left.localeCompare(right)
+    )) {
+      const filters = Object.entries(declarations?.filters ?? {})
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([name, spec]) => ({
+          name,
+          filterType: spec.filterType,
+          description: spec.description ?? null,
+        }));
+      result.push({ resource, method, filters });
+    }
+  }
+  return result;
+}

--- a/lib/ts-sdk/src/extensions/index.ts
+++ b/lib/ts-sdk/src/extensions/index.ts
@@ -12,6 +12,12 @@
 export type { Plugin, DefinePluginOptions, PluginSchemasInput } from "./define-plugin";
 export type { CustomFieldSpec, HasCustomFields, ExtensibleObject } from "./types";
 export { definePlugin } from "./define-plugin";
+export type {
+  PluginDescriptorV1,
+  PluginRouteDescriptor,
+  PluginSchemaDescriptor,
+} from "./describe-plugin";
+export { describePlugin, PLUGIN_DESCRIPTOR_VERSION } from "./describe-plugin";
 
 // Custom filters — route-keyed filter registration + classification
 export type {


### PR DESCRIPTION
## What changed

- add `describePlugin()` to `@common-grants/sdk/extensions`
- return a versioned, stable, JSON-safe descriptor for plugin metadata, declared and observed capabilities, custom fields, transforms, and route filters
- distinguish each custom field's stable record key from its optional display name
- add a changeset and focused coverage for serialization, mismatches, empty plugins, transform modes, and deterministic ordering

## Why

CommonGrants plugins retain useful structural metadata at runtime, but consumers currently have to inspect SDK objects or duplicate SDK knowledge to discover it. A small SDK-owned descriptor gives CLIs, MCP servers, diagnostics, and documentation generators one truthful interface that evolves with the plugin framework.

The descriptor deliberately does not execute transforms, serialize Zod schemas or functions, or claim that a downstream tool exposes every plugin capability.

## Follow-on experiment

The immediate consumer is a grant-seeker MCP prototype. It would project a smaller source manifest from this descriptor and advertise only capabilities its own tools actually make usable. That work remains separate from this SDK API.

## Validation

- `vitest run`: 28 files, 552 tests passed
- TypeScript typecheck
- ESLint
- Prettier check
- exercised against the Grants.gov plugin, including 18 custom fields and 4 custom search filters
