### PR TITLE
ci(website): retire the GitHub Pages deploy and point production at commongrants.org

### DIFF
--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -11,18 +11,16 @@ on:
   # Allows us to run this workflow manually from the Actions tab on GitHub.
   workflow_dispatch:
 
-# Serialize whole runs (build + deploys) so a slow older build can't deploy
+# Serialize whole runs (build + deploy) so a slow older build can't deploy
 # after a newer one. The default single pending slot skips stale intermediate
 # runs; only the newest queued run deploys.
 concurrency:
   group: deploy-website-${{ github.ref }}
   cancel-in-progress: false
 
-# Allow this job to clone the repo and create a page deployment
+# Allow this job to clone the repo
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
@@ -46,19 +44,9 @@ jobs:
       - name: Build website
         run: pnpm --filter website build
 
-      - name: Upload Pages artifact
-        # Nonblocking so an upload failure for one deploy target
-        # doesn't take down the other one.
-        continue-on-error: true
-        uses: actions/upload-pages-artifact@v5
-        with:
-          path: ./website/dist
-
       - name: Upload build output
-        # Shared with deploy-cloudflare so both targets ship the same build.
-        # Nonblocking so an upload failure for one deploy target
-        # doesn't take down the other one.
-        continue-on-error: true
+        # Handed to deploy-cloudflare so the deploy ships this exact build
+        # instead of rebuilding it.
         uses: actions/upload-artifact@v7
         with:
           name: website-build
@@ -66,26 +54,11 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  deploy-github-pages:
-    needs: build
-    runs-on: ubuntu-latest
-    # Only deploy from main branch
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
-
-  # Parallel production deploy to the shared `common-grants` Cloudflare Worker
-  # (beta.commongrants.org) during the GH Pages deploy
+  # Production deploy to the shared `common-grants` Cloudflare Worker. Serves
+  # beta.commongrants.org until the DNS cutover points commongrants.org here.
   deploy-cloudflare:
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     # Only deploy from main branch
     if: github.ref == 'refs/heads/main'
     environment:

--- a/.github/workflows/cd-deploy-website.yml
+++ b/.github/workflows/cd-deploy-website.yml
@@ -54,8 +54,8 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # Production deploy to the shared `common-grants` Cloudflare Worker. Serves
-  # beta.commongrants.org until the DNS cutover points commongrants.org here.
+  # Production deploy to the shared `common-grants` Cloudflare Worker, which
+  # serves commongrants.org.
   deploy-cloudflare:
     needs: build
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment:
       name: cloudflare
-      url: https://beta.commongrants.org
+      url: https://commongrants.org
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ CommonGrants is part of the [SimplerGrants](https://simpler.grants.gov/) initiat
 The grant ecosystem today is fragmented. A patchwork of portals, formats, and systems creates friction for everyone involved:
 
 - **Funders** must choose between usability and reach.
-- **Grant seekers** juggle multiple platforms, answering the same questions over and over.
+- **Grant seekers** balance multiple platforms, answering the same questions over and over.
 - **Grant platforms** spend time reconciling inconsistent data from disparate sources.
 - **Developers** face steep costs to build tools that only work in one place.
 


### PR DESCRIPTION
### Summary

- Follows #1110 — the parallel Cloudflare deploy. No tracking issue exists for the retirement itself.
- Time to review: 5 minutes

### Changes proposed

> What was added, updated, or removed in this PR.

**`ci: retire the GitHub Pages deploy from the website CD workflow`**

- Removes the `deploy-github-pages` job and the `Upload Pages artifact` step, leaving `deploy-cloudflare` as the only production pipeline.
- Drops `pages: write` and `id-token: write`.

**`ci: point the Cloudflare production deploy at commongrants.org`**

- The `cloudflare` environment URL was still advertising `beta.commongrants.org`, the parallel-deploy label from when Pages was production. It now names the apex domain.

**Drive-by:** one word in `website/src/content/docs/index.mdx` ("juggle" → "balance"), unrelated to the CI change.

### Context for reviewers

> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

**Why now:** the website is moving to the `@astrojs/cloudflare` adapter (#1114). That build output isn't a plain static site — the adapter splits it into `dist/client` (prerendered) and `dist/server` (the Worker) — so the Pages deploy can't serve it once the adapter lands. Retiring the step ahead of that merge avoids shipping a job that's expected to break.

**Verified:** `prettier --check` passes on the workflow. Not exercised end to end — `cd-deploy-website.yml` only runs on push to `main`, so the first real run is post-merge.

Three things this PR deliberately does **not** do:

1. **It doesn't bind the domain.** `environment.url` is only a GitHub deployment label. As of 2026-09-01 `commongrants.org` resolves through Cloudflare to a *GitHub Pages* origin (responses still carry `x-github-request-id` / `x-github-edge-region`), so attaching the apex to the `common-grants` Worker is still a Cloudflare custom-domain change made outside this repo. **Between merging this and that change, production goes stale rather than down** — the apex keeps serving the last Pages build and stops picking up merges to `main`.
2. **It doesn't clean up repo settings.** The `github-pages` environment and the Pages custom-domain setting still need an admin pass.
3. **It doesn't carry the `--config` fix.** `main`'s deploy step runs bare `wrangler@4 deploy`, which deploys the checked-in `website/wrangler.jsonc` — the adapter's *input* config, describing an assets-only Worker with no `main`. The fix (`--config dist/server/wrangler.json`) lives on #1114 as `ac130bb` and is not on this branch. **If this PR merges first, main's production deploy ships that wrong config, now pointed at the apex domain.** Happy to cherry-pick `ac130bb` here if reviewers would rather not depend on merge order.

### Additional information

> Screenshots, GIF demos, code examples or output to help show the changes working as expected.

Resulting `deploy-cloudflare` job (the only deploy job left):

```yaml
  # Production deploy to the shared `common-grants` Cloudflare Worker, which
  # serves commongrants.org.
  deploy-cloudflare:
    needs: build
    runs-on: ubuntu-latest
    # Only deploy from main branch
    if: github.ref == 'refs/heads/main'
    environment:
      name: cloudflare
      url: https://commongrants.org
```
