### PR TITLE
fix(core): apply remaining v0.4.0 hold branch audit findings

### DIFF
--- a/.changeset/extensible-enum-field.md
+++ b/.changeset/extensible-enum-field.md
@@ -4,9 +4,9 @@
 
 Add an `ExtensibleEnum` base model and `ExtensibleEnumT<T>` templated model to the core
 fields library (#961), formalizing the extensible enum pattern (a `value` from a predefined
-set of options, plus optional `customValue` and `description`). The existing extensible enum
-fields — `OppStatus`, `AppStatus`, `ApplicantType`, `FormResponseStatus`, and
-`CompetitionStatus` — are now defined via `ExtensibleEnumT`, so the pattern has a single
-source of truth. Also adds the previously missing `custom` option to
+set of options, plus optional `customValue` and `description`). Every extensible enum field —
+`OppStatus`, `AppStatus`, `ApplicantType`, `FormResponseStatus`, `CompetitionStatus`, and the
+0.4.0 additions `AwdStatus` and `RevisionStatus` — is now defined via `ExtensibleEnumT`, so the
+pattern has a single source of truth. Also adds the previously missing `custom` option to
 `FormResponseStatusOptions` at protocol version 0.4.0. Emitted schema shapes are unchanged
 apart from property description wording.

--- a/lib/core/lib/core/models/award.tsp
+++ b/lib/core/lib/core/models/award.tsp
@@ -33,16 +33,7 @@ enum AwdStatusOptions {
 @example(Examples.Award.customStatus)
 @example(Examples.Award.status)
 @Versioning.added(CommonGrants.Versions.v0_4)
-model AwdStatus {
-  /** The status of the award, from a predefined set of options */
-  value: AwdStatusOptions;
-
-  /** A custom value for the status */
-  customValue?: string;
-
-  /** A human-readable description of the status */
-  description?: string;
-}
+model AwdStatus is Fields.ExtensibleEnumT<AwdStatusOptions>;
 
 // #########################################################
 // AwdFunding

--- a/lib/core/lib/core/models/revision.tsp
+++ b/lib/core/lib/core/models/revision.tsp
@@ -39,16 +39,7 @@ enum RevisionStatusOptions {
 @example(Examples.Revision.acceptedStatus)
 @example(Examples.Revision.customStatus)
 @Versioning.added(CommonGrants.Versions.v0_4)
-model RevisionStatus {
-  /** The status of the revision, from a predefined set of options */
-  value: RevisionStatusOptions;
-
-  /** A custom value for the status */
-  customValue?: string;
-
-  /** A human-readable description of the status */
-  description?: string;
-}
+model RevisionStatus is Fields.ExtensibleEnumT<RevisionStatusOptions>;
 
 // #########################################################
 // Revision

--- a/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
+++ b/lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py
@@ -11,9 +11,6 @@ class BooleanComparisonFilter(CommonGrantsBaseModel):
 
     Strict boolean: 1/0 and "true"/"false" are rejected, matching the Zod
     ``z.boolean()`` semantics of the TS SDK's ``BooleanComparisonFilterSchema``.
-
-    No spec model backs this filter yet: the core spec defines no boolean
-    filter, so both SDKs carry an SDK-level model until one lands.
     """
 
     operator: EquivalenceOperator = Field(

--- a/website/.cspell.json
+++ b/website/.cspell.json
@@ -76,6 +76,7 @@
     "numberarrayfilter",
     "moneycomparisonfilter",
     "moneyrangefilter",
+    "booleancomparisonfilter",
     "dataclass",
     "dataclasses",
     "datecomparisonfilter",

--- a/website/__tests__/lib/plugins/filter-docs.spec.ts
+++ b/website/__tests__/lib/plugins/filter-docs.spec.ts
@@ -6,12 +6,6 @@ import { Paths } from "@/lib/schema/paths";
 import { CUSTOM_FILTER_TYPES } from "@/lib/plugins/types";
 
 describe("filterDocsHref", () => {
-  // The protocol has no boolean filter model, so no boolean anchor is ever
-  // emitted. Catches "completing" the map by pattern with a made-up anchor.
-  it("sends booleanComparison to the filters index, not an anchor", () => {
-    expect(filterDocsHref("booleanComparison")).toBe("/protocol/filters/");
-  });
-
   // starlight-links-validator parses markdown, so it never sees links emitted
   // from the .astro plugin pages — confirmed by building with a deliberately
   // dead anchor and watching it report all links valid. Nothing else catches a
@@ -20,7 +14,6 @@ describe("filterDocsHref", () => {
     for (const filterType of CUSTOM_FILTER_TYPES) {
       const href = filterDocsHref(filterType);
       const [page, anchor] = href.replace("/protocol/filters/", "").split("#");
-      if (!anchor) continue;
       const mdx = fs.readFileSync(
         path.join(Paths.PROTOCOL_DOCS_DIR, "filters", `${page}.mdx`),
         "utf-8",

--- a/website/__tests__/lib/plugins/loader.spec.ts
+++ b/website/__tests__/lib/plugins/loader.spec.ts
@@ -30,16 +30,18 @@ describe("plugins loader", () => {
       expect(agency?.description).not.toBe("");
     });
 
-    // The one filter type with no protocol model of its own, so it is the one
-    // whose href comes from the fallback rather than the anchor map.
-    it("sends a booleanComparison filter to the filters index", () => {
+    // The newest filter model, and the one a plugin declares against a boolean
+    // custom field, so it is the likeliest to lose its docs link in a rewire.
+    it("links a booleanComparison filter to the boolean filter model", () => {
       const plugin = loadAllPlugins().find((p) => p.id === "cg-grants-gov");
       const costSharing = plugin?.resolvedFilters.find(
         (f) => f.name === "costSharing",
       );
 
       expect(costSharing?.filterType).toBe("booleanComparison");
-      expect(costSharing?.docsHref).toBe("/protocol/filters/");
+      expect(costSharing?.docsHref).toBe(
+        "/protocol/filters/boolean#booleancomparisonfilter",
+      );
     });
   });
 });

--- a/website/__tests__/lib/plugins/loader.spec.ts
+++ b/website/__tests__/lib/plugins/loader.spec.ts
@@ -29,19 +29,5 @@ describe("plugins loader", () => {
       // Authored per filter in index.json; "" means the wiring dropped it.
       expect(agency?.description).not.toBe("");
     });
-
-    // The newest filter model, and the one a plugin declares against a boolean
-    // custom field, so it is the likeliest to lose its docs link in a rewire.
-    it("links a booleanComparison filter to the boolean filter model", () => {
-      const plugin = loadAllPlugins().find((p) => p.id === "cg-grants-gov");
-      const costSharing = plugin?.resolvedFilters.find(
-        (f) => f.name === "costSharing",
-      );
-
-      expect(costSharing?.filterType).toBe("booleanComparison");
-      expect(costSharing?.docsHref).toBe(
-        "/protocol/filters/boolean#booleancomparisonfilter",
-      );
-    });
   });
 });

--- a/website/public/openapi/openapi.0.4.0.yaml
+++ b/website/public/openapi/openapi.0.4.0.yaml
@@ -3007,13 +3007,13 @@ components:
         value:
           allOf:
             - $ref: '#/components/schemas/CommonGrants.Models.AwdStatusOptions'
-          description: The status of the award, from a predefined set of options
+          description: The selected value, from a predefined set of options
         customValue:
           type: string
-          description: A custom value for the status
+          description: A custom value, used when the selected value is the `custom` option
         description:
           type: string
-          description: A human-readable description of the status
+          description: A human-readable description of the value
       description: The status of the award
       example:
         value: awarded
@@ -4942,13 +4942,13 @@ components:
         value:
           allOf:
             - $ref: '#/components/schemas/CommonGrants.Models.RevisionStatusOptions'
-          description: The status of the revision, from a predefined set of options
+          description: The selected value, from a predefined set of options
         customValue:
           type: string
-          description: A custom value for the status
+          description: A custom value, used when the selected value is the `custom` option
         description:
           type: string
-          description: A human-readable description of the status
+          description: A human-readable description of the value
       description: |-
         The status of a revision, including its lifecycle state and an optional
         human-readable description.

--- a/website/public/schemas/yaml/AwdStatus.yaml
+++ b/website/public/schemas/yaml/AwdStatus.yaml
@@ -4,13 +4,13 @@ type: object
 properties:
   value:
     $ref: AwdStatusOptions.yaml
-    description: The status of the award, from a predefined set of options
+    description: The selected value, from a predefined set of options
   customValue:
     type: string
-    description: A custom value for the status
+    description: A custom value, used when the selected value is the `custom` option
   description:
     type: string
-    description: A human-readable description of the status
+    description: A human-readable description of the value
 required:
   - value
 unevaluatedProperties:

--- a/website/public/schemas/yaml/RevisionStatus.yaml
+++ b/website/public/schemas/yaml/RevisionStatus.yaml
@@ -4,13 +4,13 @@ type: object
 properties:
   value:
     $ref: RevisionStatusOptions.yaml
-    description: The status of the revision, from a predefined set of options
+    description: The selected value, from a predefined set of options
   customValue:
     type: string
-    description: A custom value for the status
+    description: A custom value, used when the selected value is the `custom` option
   description:
     type: string
-    description: A human-readable description of the status
+    description: A human-readable description of the value
 required:
   - value
 unevaluatedProperties:

--- a/website/src/content/docs/governance/adr/0023-org-ids.mdx
+++ b/website/src/content/docs/governance/adr/0023-org-ids.mdx
@@ -711,11 +711,11 @@ All three options below share the same principle: registry-level facts (the same
 | ---------------------------------------------- | :------------------: | :--: | :--------------: |
 | Explicit pointer to the catalog entry          |          ✅          |  ✅  |        ✅        |
 | Registry vs. instance fields visually grouped  |          ✅          |  ❌  |        ✅        |
-| Inline filtering by scope or kind              |          ✅          |  ❌  |        ✅        |
-| Per-registry schema validation                 |          ✅          |  ❌  |        ✅        |
+| Inline filtering by scope or kind              |          ❌          |  ❌  |        ✅        |
+| Per-registry schema validation                 |          ❌          |  ❌  |        ✅        |
 | Avoids duplicating catalog metadata per record |          ✅          |  ✅  |        ❌        |
-| Payload brevity                                |          🟡          |  ✅  |        ❌        |
-| Fully self-contained without a catalog         |          🟡          |  ❌  |        ✅        |
+| Payload brevity                                |          ✅          |  ✅  |        ❌        |
+| Fully self-contained without a catalog         |          ❌          |  ❌  |        ✅        |
 | Few required fields                            |          ✅          |  ✅  |        ❌        |
 
 #### Option 1: Nested hybrid (recommended)
@@ -723,11 +723,11 @@ All three options below share the same principle: registry-level facts (the same
 :::note[Bottom line]
 The nested hybrid shape is best if:
 
-- we want payloads to carry just enough registry context for filtering and validation, with a clear pointer to the catalog for everything else,
+- we want payloads to name the registry and point at the catalog for everything else,
 - but we're willing to nest registry-level fields under a `registry` object instead of keeping the shape flat.
   :::
 
-The `registry` object holds a curated subset of the catalog entry: the fields that are useful in payload (filtering, validation, identification) plus a `url` linking back to the full catalog entry. Required fields are kept minimal (`code` and `url`); the rest are optional. Per-instance fields stay at the top level.
+The `registry` object holds only the facts needed to name the registry in payload: its canonical `code` plus a `url` linking to the full catalog entry. Every other registry-level fact lives in the catalog. Both fields are optional, so a payload carries only what the publishing system knows. Per-instance fields stay at the top level.
 
 **Example**
 
@@ -736,13 +736,9 @@ The `registry` object holds a curated subset of the catalog entry: the fields th
   "org:us:ein": {
     "registry": {
       "code": "org:us:ein",
-      "url": "https://commongrants.org/registries/org-us-ein",
-      "scope": "US",
-      "kind": "government",
-      "schema": "https://commongrants.org/registries/org-us-ein/schema.json"
+      "url": "https://commongrants.org/registries/org-us-ein"
     },
-    "id": "123456789",
-    "uri": "https://apps.irs.gov/app/eos/detailsPage?ein=123456789"
+    "id": "123456789"
   }
 }
 ```
@@ -765,14 +761,13 @@ source: https://org-id.guide/list/US-EIN
 - **Pros**
   - `registry.url` gives consumers an explicit pointer to the catalog entry, removing ambiguity about how inline and catalog fields relate.
   - Nesting visually groups registry-level vs. instance-level facts, mirroring the catalog shape.
-  - `scope` and `kind` are available inline for filtering and UI decisions (e.g. "show all government-issued IDs") without a catalog fetch.
-  - `schema` supports per-registry validation in JSON Schema.
-  - Required surface stays minimal: only `registry.code`, `registry.url`, and `id` are required; everything else is optional.
-  - Verbose metadata (full name, issuer, lookup template) stays in the catalog so payloads don't bloat.
+  - Registry-level facts can be added under `registry` later without reshaping the instance-level fields around them.
+  - Nothing is required, so a system that only knows a record's ID in a registry can publish exactly that.
+  - All registry metadata (name, scope, kind, issuer, schema, lookup template) stays in the catalog so payloads don't bloat.
 - **Cons**
   - One extra level of access (`identifier.registry.code` vs. a flat `identifier.registry`).
-  - Inline registry fields can drift from the catalog if not kept in sync.
-  - `scope` and `kind` are technically derivable from `registry.code` via the catalog, so they are redundant.
+  - Any registry fact beyond the code requires a catalog lookup, so scope- or kind-based filtering can't be done from the payload alone.
+  - `registry.url` duplicates a location the catalog already owns, so it can drift if an entry moves.
 
 #### Option 2: Flat with `registryUrl`
 
@@ -970,9 +965,7 @@ A reference with identifiers is best if:
       "org:us:ein": {
         "registry": {
           "code": "org:us:ein",
-          "url": "https://commongrants.org/registries/org-us-ein",
-          "scope": "US",
-          "kind": "government"
+          "url": "https://commongrants.org/registries/org-us-ein"
         },
         "id": "987654321"
       }

--- a/website/src/content/docs/protocol/filters/boolean.mdx
+++ b/website/src/content/docs/protocol/filters/boolean.mdx
@@ -1,0 +1,54 @@
+---
+title: Boolean filters
+description: Filters that can be applied to boolean fields.
+booleanComparisonFilter:
+  example:
+    file:
+      path: "website/public/schemas/yaml/BooleanComparisonFilter.yaml"
+  jsonSchema:
+    file:
+      path: "website/public/schemas/yaml/BooleanComparisonFilter.yaml"
+  typeSpec:
+    file:
+      path: "lib/core/lib/core/filters/boolean.tsp"
+      startLine: 9
+      endLine: 18
+  python:
+    file:
+      path: "lib/python-sdk/common_grants_sdk/schemas/pydantic/filters/boolean.py"
+      startLine: 9
+      endLine: 31
+  typescript:
+    file:
+      path: "lib/ts-sdk/src/schemas/zod/filters.ts"
+      startLine: 114
+      endLine: 117
+---
+
+import SchemaFormatTabs from "@/components/SchemaFormatTabs.astro";
+import SchemaChangelog from "@/components/SchemaChangelog.astro";
+
+## BooleanComparisonFilter
+
+A filter that applies a comparison to a boolean value.
+
+### Table
+
+| Property | Type                                                                | Description                               |
+| -------- | ------------------------------------------------------------------- | ----------------------------------------- |
+| operator | [EquivalenceOperators](/protocol/filters/base#equivalenceoperators) | The operator to apply to the filter value |
+| value    | [boolean](/protocol/types/other#boolean)                            | The value to use for the filter operation |
+
+### Formats
+
+<SchemaFormatTabs
+  example={frontmatter.booleanComparisonFilter.example}
+  jsonSchema={frontmatter.booleanComparisonFilter.jsonSchema}
+  typeSpec={frontmatter.booleanComparisonFilter.typeSpec}
+  python={frontmatter.booleanComparisonFilter.python}
+  typescript={frontmatter.booleanComparisonFilter.typescript}
+/>
+
+### Changelog
+
+<SchemaChangelog schema="BooleanComparisonFilter" />

--- a/website/src/content/docs/protocol/filters/index.mdx
+++ b/website/src/content/docs/protocol/filters/index.mdx
@@ -93,6 +93,16 @@ Learn more about the default filters supported by the CommonGrants protocol:
   />
 </CardGrid>
 
+### Boolean
+
+<CardGrid>
+  <LinkCard
+    title="Boolean Comparison Filter"
+    href="/protocol/filters/boolean#booleancomparisonfilter"
+    description="Compare a field to a boolean value"
+  />
+</CardGrid>
+
 ### Date and time
 
 <CardGrid>

--- a/website/src/lib/plugins/filter-docs.ts
+++ b/website/src/lib/plugins/filter-docs.ts
@@ -1,24 +1,13 @@
 import type { CustomFilterType } from "./types";
 
-/** Filter docs index, used when a filter type has no model of its own. */
-const FILTERS_OVERVIEW = "/protocol/filters/";
-
-/**
- * Maps each filter type to the protocol model that defines it.
- *
- * `booleanComparison` points at the overview because the protocol has no
- * boolean filter model: custom filter values are typed `unknown`
- * (Filters.DefaultFilter) and no base field is boolean, so the type exists only
- * in the SDKs. None of the filter docs pages emit a boolean anchor, so there is
- * nothing more specific to link to — don't invent one.
- */
+/** Maps each filter type to the protocol model that defines it. */
 const DOCS_HREF: Record<CustomFilterType, string> = {
   stringComparison: "/protocol/filters/string#stringcomparisonfilter",
   stringArray: "/protocol/filters/string#stringarrayfilter",
   numberComparison: "/protocol/filters/numeric#numbercomparisonfilter",
   numberArray: "/protocol/filters/numeric#numberarrayfilter",
   numberRange: "/protocol/filters/numeric#numberrangefilter",
-  booleanComparison: FILTERS_OVERVIEW,
+  booleanComparison: "/protocol/filters/boolean#booleancomparisonfilter",
   dateComparison: "/protocol/filters/date#datecomparisonfilter",
   dateRange: "/protocol/filters/date#daterangefilter",
   moneyComparison: "/protocol/filters/money#moneycomparisonfilter",


### PR DESCRIPTION
### Summary

Second cleanup pass over the v0.4.0 hold branch, covering the three items left open on #1032:

- `BooleanComparisonFilter` ships in 0.4.0 but had no docs page, so every plugin's `booleanComparison` filter linked to the filters overview instead of a model.
- The two status models added in 0.4.0 hand-rolled the extensible enum shape instead of instantiating `Fields.ExtensibleEnumT<T>` like every other extensible enum field.
- ADR-0023's recommended examples described a richer `registry` object than the one that shipped.

- Closes #1032
- Time to review: 10 minutes

### Changes proposed

> What was added, updated, or removed in this PR.

**Document `BooleanComparisonFilter`** — adds `protocol/filters/boolean.mdx` (table, format tabs, changelog) and a Boolean card on the filters overview, then points the plugin filter map at `/protocol/filters/boolean#booleancomparisonfilter`. The map previously sent `booleanComparison` to the overview because no boolean model existed when the custom filters section was built in #1045; the model landed in #953 on this branch. Both tests that pinned the old fallback are dropped rather than repointed: removing the `if (!anchor) continue;` guard raises the anchor-exists check from the nine types with anchors to all ten, which covers `booleanComparison` on its own, and the loader resolves every filter through one `filterDocsHref` call, so the `agency` case already covers filterType to docsHref. The py-SDK docstring saying no spec model backs the filter is removed for the same reason.

**Define the 0.4.0 status models via `ExtensibleEnumT`** — `AwdStatus` and `RevisionStatus` both spelled out `value` / `customValue` / `description` by hand. `OppStatus`, `AppStatus`, `ApplicantType`, `FormResponseStatus`, and `CompetitionStatus` all instantiate the template, so these two were the only extensible enum fields with a second source of truth for the shape. `RevisionStatus` is included alongside `AwdStatus` because it has the same defect and ships in the same release. Wire shape is unchanged; the regenerated `AwdStatus.yaml`, `RevisionStatus.yaml`, and `openapi.0.4.0.yaml` diffs are property descriptions moving to the template's wording, which is what `.changeset/extensible-enum-field.md` already documents for the other five fields. That changeset's list is extended rather than adding a new one.

**Align ADR-0023 with the shipped identifier** — the recommended nested-hybrid example carried `scope`, `kind`, `schema`, and a top-level `uri`, and the recommended parent-reference example carried `scope` and `kind`. `IdentifierT.registry` defines `code` and `url` only, and both are optional, so the prose describing `code`/`url` as required is corrected too. The pros, cons, and three comparison rows that rested on the dropped fields move with the example: inline scope/kind filtering and per-registry schema validation are now ❌ for the nested hybrid, payload brevity ✅, and self-contained-without-a-catalog ❌. The remaining `scope`/`kind` examples are in the rejected flat and fully-decomposed options, where the richer shape is the point, and the `US-EIN`/`US-SAM` codes are in the rejected adopt-org-id.guide-codes option. This is the follow-up to karinamzalez's question on #1040 about whether ADR-0023 should drop the fields ADR-0026's examples dropped.

### Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Verified with `pnpm run ci` from the root (exit 0), plus `make checks && make test` in `lib/python-sdk` (0 pyright errors, 396 passed). The website build reports all internal links valid, which covers the new overview card and the anchors on the new page.

The anchor check was confirmed to discriminate: pointing `booleanComparison` back at `/protocol/filters/` fails it.

### Additional information

> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

The shipped shape the ADR examples now match, from `lib/core/lib/core/fields/identifier.tsp`:

```typespec
model IdentifierT<Id extends string = string, Code extends string = string> {
  registry?: {
    code?: Code;
    url?: url;
  };
  id?: Id;
  allIds?: Array<{ id: Id; status: IdentifierStatus }>;
}
```

The regenerated schema diff for both status models is descriptions only:

```diff
   value:
     $ref: AwdStatusOptions.yaml
-    description: The status of the award, from a predefined set of options
+    description: The selected value, from a predefined set of options
   customValue:
     type: string
-    description: A custom value for the status
+    description: A custom value, used when the selected value is the `custom` option
```


