### PR TITLE
ci: skip the co-planning dry runs when the Fider token is unavailable

### DIFF
--- a/.github/workflows/coplanning-sync-fider-to-gh.yml
+++ b/.github/workflows/coplanning-sync-fider-to-gh.yml
@@ -35,7 +35,9 @@ jobs:
           python-version: "3.13"
 
       - name: Run script (dry run)
-        if: github.event_name == 'pull_request'
+        # Dependabot and fork PRs run without repository secrets; skip the dry
+        # run there instead of failing on the missing token.
+        if: github.event_name == 'pull_request' && env.FIDER_API_TOKEN != ''
         run: |
           python run.py \
             --org "${{ github.repository_owner }}" \

--- a/.github/workflows/coplanning-sync-gh-to-fider.yml
+++ b/.github/workflows/coplanning-sync-gh-to-fider.yml
@@ -33,7 +33,9 @@ jobs:
           python-version: "3.13"
 
       - name: Run script (dry run)
-        if: github.event_name == 'pull_request'
+        # Dependabot and fork PRs run without repository secrets; skip the dry
+        # run there instead of failing on the missing token.
+        if: github.event_name == 'pull_request' && env.FIDER_API_TOKEN != ''
         run: |
           python run.py \
             --org "${{ github.repository_owner }}" \


### PR DESCRIPTION
### Summary

- Stops the two co-planning sync workflows from failing on PRs that run without repository secrets (Dependabot, external forks)
- Time to review: 2 minutes

### Changes proposed

- In `coplanning-sync-fider-to-gh.yml` and `coplanning-sync-gh-to-fider.yml`, extend the dry-run step's condition from `github.event_name == 'pull_request'` to also require `env.FIDER_API_TOKEN != ''`, so the step is skipped (not failed) when the token isn't available to the run.

### Context for reviewers

Dependabot-triggered `pull_request` events receive no repository secrets, so on any Dependabot PR touching the co-planning paths the dry run dies with `[ERROR] FIDER_API_TOKEN environment variable must be set` — both sync checks showed this on #1093. External-fork PRs would hit the same thing, which is why the guard checks token presence rather than the PR author.

Trade-off: a secretless PR that touches these workflows merges without the dry run exercising the change. How fast that surfaces afterward differs by workflow: `coplanning-sync-fider-to-gh.yml` also runs daily on `schedule`, so a break there shows up within a day; `coplanning-sync-gh-to-fider.yml` has only `pull_request` and `workflow_dispatch` triggers, so a break there waits for the next manual dispatch.

The real-run steps (`workflow_dispatch` / `schedule`) are untouched. The skip can't be reproduced locally or by dispatch (the guard only alters `pull_request` behavior); the next secretless PR touching these paths is the live validation.

### Additional information

The step-level `env` block maps `secrets.FIDER_TOKEN` into `FIDER_API_TOKEN` at the job level, and an unset secret renders as an empty string — which is exactly what the new condition tests.

