### PR TITLE
fix(core): resolve v0.4.0 hold branch audit findings

### DIFF
--- a/.changeset/org-identifiers.md
+++ b/.changeset/org-identifiers.md
@@ -1,0 +1,32 @@
+---
+"@common-grants/core": minor
+---
+
+Add identifier models to the core library (#957).
+
+Introduces the models that carry a record's external identifiers, following
+the pattern in ADR-0023:
+
+- `IdentifierT<Id, Code>`, a template that pins an identifier's value type and
+  its `registry.code`, plus the generic `Identifier` it instantiates and the
+  `IdentifierStatus` options (`active`, `archived`) used by `allIds`.
+- `SystemId`, the hosting system's own UUID for a record, whose registry code
+  names that system (e.g. `org:grants.gov:system`).
+- `IdentifierCollection`, which holds a record's `systemId` plus any
+  registries the protocol does not define as base identifiers, under
+  `otherIds`.
+- `OrgIds`, the organization collection, which adds the `org:us:ein`,
+  `org:us:uei`, and `org:xi:duns` base identifiers as `OrgIdEin`, `OrgIdUei`,
+  and `OrgIdDuns`. Registry codes follow `<schema>:<scope>:<prop>`.
+
+Breaking: `OrganizationBase.ein`, `uei`, and `duns` are removed in favor of
+the `identifiers` collection, so a producer that sent `ein` now sends
+`identifiers["org:us:ein"].id`.
+
+Breaking: the `employerTaxId`, `samUEI`, and `duns` scalars are tightened to
+their registry formats. `employerTaxId` and `duns` now require nine digits
+with no separators, where `employerTaxId` previously required the hyphenated
+`12-3456789` form and `duns` accepted several separator styles. `samUEI` now
+excludes the letters `I` and `O` and no longer accepts lowercase.
+
+All changes are added at protocol version 0.4.0.

--- a/.changeset/org-profile-syncing.md
+++ b/.changeset/org-profile-syncing.md
@@ -15,8 +15,9 @@ systems, following the contract in ADR-0026:
   `RevisionStatus`, and the status options (`pending`, `accepted`, `denied`,
   `superseded`, `custom`). `OrgRevision` binds it to `OrganizationBase` and
   `OrgPatchData`.
-- `Responses.Accepted<T>`, a `202` envelope with a `Location` header for changes
-  that are accepted for review.
+- `Responses.AcceptedT<T>`, a `202` envelope with a `Location` header for
+  changes that are accepted for review, plus its non-templated `Accepted`
+  schema and the `Responses.Forbidden` error alias the org routes return.
 
 Adds six experimental routes under `/common-grants/orgs`, each requiring an
 OAuth 2.0 scope: `GET /orgs` (`org:read`), `GET /orgs/{orgId}` (`org:read`),

--- a/lib/core/lib/core/routes/orgs.tsp
+++ b/lib/core/lib/core/routes/orgs.tsp
@@ -56,7 +56,7 @@ interface Organizations {
   list<T extends Models.OrganizationBase = Models.OrganizationBase>(
     ...Pagination.PaginatedQueryParams,
 
-    /** Registry code of an external identifier to filter by (e.g. `us:ein`) */
+    /** Registry code of an external identifier to filter by (e.g. `org:us:ein`) */
     @query registry?: string,
 
     /** Identifier value within the given registry to filter by */

--- a/website/public/openapi/openapi.0.4.0.yaml
+++ b/website/public/openapi/openapi.0.4.0.yaml
@@ -742,7 +742,7 @@ paths:
         - name: registry
           in: query
           required: false
-          description: Registry code of an external identifier to filter by (e.g. `us:ein`)
+          description: Registry code of an external identifier to filter by (e.g. `org:us:ein`)
           schema:
             type: string
           explode: false

--- a/website/src/content/docs/governance/adr/0026-org-profile-syncing.md
+++ b/website/src/content/docs/governance/adr/0026-org-profile-syncing.md
@@ -79,7 +79,7 @@ Here is a brief summary of the API contract this ADR proposes:
 
 Every endpoint sits under `/common-grants/orgs`, and the path-based `{orgId}` refers to the organization's system-specific UUID (`Organization.id`). A client that only knows an external identifier, like an EIN, UEI, or platform ID, can look up the UUID via a filter query param on `GET /orgs` (see [ADR-0023](/governance/adr/0023-org-ids/)). The org record follows [`OrganizationBase`](/protocol/models/organization). Server-assigned fields like `datasetVersion` appear in response bodies but are ignored in request bodies, and since field-level schemas still need to be finalized in the follow-up spec, the payloads below are just illustrative.
 
-Successful responses use the standard CommonGrants envelope: `Responses.Ok<T>` wraps a single resource as `{ status, message, data }` and `Responses.Paginated<T>` wraps a list as `{ status, message, items, pagination }`, where the envelope's `status` is the HTTP status code. The read and list examples below show only the `data`/`items` payload; the write examples show the full envelope, since a write returns a change whose own lifecycle `status` (`accepted`, `pending`, and so on) sits inside `data`.
+Successful responses use the standard CommonGrants envelope: `Responses.OkT<T>` wraps a single resource as `{ status, message, data }` and `Responses.PaginatedT<T>` wraps a list as `{ status, message, items, pagination }`, where the envelope's `status` is the HTTP status code. The read and list examples below show only the `data`/`items` payload; the write examples show the full envelope, since a write returns a change whose own lifecycle `status` (`accepted`, `pending`, and so on) sits inside `data`.
 
 **Required endpoints**
 
@@ -156,18 +156,14 @@ Response:
     "systemId": {
       "registry": {
         "code": "org:grants.gov:system",
-        "url": "/registries/org-grants-gov-system",
-        "scope": "grants.gov",
-        "kind": "platform"
+        "url": "https://commongrants.org/registries/org-grants-gov-system"
       },
       "id": "01912a8b-7c3d-7890-abcd-ef1234567890"
     },
     "org:us:ein": {
       "registry": {
         "code": "org:us:ein",
-        "url": "/registries/org-us-ein",
-        "scope": "US",
-        "kind": "government"
+        "url": "https://commongrants.org/registries/org-us-ein"
       },
       "id": "123456789"
     }

--- a/website/src/content/docs/governance/adr/0026-org-profile-syncing.md
+++ b/website/src/content/docs/governance/adr/0026-org-profile-syncing.md
@@ -104,7 +104,7 @@ Successful responses use the standard CommonGrants envelope: `Responses.Ok<T>` w
 <details>
 <summary>List orgs: `GET /orgs`</summary>
 
-Required scope: `org:read`. By default this returns every organization the caller can view, which is likely the full set for a public directory. Results are paginated per [ADR-0011](/governance/adr/0011-pagination/), and each item is an organization record, including its identifier collection. To look up an org by an external identifier, filter with `registry` and `id`, like `?registry=us:ein&id=123456789` (see [ADR-0023](/governance/adr/0023-org-ids/)).
+Required scope: `org:read`. By default this returns every organization the caller can view, which is likely the full set for a public directory. Results are paginated per [ADR-0011](/governance/adr/0011-pagination/), and each item is an organization record, including its identifier collection. To look up an org by an external identifier, filter with `registry` and `id`, like `?registry=org:us:ein&id=123456789` (see [ADR-0023](/governance/adr/0023-org-ids/)).
 
 Request:
 
@@ -123,8 +123,8 @@ Response:
       "name": "Example Nonprofit",
       "datasetVersion": 7,
       "identifiers": {
-        "us:ein": { "id": "123456789" },
-        "us:uei": { "id": "AB0123456789" }
+        "org:us:ein": { "id": "123456789" },
+        "org:us:uei": { "id": "AB0123456789" }
       }
     }
   ],
@@ -155,17 +155,17 @@ Response:
   "identifiers": {
     "systemId": {
       "registry": {
-        "code": "grants.gov:org",
-        "url": "/registries/grants-gov-org",
+        "code": "org:grants.gov:system",
+        "url": "/registries/org-grants-gov-system",
         "scope": "grants.gov",
         "kind": "platform"
       },
       "id": "01912a8b-7c3d-7890-abcd-ef1234567890"
     },
-    "us:ein": {
+    "org:us:ein": {
       "registry": {
-        "code": "us:ein",
-        "url": "/registries/us-ein",
+        "code": "org:us:ein",
+        "url": "/registries/org-us-ein",
         "scope": "US",
         "kind": "government"
       },


### PR DESCRIPTION
### Summary

Audit pass over the v0.4.0 hold branch ahead of the release, fixing three inconsistencies it turned up:

- Adds the missing changeset for the org identifier models, which the 0.4.0 release notes would otherwise have shipped without.
- Uses the fully qualified registry codes (`org:us:ein`, not `us:ein`) in the org route docs and ADR-0026 examples.
- Aligns ADR-0026 and the org-syncing changeset with the shipped 0.4.0 response names and identifier shape.

- Addresses #1032
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

**Add `.changeset/org-identifiers.md`** — the identifier work from #957 landed here without a changeset, so `@common-grants/core`'s 0.4.0 notes would have omitted `Identifier`, `SystemId`, `IdentifierCollection`, and `OrgIds`, along with both of its breaking changes: the removal of `OrganizationBase.ein`/`uei`/`duns`, and the tightened `employerTaxId`/`samUEI`/`duns` scalar formats. Minor, matching the other 0.4.0 changesets, so core still lands on 0.4.0.

**Fix registry codes** — codes follow `<schema>:<scope>:<prop>`, so the canonical forms are `org:us:ein`, `org:us:uei`, and `org:grants.gov:system`. The `registry` query param doc in `orgs.tsp` and the ADR-0026 examples still used short forms that contradicted `OrgIds` and `IdentifierT`. Catalog links are corrected alongside them, since slugs derive from the code (`org:us:ein` → `org-us-ein`) and `/registries/us-ein` and `/registries/grants-gov-org` pointed at pages that do not exist. The one-line change to `website/public/openapi/openapi.0.4.0.yaml` is the regenerated param description.

**Align ADR-0026 and the org-syncing changeset with the shipped names** — `.changeset/org-profile-syncing.md` called the 202 envelope `Responses.Accepted<T>`; the shipped names follow #1007's `T`-suffix convention (`AcceptedT<T>` plus the non-templated `Accepted`), and the org routes also return the new `Responses.Forbidden` alias. In ADR-0026, the contract summary used the pre-rename `Responses.Ok<T>`/`Responses.Paginated<T>` names, and the `GET /orgs/{orgId}` example gave `registry` objects `scope` and `kind` fields that don't exist on `IdentifierT.registry` (`code` and `url` only), with relative catalog URLs where the canonical `identifier.tsp` examples use absolute links.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Verified with `pnpm run ci` (exit 0; 40, 119, 548, and 71 tests across changelog-emitter, cli, sdk, and website).

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

The registry-code correction, against the canonical definitions in `organization.tsp`:

```
model OrgIdEin  is Fields.IdentifierT<Types.employerTaxId, "org:us:ein">;
model OrgIdUei  is Fields.IdentifierT<Types.samUEI,        "org:us:uei">;
model OrgIdDuns is Fields.IdentifierT<Types.duns,          "org:xi:duns">;
```

`pnpm changeset status` confirms the release still resolves to a single minor bump:

```
Packages to be bumped at minor:
- @common-grants/core
```


