### PR TITLE
fix(deps): force brace-expansion >=5.0.9 to resolve GHSA-rgw5-rvv9-x895

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ catalogs:
 
 overrides:
   axios@<1.15.0: '>=1.15.0'
-  brace-expansion@<5.0.8: '>=5.0.8'
+  brace-expansion@<5.0.9: '>=5.0.9'
   defu@<=6.1.4: '>=6.1.5'
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'
@@ -3132,8 +3132,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -9411,7 +9411,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11443,11 +11443,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalogs:
 
 overrides:
   axios@<1.15.0: '>=1.15.0'
-  brace-expansion@<5.0.8: '>=5.0.8'
+  brace-expansion@<5.0.9: '>=5.0.9'
   defu@<=6.1.4: '>=6.1.5'
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
   form-data@>=4.0.0 <4.0.6: '>=4.0.6'


### PR DESCRIPTION
### Summary

- Clears the failing dependency-audit gate, which currently reds `main` and every open PR.
- No linked issue; advisory published upstream today.
- Time to review: ~2 minutes

### Changes proposed

Moves the `brace-expansion` override floor from `>=5.0.8` to `>=5.0.9` in `pnpm-workspace.yaml`, with the lockfile regenerated to match. Same shape as #1041, which set the previous floor.

```diff
-  brace-expansion@<5.0.8: '>=5.0.8'
+  brace-expansion@<5.0.9: '>=5.0.9'
```

### Context for reviewers

GHSA-rgw5-rvv9-x895 covers `brace-expansion >=4.0.0 <5.0.9` — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. The floor set in #1041 pins `>=5.0.8`, which resolves to exactly `5.0.8`, one patch below the fixed version. `5.0.9` is published and is the advisory's stated fix.

This is not specific to any one branch: `main` carries the same override and resolves the same `5.0.8`, so the audit step fails everywhere until the floor moves.

Verified at all three CI audit scopes. The scopes matter because `audit-deps.js` shells out to `pnpm list`, whose package count depends on the working directory:

| Invocation | Packages | Result |
|---|---|---|
| `audit-deps.js --filter @common-grants/cli` | 183 | no vulnerabilities |
| `audit-deps.js --filter @common-grants/sdk` | 99 | no vulnerabilities |
| `audit-deps.js --level high` from `./website` | 696 | none at or above high |

Root `pnpm run ci` is green across core, changelog-emitter, cli (119), sdk (548), and website (76).

### Additional information

No changeset. The override affects a transitive dependency only; no published package's declared dependencies or public surface change.

The pre-existing `postcss` moderate advisory (GHSA-fxqj-rqcc-2cmp) still lists in the repo-wide audit output but sits below the `high` gate and is unaffected by this change.
