### PR TITLE
fix(express-js): bump nanoid to 3.3.18 for GHSA-2v37-7h3g-55p8

### DIFF
--- a/templates/express-js/pnpm-lock.yaml
+++ b/templates/express-js/pnpm-lock.yaml
@@ -1704,8 +1704,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3651,7 +3651,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -3712,7 +3712,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
### Summary

- Clears the high-severity nanoid advisory failing the express-js template's audit
- Time to review: 2 minutes

### Changes proposed

- Refresh `templates/express-js/pnpm-lock.yaml` so nanoid resolves to 3.3.18, clearing [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high: custom generators can loop indefinitely when size is zero).

### Context for reviewers

nanoid is transitive here (`vitest → vite → postcss → nanoid`, 6 paths), so Dependabot won't file a direct-dependency bump that reaches it.

No override is needed for this one. `postcss` declares `nanoid: ^3.3.16`, a range that already admits the patched 3.3.18 — the lockfile was simply still pinned to 3.3.16. Refreshing the lockfile is enough, so the template's security-floor overrides in `pnpm-workspace.yaml` are untouched and there is no entry to remember to remove later.

The advisory currently fails `pnpm audit` on any PR whose CI touches this template (seen on #1093, and reproducible on `main`).

Verified by running the template's CI steps locally against the updated lockfile: `pnpm install --frozen-lockfile`, `pnpm run checks`, `pnpm run build`, and `pnpm audit`, all green with `No known vulnerabilities found`.

### Additional information

Lockfile-wide check after the refresh: `grep 'nanoid@' pnpm-lock.yaml` shows only 3.3.18.
