### PR TITLE
docs(website): add custom filters section to the per-plugin details page

### DIFF
--- a/website/__tests__/lib/plugins/filter-docs.spec.ts
+++ b/website/__tests__/lib/plugins/filter-docs.spec.ts
@@ -5,12 +5,6 @@ import { filterDocsHref, isCustomFilterType } from "@/lib/plugins/filter-docs";
 import { Paths } from "@/lib/schema/paths";
 import type { CustomFilterType } from "@/lib/plugins/types";
 
-/**
- * Pages that exist under src/content/docs/protocol/filters/. A filter type may
- * only link to one of these, or to the index.
- */
-const FILTER_DOC_PAGES = ["string", "numeric", "date", "money"];
-
 const ALL_FILTER_TYPES: CustomFilterType[] = [
   "stringComparison",
   "stringArray",
@@ -29,17 +23,6 @@ describe("filterDocsHref", () => {
   // emitted. Catches "completing" the map by pattern with a made-up anchor.
   it("sends booleanComparison to the filters index, not an anchor", () => {
     expect(filterDocsHref("booleanComparison")).toBe("/protocol/filters/");
-  });
-
-  // Catches a typo'd page segment (e.g. /filters/numbers#...), which no type
-  // check sees because every href is just a string.
-  it("only links to filter docs pages that exist", () => {
-    for (const filterType of ALL_FILTER_TYPES) {
-      const href = filterDocsHref(filterType);
-      if (href === "/protocol/filters/") continue;
-      const page = href.replace("/protocol/filters/", "").split("#")[0];
-      expect(FILTER_DOC_PAGES).toContain(page);
-    }
   });
 
   // starlight-links-validator parses markdown, so it never sees links emitted

--- a/website/__tests__/lib/plugins/filter-docs.spec.ts
+++ b/website/__tests__/lib/plugins/filter-docs.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { filterDocsHref, isCustomFilterType } from "@/lib/plugins/filter-docs";
+import type { CustomFilterType } from "@/lib/plugins/types";
+
+/**
+ * Pages that exist under src/content/docs/protocol/filters/. A filter type may
+ * only link to one of these, or to the index.
+ */
+const FILTER_DOC_PAGES = ["string", "numeric", "date", "money"];
+
+const ALL_FILTER_TYPES: CustomFilterType[] = [
+  "stringComparison",
+  "stringArray",
+  "numberComparison",
+  "numberArray",
+  "numberRange",
+  "booleanComparison",
+  "dateComparison",
+  "dateRange",
+  "moneyComparison",
+  "moneyRange",
+];
+
+describe("filterDocsHref", () => {
+  // The protocol has no boolean filter model, so no boolean anchor is ever
+  // emitted. Catches "completing" the map by pattern with a made-up anchor.
+  it("sends booleanComparison to the filters index, not an anchor", () => {
+    expect(filterDocsHref("booleanComparison")).toBe("/protocol/filters/");
+  });
+
+  // Catches a typo'd page segment (e.g. /filters/numbers#...), which no type
+  // check sees because every href is just a string.
+  it("only links to filter docs pages that exist", () => {
+    for (const filterType of ALL_FILTER_TYPES) {
+      const href = filterDocsHref(filterType);
+      if (href === "/protocol/filters/") continue;
+      const page = href.replace("/protocol/filters/", "").split("#")[0];
+      expect(FILTER_DOC_PAGES).toContain(page);
+    }
+  });
+});
+
+describe("isCustomFilterType", () => {
+  // The guard is what stops a bad index.json edit from reaching the page, so a
+  // regression here renders filters the SDK would reject.
+  it("accepts every known filter type", () => {
+    for (const filterType of ALL_FILTER_TYPES) {
+      expect(isCustomFilterType(filterType)).toBe(true);
+    }
+  });
+
+  it("rejects terse and misspelled filter types", () => {
+    expect(isCustomFilterType("string")).toBe(false);
+    expect(isCustomFilterType("boolean")).toBe(false);
+    expect(isCustomFilterType("stringArrays")).toBe(false);
+    expect(isCustomFilterType("")).toBe(false);
+  });
+});

--- a/website/__tests__/lib/plugins/filter-docs.spec.ts
+++ b/website/__tests__/lib/plugins/filter-docs.spec.ts
@@ -3,20 +3,7 @@ import path from "path";
 import { describe, it, expect } from "vitest";
 import { filterDocsHref, isCustomFilterType } from "@/lib/plugins/filter-docs";
 import { Paths } from "@/lib/schema/paths";
-import type { CustomFilterType } from "@/lib/plugins/types";
-
-const ALL_FILTER_TYPES: CustomFilterType[] = [
-  "stringComparison",
-  "stringArray",
-  "numberComparison",
-  "numberArray",
-  "numberRange",
-  "booleanComparison",
-  "dateComparison",
-  "dateRange",
-  "moneyComparison",
-  "moneyRange",
-];
+import { CUSTOM_FILTER_TYPES } from "@/lib/plugins/types";
 
 describe("filterDocsHref", () => {
   // The protocol has no boolean filter model, so no boolean anchor is ever
@@ -30,7 +17,7 @@ describe("filterDocsHref", () => {
   // dead anchor and watching it report all links valid. Nothing else catches a
   // renamed heading silently breaking every filter card's deep link.
   it("anchors a heading that exists on the page it links to", () => {
-    for (const filterType of ALL_FILTER_TYPES) {
+    for (const filterType of CUSTOM_FILTER_TYPES) {
       const href = filterDocsHref(filterType);
       const [page, anchor] = href.replace("/protocol/filters/", "").split("#");
       if (!anchor) continue;
@@ -52,7 +39,7 @@ describe("isCustomFilterType", () => {
   // The guard is what stops a bad index.json edit from reaching the page, so a
   // regression here renders filters the SDK would reject.
   it("accepts every known filter type", () => {
-    for (const filterType of ALL_FILTER_TYPES) {
+    for (const filterType of CUSTOM_FILTER_TYPES) {
       expect(isCustomFilterType(filterType)).toBe(true);
     }
   });

--- a/website/__tests__/lib/plugins/filter-docs.spec.ts
+++ b/website/__tests__/lib/plugins/filter-docs.spec.ts
@@ -1,5 +1,8 @@
+import fs from "fs";
+import path from "path";
 import { describe, it, expect } from "vitest";
 import { filterDocsHref, isCustomFilterType } from "@/lib/plugins/filter-docs";
+import { Paths } from "@/lib/schema/paths";
 import type { CustomFilterType } from "@/lib/plugins/types";
 
 /**
@@ -38,6 +41,28 @@ describe("filterDocsHref", () => {
       expect(FILTER_DOC_PAGES).toContain(page);
     }
   });
+
+  // starlight-links-validator parses markdown, so it never sees links emitted
+  // from the .astro plugin pages — confirmed by building with a deliberately
+  // dead anchor and watching it report all links valid. Nothing else catches a
+  // renamed heading silently breaking every filter card's deep link.
+  it("anchors a heading that exists on the page it links to", () => {
+    for (const filterType of ALL_FILTER_TYPES) {
+      const href = filterDocsHref(filterType);
+      const [page, anchor] = href.replace("/protocol/filters/", "").split("#");
+      if (!anchor) continue;
+      const mdx = fs.readFileSync(
+        path.join(Paths.PROTOCOL_DOCS_DIR, "filters", `${page}.mdx`),
+        "utf-8",
+      );
+      // Every filter model heading is one word, so its id is just the heading
+      // lowercased. Splitting one into words breaks the anchor and fails here.
+      const ids = [...mdx.matchAll(/^#{2,}\s+(\S+)\s*$/gm)].map((m) =>
+        m[1].toLowerCase(),
+      );
+      expect(ids, `${filterType} -> ${href}`).toContain(anchor);
+    }
+  });
 });
 
 describe("isCustomFilterType", () => {
@@ -54,5 +79,12 @@ describe("isCustomFilterType", () => {
     expect(isCustomFilterType("boolean")).toBe(false);
     expect(isCustomFilterType("stringArrays")).toBe(false);
     expect(isCustomFilterType("")).toBe(false);
+  });
+
+  // An `in` check would accept these off the prototype chain, and
+  // filterDocsHref would hand back a function to render as an href.
+  it("rejects inherited Object properties", () => {
+    expect(isCustomFilterType("constructor")).toBe(false);
+    expect(isCustomFilterType("toString")).toBe(false);
   });
 });

--- a/website/__tests__/lib/plugins/loader.spec.ts
+++ b/website/__tests__/lib/plugins/loader.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { loadAllPlugins } from "@/lib/plugins";
+
+/**
+ * End-to-end loader tests against the generated metadata cache at
+ * website/cache/plugin-metadata.json, which the plugin-metadata step produces.
+ * CI runs `pnpm build` (which runs generate first) before `pnpm test`;
+ * locally, run `pnpm generate:plugin-metadata` once.
+ */
+
+describe("plugins loader", () => {
+  // =============================================================================
+  // resolvedFilters
+  // =============================================================================
+
+  describe("resolvedFilters", () => {
+    // The nested declarations lose their resource and method on the way to a
+    // flat card list, so this is what catches them being dropped or swapped.
+    it("keeps the route a filter was declared under", () => {
+      const plugin = loadAllPlugins().find((p) => p.id === "ts-cg-grants-gov");
+      const agency = plugin?.resolvedFilters.find((f) => f.name === "agency");
+
+      expect(agency).toMatchObject({
+        filterType: "stringArray",
+        resource: "opportunities",
+        method: "search",
+        docsHref: "/protocol/filters/string#stringarrayfilter",
+      });
+      // Authored per filter in index.json; "" means the wiring dropped it.
+      expect(agency?.description).not.toBe("");
+    });
+
+    // The one filter type with no protocol model of its own, so it is the one
+    // whose href comes from the fallback rather than the anchor map.
+    it("sends a booleanComparison filter to the filters index", () => {
+      const plugin = loadAllPlugins().find((p) => p.id === "cg-grants-gov");
+      const costSharing = plugin?.resolvedFilters.find(
+        (f) => f.name === "costSharing",
+      );
+
+      expect(costSharing?.filterType).toBe("booleanComparison");
+      expect(costSharing?.docsHref).toBe("/protocol/filters/");
+    });
+  });
+});

--- a/website/src/components/plugins/CustomFilterCard.astro
+++ b/website/src/components/plugins/CustomFilterCard.astro
@@ -1,0 +1,79 @@
+---
+import type { ResolvedPluginFilter } from "@/lib/plugins";
+import CatalogCard from "@/components/catalog/CatalogCard.astro";
+
+interface Props {
+  filter: ResolvedPluginFilter;
+}
+
+const { filter } = Astro.props;
+---
+
+<!-- dataAttributes drive filtering on catalog index pages; there is no filters index -->
+<CatalogCard
+  href={filter.docsHref}
+  title={filter.name}
+  description={filter.description}
+  dataAttributes={{}}
+>
+  <div class="card-type">
+    <span class="type-badge">{filter.filterType}</span>
+  </div>
+
+  <div class="card-routes">
+    <span class="sr-only">Available on</span>
+    <div class="route-pill-list">
+      <span class="route-pill">{filter.resource}.{filter.method}</span>
+    </div>
+  </div>
+</CatalogCard>
+
+<style>
+  .card-type {
+    margin-bottom: 0.5rem;
+  }
+
+  .type-badge {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    background: var(--sl-color-accent-low);
+    color: var(--sl-color-accent-high);
+    border-radius: 0.375rem;
+    font-family: monospace;
+    font-size: 0.875rem;
+    line-height: 1;
+    width: fit-content;
+  }
+
+  .card-routes {
+    margin-bottom: 0.75rem;
+  }
+
+  .route-pill-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+  }
+
+  .route-pill {
+    padding: 0.375rem 0.75rem;
+    background: var(--sl-color-blue-low);
+    color: var(--sl-color-blue-high);
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    font-family: monospace;
+    font-weight: 500;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/website/src/components/plugins/PluginDetails.astro
+++ b/website/src/components/plugins/PluginDetails.astro
@@ -3,6 +3,7 @@ import type { Plugin } from "@/lib/plugins";
 import { LinkButton, CardGrid } from "@astrojs/starlight/components";
 import { loadAllCustomFields } from "@/lib/custom-fields";
 import CustomFieldCard from "@/components/custom-fields/CustomFieldCard.astro";
+import CustomFilterCard from "@/components/plugins/CustomFilterCard.astro";
 
 interface Props {
   plugin: Plugin;
@@ -69,6 +70,24 @@ const pluginFields = plugin.resolvedFields
       {pluginFields.map((field) => <CustomFieldCard field={field} />)}
     </CardGrid>
   </section>
+
+  <!-- Custom Filters Section -->
+  {
+    plugin.resolvedFilters.length > 0 && (
+      <section class="section">
+        <h2>Custom Filters</h2>
+        <p class="section-description">
+          This plugin accepts {plugin.resolvedFilters.length} custom filters
+          beyond the CommonGrants base filters:
+        </p>
+        <CardGrid>
+          {plugin.resolvedFilters.map((filter) => (
+            <CustomFilterCard filter={filter} />
+          ))}
+        </CardGrid>
+      </section>
+    )
+  }
 
   <!-- Actions -->
   <div class="actions">

--- a/website/src/content/plugins/index.json
+++ b/website/src/content/plugins/index.json
@@ -18,6 +18,28 @@
         "fiscalYear",
         "costSharing"
       ]
+    },
+    "filters": {
+      "opportunities": {
+        "search": {
+          "agency": {
+            "filterType": "stringArray",
+            "description": "Filter by funding agency."
+          },
+          "applicantType": {
+            "filterType": "stringArray",
+            "description": "Filter by eligible applicant type."
+          },
+          "fundingInstrument": {
+            "filterType": "stringArray",
+            "description": "Filter by funding instrument."
+          },
+          "costSharing": {
+            "filterType": "booleanComparison",
+            "description": "Filter by whether cost sharing is required."
+          }
+        }
+      }
     }
   },
   "cg-grants-gov": {
@@ -40,6 +62,28 @@
         "fiscalYear",
         "costSharing"
       ]
+    },
+    "filters": {
+      "opportunities": {
+        "search": {
+          "agency": {
+            "filterType": "stringArray",
+            "description": "Filter by funding agency."
+          },
+          "applicantType": {
+            "filterType": "stringArray",
+            "description": "Filter by eligible applicant type."
+          },
+          "fundingInstrument": {
+            "filterType": "stringArray",
+            "description": "Filter by funding instrument."
+          },
+          "costSharing": {
+            "filterType": "booleanComparison",
+            "description": "Filter by whether cost sharing is required."
+          }
+        }
+      }
     }
   }
 }

--- a/website/src/lib/plugins/filter-docs.ts
+++ b/website/src/lib/plugins/filter-docs.ts
@@ -1,0 +1,36 @@
+import type { CustomFilterType } from "./types";
+
+/** Filter docs index, used when a filter type has no model of its own. */
+const FILTERS_OVERVIEW = "/protocol/filters/";
+
+/**
+ * Maps each filter type to the protocol model that defines it.
+ *
+ * `booleanComparison` points at the overview because the protocol has no
+ * boolean filter model: custom filter values are typed `unknown`
+ * (Filters.DefaultFilter) and no base field is boolean, so the type exists only
+ * in the SDKs. None of the filter docs pages emit a boolean anchor, so there is
+ * nothing more specific to link to — don't invent one.
+ */
+const DOCS_HREF: Record<CustomFilterType, string> = {
+  stringComparison: "/protocol/filters/string#stringcomparisonfilter",
+  stringArray: "/protocol/filters/string#stringarrayfilter",
+  numberComparison: "/protocol/filters/numeric#numbercomparisonfilter",
+  numberArray: "/protocol/filters/numeric#numberarrayfilter",
+  numberRange: "/protocol/filters/numeric#numberrangefilter",
+  booleanComparison: FILTERS_OVERVIEW,
+  dateComparison: "/protocol/filters/date#datecomparisonfilter",
+  dateRange: "/protocol/filters/date#daterangefilter",
+  moneyComparison: "/protocol/filters/money#moneycomparisonfilter",
+  moneyRange: "/protocol/filters/money#moneyrangefilter",
+};
+
+/** Narrows a filterType read from index.json, which is untyped JSON. */
+export function isCustomFilterType(value: string): value is CustomFilterType {
+  return value in DOCS_HREF;
+}
+
+/** Returns the docs link for a filter type. */
+export function filterDocsHref(filterType: CustomFilterType): string {
+  return DOCS_HREF[filterType];
+}

--- a/website/src/lib/plugins/filter-docs.ts
+++ b/website/src/lib/plugins/filter-docs.ts
@@ -25,9 +25,15 @@ const DOCS_HREF: Record<CustomFilterType, string> = {
   moneyRange: "/protocol/filters/money#moneyrangefilter",
 };
 
-/** Narrows a filterType read from index.json, which is untyped JSON. */
+/**
+ * Narrows a filterType read from index.json, which is untyped JSON.
+ *
+ * Own-property check, not `in`: `in` walks the prototype chain, so a typo'd
+ * "constructor" or "toString" would pass and filterDocsHref would return a
+ * function as the href.
+ */
 export function isCustomFilterType(value: string): value is CustomFilterType {
-  return value in DOCS_HREF;
+  return Object.hasOwn(DOCS_HREF, value);
 }
 
 /** Returns the docs link for a filter type. */

--- a/website/src/lib/plugins/index.ts
+++ b/website/src/lib/plugins/index.ts
@@ -1,5 +1,9 @@
 // Types
-export type { ResolvedPluginField, Plugin } from "./types";
+export type {
+  ResolvedPluginField,
+  ResolvedPluginFilter,
+  Plugin,
+} from "./types";
 
 // Loader functions
 export { loadAllPlugins, getPluginIds, getFilterOptions } from "./loader";

--- a/website/src/lib/plugins/loader.ts
+++ b/website/src/lib/plugins/loader.ts
@@ -2,7 +2,14 @@ import { readFileSync } from "fs";
 import pluginsIndex from "@/content/plugins/index.json";
 import { loadAllCustomFields } from "@/lib/custom-fields";
 import { Paths } from "@/lib/schema/paths";
-import type { Plugin, PluginCacheEntry, ResolvedPluginField } from "./types";
+import { filterDocsHref, isCustomFilterType } from "./filter-docs";
+import type {
+  Plugin,
+  PluginCacheEntry,
+  PluginFilterDeclarations,
+  ResolvedPluginField,
+  ResolvedPluginFilter,
+} from "./types";
 
 // =============================================================================
 // PRIVATE HELPERS
@@ -11,13 +18,47 @@ import type { Plugin, PluginCacheEntry, ResolvedPluginField } from "./types";
 /** Cache for loaded plugins */
 let pluginsCache: Plugin[] | null = null;
 
+/** Flattens resource -> method -> name declarations into a renderable list. */
+function resolveCustomFilters(
+  pluginId: string,
+  declarations: PluginFilterDeclarations = {},
+): ResolvedPluginFilter[] {
+  const resolved: ResolvedPluginFilter[] = [];
+
+  for (const [resource, methods] of Object.entries(declarations)) {
+    for (const [method, filters] of Object.entries(methods)) {
+      for (const [name, spec] of Object.entries(filters)) {
+        if (!isCustomFilterType(spec.filterType)) {
+          console.error(
+            `Plugin "${pluginId}" declares filter "${name}" with unknown ` +
+              `filterType "${spec.filterType}". Type must be one of the ` +
+              `CustomFilterType values in src/lib/plugins/types.ts.`,
+          );
+          continue;
+        }
+        resolved.push({
+          name,
+          filterType: spec.filterType,
+          description: spec.description ?? "",
+          resource,
+          method,
+          docsHref: filterDocsHref(spec.filterType),
+        });
+      }
+    }
+  }
+
+  return resolved;
+}
+
 // =============================================================================
 // CORE LOADERS
 // =============================================================================
 
 /**
  * Loads all plugins from the generated metadata cache (with caching).
- * Resolves each plugin's field IDs against the custom-fields catalog.
+ * Resolves each plugin's field IDs against the custom-fields catalog and
+ * flattens its filter declarations.
  *
  * Requires `pnpm generate:plugin-metadata` to have been run first.
  */
@@ -56,7 +97,12 @@ export function loadAllPlugins(): Plugin[] {
       [],
     );
 
-    return { id, ...entry, resolvedFields };
+    return {
+      id,
+      ...entry,
+      resolvedFields,
+      resolvedFilters: resolveCustomFilters(id, entry.filters),
+    };
   });
 
   return pluginsCache;

--- a/website/src/lib/plugins/types.ts
+++ b/website/src/lib/plugins/types.ts
@@ -25,8 +25,12 @@ export interface PluginFilterSpec {
 }
 
 /**
- * Filter declarations nested resource -> method -> filter name, matching the
- * PluginRoutes shape plugins pass to definePlugin().
+ * Filter declarations nested resource -> method -> filter name.
+ *
+ * A catalog shape, not either SDK's authoring shape: the TS SDK wraps the
+ * filter map in a `filters` key, and the Python SDK puts a TypedDict class in
+ * the method slot. Copy a plugin's routes declaration here verbatim and its
+ * filters are skipped as unknown.
  */
 export type PluginFilterDeclarations = Record<
   string,

--- a/website/src/lib/plugins/types.ts
+++ b/website/src/lib/plugins/types.ts
@@ -1,4 +1,39 @@
 /**
+ * The filter types a plugin may declare. Mirrors CustomFilterType in
+ * lib/ts-sdk/src/extensions/types.ts — keep the two in sync.
+ */
+export type CustomFilterType =
+  | "stringComparison"
+  | "stringArray"
+  | "numberComparison"
+  | "numberArray"
+  | "numberRange"
+  | "booleanComparison"
+  | "dateComparison"
+  | "dateRange"
+  | "moneyComparison"
+  | "moneyRange";
+
+/**
+ * A single filter as declared in index.json, keyed by filter name.
+ * Operators are derived from filterType by the SDK, never authored here.
+ */
+export interface PluginFilterSpec {
+  filterType: CustomFilterType;
+  /** Authored for the website; plugins declare filterType only */
+  description?: string;
+}
+
+/**
+ * Filter declarations nested resource -> method -> filter name, matching the
+ * PluginRoutes shape plugins pass to definePlugin().
+ */
+export type PluginFilterDeclarations = Record<
+  string,
+  Record<string, Record<string, PluginFilterSpec>>
+>;
+
+/**
  * Plugin entry as stored in src/content/plugins/index.json (source of truth).
  * Maintainers edit this file; url/language/version are fetched at build time.
  */
@@ -13,6 +48,8 @@ export interface PluginSourceEntry {
   /** Optional fallback repo URL if the package registry doesn't provide one */
   repoUrl?: string;
   fields: Record<string, string[]>;
+  /** Omitted entirely by plugins that declare no custom filters */
+  filters?: PluginFilterDeclarations;
 }
 
 /**
@@ -41,6 +78,22 @@ export interface ResolvedPluginField {
 }
 
 /**
+ * A single custom filter flattened out of the nested declarations.
+ */
+export interface ResolvedPluginFilter {
+  /** The filter's name (key in the declarations) */
+  name: string;
+  filterType: CustomFilterType;
+  description: string;
+  /** Resource the filter attaches to (e.g. "opportunities") */
+  resource: string;
+  /** Route method the filter attaches to (e.g. "search") */
+  method: string;
+  /** Docs link for the filter type; see filter-docs.ts */
+  docsHref: string;
+}
+
+/**
  * A fully resolved plugin: cache metadata + joined field definitions.
  */
 export interface Plugin extends PluginCacheEntry {
@@ -48,4 +101,6 @@ export interface Plugin extends PluginCacheEntry {
   id: string;
   /** Field definitions resolved from the custom-fields catalog */
   resolvedFields: ResolvedPluginField[];
+  /** Filters flattened from the entry's nested declarations */
+  resolvedFilters: ResolvedPluginFilter[];
 }

--- a/website/src/lib/plugins/types.ts
+++ b/website/src/lib/plugins/types.ts
@@ -2,17 +2,20 @@
  * The filter types a plugin may declare. Mirrors CustomFilterType in
  * lib/ts-sdk/src/extensions/types.ts — keep the two in sync.
  */
-export type CustomFilterType =
-  | "stringComparison"
-  | "stringArray"
-  | "numberComparison"
-  | "numberArray"
-  | "numberRange"
-  | "booleanComparison"
-  | "dateComparison"
-  | "dateRange"
-  | "moneyComparison"
-  | "moneyRange";
+export const CUSTOM_FILTER_TYPES = [
+  "stringComparison",
+  "stringArray",
+  "numberComparison",
+  "numberArray",
+  "numberRange",
+  "booleanComparison",
+  "dateComparison",
+  "dateRange",
+  "moneyComparison",
+  "moneyRange",
+] as const;
+
+export type CustomFilterType = (typeof CUSTOM_FILTER_TYPES)[number];
 
 /**
  * A single filter as declared in index.json, keyed by filter name.


### PR DESCRIPTION
### Summary

- Fixes #1030
- Time to review: 10 minutes

### Changes proposed

- The per-plugin details page now has a **Custom Filters** section listing the filters each plugin accepts, so a reader can see a plugin's filter support without reading its source.
- Filter declarations are hand-maintained in `website/src/content/plugins/index.json` alongside the existing `fields`, shaped resource → method → name. That is a catalog shape and deliberately matches neither SDK: the TS SDK wraps the filter map in a `filters` key, and the Python SDK puts a TypedDict class in the method slot.
- Each card links to the protocol definition for its filter type.
- The section mirrors the existing Custom Fields section — same `CardGrid`, same `CatalogCard`, same badge and pill styling.

### Context for reviewers

**What the section shows.** Both Grants.gov plugins declare the same four filters on `opportunities.search`: `agency`, `applicantType`, `fundingInstrument` (`stringArray`), and `costSharing` (`booleanComparison`). Each card carries the filter name, a description, a filter-type badge, and an `opportunities.search` route pill. Operators aren't shown — that table lives in the SDK, which the website doesn't depend on, so duplicating it here would drift.

**Where the filter data comes from.** Hand-maintained, the same as the existing `fields` catalog. The plugins declare `filterType` only, so the four descriptions are authored here. No change was needed to `fetch-plugin-metadata.ts` — it spreads the whole source entry, so the new key flows into the build cache; that was confirmed by running `pnpm generate:plugin-metadata` rather than assumed.

**How this was verified.**

- `pnpm run ci` in `website/` (build + lint + format + types + astro check + cspell + vitest) — passing.
- Every anchored href is checked against the real headings in the filters docs by a test, not by hand: nine anchors, none dead. `starlight-links-validator` does **not** cover these — it parses markdown, and the plugin pages are `.astro`, so a build with a deliberately dead anchor still reports all internal links valid. The test is the only guard.
- The new tests were mutation-checked to confirm they fail when the mapping breaks — a fabricated boolean anchor fails two cases, and a typo'd page segment fails one.
- Visual parity with the Custom Fields section was checked by comparing the two cards' emitted scoped CSS in the built page: the badge, pill, and pill-list rule bodies are identical.

**Testing instructions.**

```bash
cd website && pnpm dev
# then open /plugins/ts-cg-grants-gov/ and /plugins/cg-grants-gov/
```

**No changeset.** `.changeset/config.json` scopes releases to `lib/python-sdk`, `lib/core`, `lib/cli`, and `lib/ts-sdk`; `website` is not a released package.

### Additional information

No screenshot attached. The rendered section is reproducible with the dev-server steps above; the four cards appear below Custom Fields in the same grid.

