### PR TITLE
fix(sdk): stop duplicating baseUrl path prefix in Client.get query params

### DIFF
--- a/lib/ts-sdk/__tests__/client/client.spec.ts
+++ b/lib/ts-sdk/__tests__/client/client.spec.ts
@@ -127,6 +127,44 @@ describe("Client", () => {
       expect(url.searchParams.get("active")).toBe("true");
     });
 
+    it("does not duplicate the baseUrl path prefix when appending params", async () => {
+      let capturedUrl: string | undefined;
+
+      server.use(
+        http.get("/api/v0.4.0/test-resource", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ data: "test" });
+        })
+      );
+
+      const client = new Client({ baseUrl: `${BASE_URL}/api/v0.4.0` });
+      const response = await client.get("/test-resource", { params: { page: 2 } });
+
+      expect(response.ok).toBe(true);
+      const url = new URL(capturedUrl!);
+      expect(url.pathname).toBe("/api/v0.4.0/test-resource");
+      expect(url.searchParams.get("page")).toBe("2");
+    });
+
+    it("merges params with a query string already present in the path", async () => {
+      let capturedUrl: string | undefined;
+
+      server.use(
+        http.get("/test-resource", ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({ data: "test" });
+        })
+      );
+
+      await defaultClient.get("/test-resource?status=open&page=1", {
+        params: { page: 2 },
+      });
+
+      const url = new URL(capturedUrl!);
+      expect(url.searchParams.get("status")).toBe("open");
+      expect(url.searchParams.get("page")).toBe("2");
+    });
+
     it("works without params", async () => {
       let capturedUrl: string | undefined;
 

--- a/lib/ts-sdk/src/client/client.ts
+++ b/lib/ts-sdk/src/client/client.ts
@@ -149,13 +149,17 @@ export class Client {
   async get(path: string, options?: GetOptions): Promise<Response> {
     let fullPath = path;
 
-    // Append query params if provided
+    // Append query params if provided. Build the query string from the path
+    // alone — extracting it from the full URL would fold the baseUrl's path
+    // prefix (e.g. "/api/v0.4.0") into fullPath, duplicating it in fetch().
     if (options?.params && Object.keys(options.params).length > 0) {
-      const url = new URL(this.url(path));
+      const queryIndex = path.indexOf("?");
+      const pathname = queryIndex === -1 ? path : path.slice(0, queryIndex);
+      const searchParams = new URLSearchParams(queryIndex === -1 ? "" : path.slice(queryIndex + 1));
       for (const [key, value] of Object.entries(options.params)) {
-        url.searchParams.set(key, String(value));
+        searchParams.set(key, String(value));
       }
-      fullPath = url.pathname + url.search;
+      fullPath = `${pathname}?${searchParams.toString()}`;
     }
 
     return this.fetch(fullPath, {

--- a/lib/ts-sdk/src/client/client.ts
+++ b/lib/ts-sdk/src/client/client.ts
@@ -150,8 +150,7 @@ export class Client {
     let fullPath = path;
 
     // Append query params if provided. Build the query string from the path
-    // alone — extracting it from the full URL would fold the baseUrl's path
-    // prefix (e.g. "/api/v0.4.0") into fullPath, duplicating it in fetch().
+    // alone: fetch() prepends the baseUrl, so it must not leak into fullPath.
     if (options?.params && Object.keys(options.params).length > 0) {
       const queryIndex = path.indexOf("?");
       const pathname = queryIndex === -1 ? path : path.slice(0, queryIndex);

--- a/lib/ts-sdk/src/client/client.ts
+++ b/lib/ts-sdk/src/client/client.ts
@@ -149,16 +149,14 @@ export class Client {
   async get(path: string, options?: GetOptions): Promise<Response> {
     let fullPath = path;
 
-    // Append query params if provided. Build the query string from the path
-    // alone: fetch() prepends the baseUrl, so it must not leak into fullPath.
+    // Append query params if provided. Parse the path against a placeholder
+    // origin: fetch() prepends the baseUrl, so it must not leak into fullPath.
     if (options?.params && Object.keys(options.params).length > 0) {
-      const queryIndex = path.indexOf("?");
-      const pathname = queryIndex === -1 ? path : path.slice(0, queryIndex);
-      const searchParams = new URLSearchParams(queryIndex === -1 ? "" : path.slice(queryIndex + 1));
+      const url = new URL(path, "http://placeholder");
       for (const [key, value] of Object.entries(options.params)) {
-        searchParams.set(key, String(value));
+        url.searchParams.set(key, String(value));
       }
-      fullPath = `${pathname}?${searchParams.toString()}`;
+      fullPath = url.pathname + url.search;
     }
 
     return this.fetch(fullPath, {


### PR DESCRIPTION
### Summary

- Fixes a 404-causing URL bug in the TS SDK's `Client.get()`
- Time to review: 5 minutes

### Changes proposed

- lib/ts-sdk/src/client/client.ts: Client.get() was assembling the request address the wrong way-- folders in path were getting duplicated. With a base URL like `http://host/api/v0.4.0` (the documented way to point the SDK at the CommonGrants mock API), any GET with query params ended up asking for `/api/v0.4.0/api/v0.4.0/common-grants/opportunities` -- an address that doesn't exist, so it 404'd.

- `lib/ts-sdk/__tests__/client/client.spec.ts`: two regression tests: one asserting a path-carrying baseUrl produces a single (non-duplicated) path prefix when params are passed, and one covering the merge of params into a path that already has a query string.

### Context for reviewers

- Repro before the fix: `CG_BASE_URL=http://localhost:4322/api/v0.4.0 pnpm --filter @common-grants/sdk example:list` against a running mock 404s. `example:get` and `example:search` were unaffected because they don't pass query params through `GetOptions.params`.
- Verified the path-prefix regression test fails against the pre-fix code (request hits the doubled path and 404s) and passes with the fix.
- `pnpm --filter @common-grants/sdk run ci` is fully green: 27 test files, 550 tests passed, plus compile and examples steps.

### Additional information

Before: `GET https://host/api/v0.4.0/api/v0.4.0/common-grants/opportunities?page=1` → 404
After: `GET https://host/api/v0.4.0/common-grants/opportunities?page=1` → 200