### PR TITLE
ci(website): add parallel Cloudflare production deploy on merge to main

### DIFF
--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -105,9 +105,7 @@ jobs:
 
       - name: Deploy to Cloudflare Worker
         # Uploads a new version of the Worker named in website/wrangler.jsonc
-        # (common-grants) and switches live traffic to it. PR previews are
-        # versions of this same Worker, uploaded (not deployed) with a
-        # preview alias by .github/scripts/upload-worker-preview.sh.
+        # (common-grants) and switches live traffic to it. PR previews are versions of this same Worker
         working-directory: ./website
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -11,6 +11,13 @@ on:
   # Allows us to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
+# Serialize whole runs (build + deploys) so a slow older build can't deploy
+# after a newer one. The default single pending slot skips stale intermediate
+# runs; only the newest queued run deploys.
+concurrency:
+  group: deploy-website-${{ github.ref }}
+  cancel-in-progress: false
+
 # Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
@@ -40,22 +47,22 @@ jobs:
         run: pnpm --filter website build
 
       - name: Upload Pages artifact
+        # Nonblocking so an upload failure for one deploy target
+        # doesn't take down the other one.
+        continue-on-error: true
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./website/dist
 
       - name: Upload build output
         # Shared with deploy-cloudflare so both targets ship the same build.
+        # Nonblocking so an upload failure for one deploy target
+        # doesn't take down the other one.
+        continue-on-error: true
         uses: actions/upload-artifact@v7
         with:
           name: website-build
-          path: |
-            website/dist
-            website/tsp-output
-            website/.extension-schemas
-            website/cache
-            website/public/schemas/yaml
-            website/public/openapi
+          path: website/dist
           retention-days: 1
           if-no-files-found: error
 
@@ -81,9 +88,9 @@ jobs:
       contents: read
     # Only deploy from main branch
     if: github.ref == 'refs/heads/main'
-    concurrency:
-      group: deploy-cloudflare
-      cancel-in-progress: false
+    environment:
+      name: cloudflare
+      url: https://beta.commongrants.org
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -101,7 +108,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: website-build
-          path: website
+          path: website/dist
 
       - name: Deploy to Cloudflare Worker
         # Uploads a new version of the Worker named in website/wrangler.jsonc

--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -1,4 +1,4 @@
-name: "CD - Deploy Website to GH Pages"
+name: "CD - Deploy Website"
 
 on:
   # Trigger the workflow every time we push to the `main` branch
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - "website/**"
+      - ".github/workflows/cd-deploy-website.yml"
   # Allows us to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
@@ -43,7 +44,27 @@ jobs:
         with:
           path: ./website/dist
 
-  deploy:
+      - name: Upload build output
+        # Shared with deploy-cloudflare so both targets ship the same build.
+        # Path-structure invariant (same as ci-website-preview.yml): every
+        # entry must stay under `website/` so upload-artifact strips that
+        # common prefix and the download (path: website) restores them at
+        # website/dist, etc. Adding a path outside website/ shrinks the
+        # prefix and silently shifts download locations.
+        uses: actions/upload-artifact@v7
+        with:
+          name: website-build
+          path: |
+            website/dist
+            website/tsp-output
+            website/.extension-schemas
+            website/cache
+            website/public/schemas/yaml
+            website/public/openapi
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy-github-pages:
     needs: build
     runs-on: ubuntu-latest
     # Only deploy from main branch
@@ -55,3 +76,51 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
+
+  # Parallel production deploy to the shared `common-grants` Cloudflare Worker
+  # (beta.commongrants.org) during the GH Pages -> Cloudflare migration
+  # window (#1110). Independent of deploy-github-pages so a failure in one
+  # target never blocks the other.
+  deploy-cloudflare:
+    needs: build
+    runs-on: ubuntu-latest
+    # This job doesn't touch Pages or OIDC; drop the workflow-level grants.
+    permissions:
+      contents: read
+    # Only deploy from main branch
+    if: github.ref == 'refs/heads/main'
+    # One deploy at a time, never cancelled mid-flight. GitHub keeps only the
+    # newest queued run per group, so back-to-back merges may skip an
+    # intermediate deploy -- the latest commit still ends up live.
+    concurrency:
+      group: deploy-cloudflare
+      cancel-in-progress: false
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+
+      - name: Download build output
+        uses: actions/download-artifact@v8
+        with:
+          name: website-build
+          path: website
+
+      - name: Deploy to Cloudflare Worker
+        # Uploads a new version of the Worker named in website/wrangler.jsonc
+        # (common-grants) and switches live traffic to it. PR previews are
+        # versions of this same Worker, uploaded (not deployed) with a
+        # preview alias by .github/scripts/upload-worker-preview.sh.
+        working-directory: ./website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: pnpm dlx wrangler@4 deploy

--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -46,11 +46,6 @@ jobs:
 
       - name: Upload build output
         # Shared with deploy-cloudflare so both targets ship the same build.
-        # Path-structure invariant (same as ci-website-preview.yml): every
-        # entry must stay under `website/` so upload-artifact strips that
-        # common prefix and the download (path: website) restores them at
-        # website/dist, etc. Adding a path outside website/ shrinks the
-        # prefix and silently shifts download locations.
         uses: actions/upload-artifact@v7
         with:
           name: website-build

--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -73,20 +73,14 @@ jobs:
         uses: actions/deploy-pages@v5
 
   # Parallel production deploy to the shared `common-grants` Cloudflare Worker
-  # (beta.commongrants.org) during the GH Pages -> Cloudflare migration
-  # window (#1110). Independent of deploy-github-pages so a failure in one
-  # target never blocks the other.
+  # (beta.commongrants.org) during the GH Pages deploy
   deploy-cloudflare:
     needs: build
     runs-on: ubuntu-latest
-    # This job doesn't touch Pages or OIDC; drop the workflow-level grants.
     permissions:
       contents: read
     # Only deploy from main branch
     if: github.ref == 'refs/heads/main'
-    # One deploy at a time, never cancelled mid-flight. GitHub keeps only the
-    # newest queued run per group, so back-to-back merges may skip an
-    # intermediate deploy -- the latest commit still ends up live.
     concurrency:
       group: deploy-cloudflare
       cancel-in-progress: false


### PR DESCRIPTION
### Summary

- Part of #1110 (deliberately not `Fixes` — this is the parallel-deploy setup only;
  verification, the #1078 merge-safety work, and the cutover doc follow)
- Time to review: 10 minutes

### Changes proposed

One file changed: `.github/workflows/cd-deploy-website.yml`.

- **Added a `deploy-cloudflare` job** that runs on every push to `main` touching
  `website/**` (and on `workflow_dispatch`), alongside the existing GitHub Pages
  deploy. It downloads the shared build artifact and runs `pnpm dlx wrangler@4 deploy`
  from `website/`, which publishes a new version of the `common-grants` Worker and
  switches live traffic to it-- i.e. beta.commongrants.org starts tracking `main`.
- **Added an `Upload build output` step** to the existing `build` job, mirroring the
  artifact pattern from `ci-website-preview.yml`, so both deploy targets consume one shared build.
- **Renamed** the `deploy` job to `deploy-github-pages` and the workflow to
  "CD - Deploy Website" (behavior unchanged; nothing in the repo references the old names).
- **Added the workflow file itself to the push paths filter**, so workflow edits
  (including this PR when it merges) trigger a deploy run.
- Guardrails on the new job: `permissions: contents: read`, a `concurrency` group with
  `cancel-in-progress: false` so deploys never race or get killed mid-flight, and the
  same `main`-ref guard as the Pages deploy.

### Context for reviewers

**Why:**  we don't want to swap the production host and cut DNS in one move. This PR is the first step of the migration plan: every merge to `main` deploys to *both* GitHub Pages (still production, DNS untouched) and the Cloudflare Worker (beta.commongrants.org). Once a few deploys flow through cleanly and beta matches production, the DNS cutover is just a record change. It also deliberately lands *before* the #1078 SSR/mock-API work, so we're only changing one thing (the hosting pipeline) at a time.

**Design choices worth a look:**
- The two deploy jobs both `needs: build` but have no edge between each other-- a
  Cloudflare failure can't block the Pages deploy, and vice versa.
- One shared build artifact rather than a second build: parity between the two targets
  is the point of this phase. `MOCK_API_ENABLED` is deliberately not set. 
- Reused the exact artifact upload/download pattern from `ci-website-preview.yml`-- same `website-build` name won't collide since the two workflows never run on the same event.
- `wrangler deploy` (not `versions upload`) -- PR previews stay as aliased, undeployed
  versions of the same Worker; this job is the only thing that moves live traffic.
- The existing `upload-worker-preview.sh` wasn't reusable: it's hardwired to `versions upload --preview-alias` and greps the preview-URL line that `wrangler deploy` never prints, so the deploy is a plain inline step.

**How it was verified:** the workflow YAML parses clean; `wrangler deploy --dry-run`
validates the config/credential path locally; the deploy command uses the same
checked-in `wrangler.jsonc` and repo secrets (`CLOUDFLARE_API_TOKEN` /
`CLOUDFLARE_ACCOUNT_ID`) the PR-preview flow already exercises daily. The real proof is the first post-merge run-- I've created a follow up ticket with  a short parity checklist (homepage, docs, redirects, OpenAPI/schema assets) between beta.commongrants.org and commongrants.org over the next 2–3 merges.

**Heads-up on the first run:** the first `deploy-cloudflare` run replaces whatever Worker version is currently live on beta.commongrants.org.

### Additional information

Job graph after this PR:

```
build ──┬──> deploy-github-pages   (production, commongrants.org — unchanged)
        └──> deploy-cloudflare     (beta, beta.commongrants.org — new)
```

Migration sequence this PR belongs to (#1110): parallel deploys (this PR) →
2–3 verified deploy cycles → #1078 merge made safe for both targets →
documented DNS cutover.