### PR TITLE
fix(deps): force brace-expansion >=5.0.8 to resolve GHSA-mh99-v99m-4gvg

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,7 @@ catalogs:
 
 overrides:
   axios@<1.15.0: '>=1.15.0'
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
+  brace-expansion@<5.0.8: '>=5.0.8'
   defu@<=6.1.4: '>=6.1.5'
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
@@ -3098,9 +3097,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3135,9 +3131,6 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
-
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -9373,8 +9366,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -9419,10 +9410,6 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
-
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -11460,7 +11447,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,8 +35,7 @@ catalogs:
 
 overrides:
   axios@<1.15.0: '>=1.15.0'
-  brace-expansion@>=2.0.0 <2.1.2: '2.1.2'
-  brace-expansion@>=3.0.0 <5.0.7: '>=5.0.7'
+  brace-expansion@<5.0.8: '>=5.0.8'
   defu@<=6.1.4: '>=6.1.5'
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'


### PR DESCRIPTION
### Summary

- Patches [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) (high, brace-expansion <=5.0.7 DoS via unbounded expansion), published 2026-07-27. Every `audit-deps.js` step in the repo currently fails on it, so this unblocks CI repo-wide.
- Time to review: 5 minutes

### Changes proposed

Collapse the two existing `brace-expansion` overrides in `pnpm-workspace.yaml` into a single floor:

```yaml
brace-expansion@<5.0.8: '>=5.0.8'
```

The previous pair pinned the 2.x chain at `2.1.2` and floated 3.x+ to `>=5.0.7` — both now inside the advisory range. The single floor moves every copy in the tree to the patched `5.0.8`.

### Context for reviewers

The advisory covers all of `<=5.0.7` and `5.0.8` is the only patched release, so the 2.x copy pulled by the eslint → minimatch chain has to cross the major boundary. `5.0.8` is not API-compatible with 2.x on paper — it exports `{ expand }` where 2.x is `module.exports = expand` — so the override was worth verifying rather than assuming:

- `pnpm-lock.yaml` now resolves `brace-expansion` to `5.0.8` only; no 2.x copy remains.
- `node .github/scripts/audit-deps.js` reports no advisories on this branch (fails on main).
- Full `pnpm run ci` gate passes — core, changelog-emitter, cli, sdk, website. Lint is the step that exercises the minimatch chain, and it passes in every package.

Verified the same override independently on the two open catalog PRs (#932, #933), where the full gate also passes.

### Additional information

Once this merges, #932 and #933 pick it up via a main merge — both currently fail their audit steps on this advisory alone.
