### PR TITLE
refactor(core): reorder OpenAPI tags

### DIFF
--- a/lib/core/lib/api.tsp
+++ b/lib/core/lib/api.tsp
@@ -31,6 +31,13 @@ using Versioning;
   }
 )
 @tagMetadata("Forms", #{ description: "Endpoints related to forms" })
+@tagMetadata("Awards", #{ description: "Endpoints related to grant awards" })
+@tagMetadata(
+  "Organizations",
+  #{
+    description: "Endpoints related to viewing and syncing organization profiles",
+  }
+)
 @tagMetadata(
   "Application Reviews",
   #{
@@ -52,13 +59,6 @@ using Versioning;
 @tagMetadata(
   "Opportunities",
   #{ description: "Endpoints related to funding opportunities" }
-)
-@tagMetadata("Awards", #{ description: "Endpoints related to grant awards" })
-@tagMetadata(
-  "Organizations",
-  #{
-    description: "Endpoints related to viewing and syncing organization profiles",
-  }
 )
 @route("/common-grants") // Prefixes all routes with `/common-grants/`
 namespace CommonGrants.API;

--- a/website/public/openapi/openapi.0.4.0.yaml
+++ b/website/public/openapi/openapi.0.4.0.yaml
@@ -8,10 +8,6 @@ info:
     it must implement all of the routes with the "required" tag in this specification.
   version: 0.4.0
 tags:
-  - name: Organizations
-    description: Endpoints related to viewing and syncing organization profiles
-  - name: Awards
-    description: Endpoints related to grant awards
   - name: Opportunities
     description: Endpoints related to funding opportunities
   - name: Competitions
@@ -20,6 +16,10 @@ tags:
     description: Endpoints related to submitting applications for a given competition
   - name: Application Reviews
     description: Endpoints related to reviewing applications for a given competition
+  - name: Organizations
+    description: Endpoints related to viewing and syncing organization profiles
+  - name: Awards
+    description: Endpoints related to grant awards
   - name: Forms
     description: Endpoints related to forms
   - name: required


### PR DESCRIPTION
### Summary

Reorders the OpenAPI tags so that Opportunities and Applications appear above Organizations and Awards in the auto-generated OpenAPI docs.

- Relates to #956 
- Time to review: 2 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

- Reorders the Awards and Organizations OpenAPI tags in the core library, so that they show up below Opportunities and Applications in the auto-generated docs
- Saves the auto-generated updates to the OpenAPI spec

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

#### Instructions for review

1. Go to https://cg-pr-1067.billy-daly.workers.dev/protocol/api-docs/
2. View the updated order of the OpenAPI tags, with Opportunities and Applications before Organizations and Awards

#### Notes

I moved these down because:
- Organizations and Awards are still experimental where Opportunities is the only tag with non-experimental routes
- I wanted the tags to roughly be listed in the order of the grants lifecycle:
  - Searching for grants (Opportunities)
  - Applying for grants (Competition and Applications, as well as Organizations to some degree)
  - Reporting on grant awards (Awards, and Organizations to some degree)

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

<img width="1440" height="900" alt="Screenshot 2026-08-04 at 3 54 19 PM" src="https://github.com/user-attachments/assets/4d788d58-20bd-49dc-a91c-74184e6007ba" />
<img width="1440" height="900" alt="Screenshot 2026-08-04 at 4 00 49 PM" src="https://github.com/user-attachments/assets/fcd56a29-f1b6-45d2-a480-9dfa11d61e8d" />

