### PR TITLE
fix(changelog-emitter): declare node types explicitly

### DIFF
--- a/lib/changelog-emitter/tsconfig.json
+++ b/lib/changelog-emitter/tsconfig.json
@@ -5,8 +5,8 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
-    // Declared explicitly: automatic @types discovery stops finding node once
-    // @typespec/compiler 1.14 changes the dependency layout.
+    // Declared explicitly rather than relying on automatic @types discovery,
+    // which stops resolving node under @typespec/compiler 1.14+.
     "types": ["node"],
     "rootDir": ".",
     "outDir": "dist",

--- a/lib/changelog-emitter/tsconfig.json
+++ b/lib/changelog-emitter/tsconfig.json
@@ -5,6 +5,9 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    // Declared explicitly: automatic @types discovery stops finding node once
+    // @typespec/compiler 1.14 changes the dependency layout.
+    "types": ["node"],
     "rootDir": ".",
     "outDir": "dist",
     "sourceMap": true,

--- a/lib/changelog-emitter/tsconfig.json
+++ b/lib/changelog-emitter/tsconfig.json
@@ -5,8 +5,6 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
-    // Declared explicitly rather than relying on automatic @types discovery,
-    // which stops resolving node under @typespec/compiler 1.14+.
     "types": ["node"],
     "rootDir": ".",
     "outDir": "dist",


### PR DESCRIPTION
### Summary

- Unblocks the `check-catalog` job, which currently fails on every PR it runs against
- The failure is the TypeScript 6 (#932) plus `@typespec/compiler` 1.14 combination; either one alone builds fine
- Time to review: 5 minutes

### Changes proposed
> What was added, updated, or removed in this PR.

Adds `"types": ["node"]` to `lib/changelog-emitter/tsconfig.json`.

### Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

`check-catalog` bumps the catalog to the latest in-range versions and rebuilds, a dry run of the next catalog update. That dry run has included `@typespec/compiler` 1.14.0 since it published on 2026-07-14 and was still passing with it as late as this morning. What broke it is the TypeScript 6 bump (#932) landing on `main`: under TS 6, building with compiler 1.14 fails in `lib/changelog-emitter`:

```
src/testing/index.ts(6,31): error TS2591: Cannot find name 'url'. Do you need to install type definitions for node?
src/testing/index.ts(10,54): error TS2339: Property 'url' does not exist on type 'ImportMeta'.
test/tester.ts(3,33): error TS2591: Cannot find name 'node:assert'.
test/tester.ts(14,27): error TS2339: Property 'dirname' does not exist on type 'ImportMeta'.
```

PR CI builds the merge ref against `main`, so every open PR inherited the failure at once, with no push of its own.

The errors point at `@types/node`, which is a red herring. The package already declares `@types/node` as a devDependency, but its tsconfig has no `types` field, so it relied on automatic `@types` discovery to find it. Under TS 6 that discovery stops resolving node once compiler 1.14 is in the tree, and every node-typed reference in the package fails at once. Declaring the types explicitly is what the compiler error itself suggests, and it removes the reliance on automatic discovery.

Combination grid without this change, bumping catalog entries against `main` with the pinned pnpm 11.20.0:

| TypeScript | `@typespec/compiler` | Result |
| --- | --- | --- |
| `^6.0.3` (current) | `^1.13.0` (current) | pass |
| `^6.0.3` | `^1.14.0` | 4 errors above, install exits 2 |
| `^5.9.3` | `^1.14.0` | pass |

With this change, on this branch:

- Current catalog (TS 6, `@typespec/compiler ^1.13.0`): `pnpm run ci` exits 0, suites 40 passed / 6 skipped, 119, 548, 106, cspell 0 issues.
- TS 6 with `@typespec/compiler` bumped to `^1.14.0`: install exits 0, 0 TypeScript errors, emitter build exits 0.

No changeset. `typespec-versioning-changelog` is not published to npm, so there is nothing to release.

### Additional information
> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Run history on this branch pins the onset: the 16:37 UTC `check-catalog` run today passed and the 17:32 run failed, straddling the #932 merge at 17:18, with identical `@typespec/compiler ^1.13.0 -> ^1.14.0` bumps in both logs.
