### PR TITLE
feat(website): always serve the mock API, dropping the build-time gate

### DIFF
--- a/.github/workflows/ci-website-preview.yml
+++ b/.github/workflows/ci-website-preview.yml
@@ -43,11 +43,6 @@ jobs:
 
       - name: Build site
         id: build
-        # Wires the docs to the same-origin mock API (#1078): injects a servers
-        # block into each spec and enables Swagger UI's Execute button.
-        # Preview-only on purpose — absent from `cd-deploy-website.yml`.
-        env:
-          MOCK_API_ENABLED: "1"
         run: pnpm run build
 
       - name: Upload build output

--- a/website/__tests__/lib/mock/router.spec.ts
+++ b/website/__tests__/lib/mock/router.spec.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect } from "vitest";
 import type { APIContext } from "astro";
 import { handleMockRequest, MOCK_API_BASE_PATH } from "@/lib/mock/router";
+import { SUPPORTED_METHODS } from "@/lib/mock/http/methods";
 import { CANONICAL_OPPORTUNITY_ID } from "@/lib/mock/data/fixtures";
+import { CANONICAL_APPLICATION_ID } from "@/lib/mock/data/applications";
+import { CANONICAL_FORM_ID } from "@/lib/mock/data/forms";
+import { CANONICAL_ORGANIZATION_ID } from "@/lib/mock/data/organizations";
 import * as apiRoute from "@/pages/api/[...path]";
 
 /** Builds `https://docs.example/api/v{version}/common-grants/opportunities{suffix}`. */
@@ -39,6 +43,102 @@ describe("Astro route wiring (src/pages/api/[...path].ts)", () => {
 
     expect(routed.status).toBe(direct.status);
     expect(await routed.json()).toEqual(await direct.json());
+  });
+});
+
+describe("method allowlist", () => {
+  const V = "0.4.0";
+  const ORG = `/api/v${V}/common-grants/orgs/${CANONICAL_ORGANIZATION_ID}`;
+
+  /**
+   * One route per supported verb, each chosen because it actually serves that
+   * verb. Between them they cover every entry in `SUPPORTED_METHODS`, which is
+   * what makes the assertions below bite in both directions: drop a verb from
+   * the constant and its route keeps answering, so the 404 sweep fails.
+   */
+  const ROUTE_SERVING: Record<string, string> = {
+    GET: ORG,
+    POST: `/api/v${V}/common-grants/opportunities/search`,
+    PUT: `/api/v${V}/common-grants/applications/${CANONICAL_APPLICATION_ID}/forms/${CANONICAL_FORM_ID}`,
+    PATCH: ORG,
+  };
+
+  /**
+   * `TRACE`, `CONNECT` and `TRACK` are absent because the Fetch spec forbids
+   * them in the `Request` constructor, so the router can never see one.
+   */
+  const CONSTRUCTIBLE_METHODS = [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "HEAD",
+    "OPTIONS",
+  ];
+
+  /**
+   * Derived, not hand-listed. `OPTIONS` is excluded because
+   * `handleMockRequest` answers preflights before routing.
+   */
+  const unlistedMethods = CONSTRUCTIBLE_METHODS.filter(
+    (method) =>
+      method !== "OPTIONS" &&
+      !(SUPPORTED_METHODS as readonly string[]).includes(method),
+  );
+
+  function call(method: string, path: string): Promise<Response> {
+    const url = `https://docs.example${path}`;
+    return handleMockRequest(
+      method === "GET" || method === "HEAD"
+        ? new Request(url, { method })
+        : new Request(url, {
+            method,
+            headers: { "Content-Type": "application/json" },
+            body: "{}",
+          }),
+    );
+  }
+
+  // Guards the two suites below: without a route per supported verb the 404
+  // sweep can pass while the router quietly serves an unlisted one, and without
+  // an unlisted verb there is nothing to sweep.
+  it("pairs every supported verb with a route that serves it", () => {
+    expect(Object.keys(ROUTE_SERVING).sort()).toEqual(
+      [...SUPPORTED_METHODS].sort(),
+    );
+  });
+
+  it("leaves at least one verb unlisted", () => {
+    expect(unlistedMethods.length).toBeGreaterThan(0);
+  });
+
+  it.each([...SUPPORTED_METHODS])(
+    "serves %s on the route that declares it",
+    async (method) => {
+      const response = await call(method, ROUTE_SERVING[method]);
+
+      expect(response.status).not.toBe(404);
+    },
+  );
+
+  it.each(unlistedMethods)(
+    "answers 404 to %s on every route that serves a listed verb",
+    async (method) => {
+      for (const path of new Set(Object.values(ROUTE_SERVING))) {
+        const response = await call(method, path);
+
+        expect(response.status).toBe(404);
+      }
+    },
+  );
+
+  it("advertises exactly these verbs, plus OPTIONS, in the CORS preflight", async () => {
+    const response = await call("OPTIONS", ROUTE_SERVING.GET);
+
+    expect(response.headers.get("Access-Control-Allow-Methods")).toBe(
+      [...SUPPORTED_METHODS, "OPTIONS"].join(", "),
+    );
   });
 });
 

--- a/website/__tests__/lib/mock/router.spec.ts
+++ b/website/__tests__/lib/mock/router.spec.ts
@@ -4,7 +4,7 @@
  * Handler and CORS behavior is pinned by the ported suites.
  */
 
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import type { APIContext } from "astro";
 import { handleMockRequest, MOCK_API_BASE_PATH } from "@/lib/mock/router";
 import { CANONICAL_OPPORTUNITY_ID } from "@/lib/mock/data/fixtures";
@@ -22,17 +22,11 @@ describe("MOCK_API_BASE_PATH", () => {
 });
 
 describe("Astro route wiring (src/pages/api/[...path].ts)", () => {
-  afterEach(() => {
-    vi.unstubAllEnvs();
-  });
-
   it("disables prerendering, since the mock must run per-request", () => {
     expect(apiRoute.prerender).toBe(false);
   });
 
   it("delegates ALL to handleMockRequest untouched, for a real opportunities request", async () => {
-    vi.stubEnv("MOCK_API_ENABLED", "1");
-
     // The ALL handler only needs `request`; the rest of APIContext is cast away.
     const context = {
       request: new Request(opportunitiesUrl("0.3.0")),
@@ -46,24 +40,6 @@ describe("Astro route wiring (src/pages/api/[...path].ts)", () => {
     expect(routed.status).toBe(direct.status);
     expect(await routed.json()).toEqual(await direct.json());
   });
-
-  // The endpoint is gated on the same flag as the docs that advertise it, so
-  // an ungated build — every production deploy — must not serve fixtures.
-  it.each([undefined, "", "0", "false"])(
-    "answers 404 without reaching the mock when MOCK_API_ENABLED is %s",
-    async (gate) => {
-      vi.stubEnv("MOCK_API_ENABLED", gate);
-
-      const context = {
-        request: new Request(opportunitiesUrl("0.3.0")),
-      } as unknown as APIContext;
-
-      const response = await apiRoute.ALL(context);
-
-      expect(response.status).toBe(404);
-      expect(await response.text()).toBe("");
-    },
-  );
 });
 
 describe("base-path handling (new in the website port, no Worker analogue)", () => {

--- a/website/__tests__/scripts/inject-mock-server.spec.ts
+++ b/website/__tests__/scripts/inject-mock-server.spec.ts
@@ -1,20 +1,22 @@
 /**
  * Tests for `src/scripts/inject-mock-server.ts` and
- * `src/lib/mock/docs-wiring.ts` (#1078). The mock is served same-origin, so
- * there is no configurable base URL — only the `MOCK_API_ENABLED` build-time
- * gate and a relative URL built from `MOCK_API_BASE_PATH`.
+ * `src/lib/mock/docs-wiring.ts` (#1078). The mock is same-origin, so there is
+ * no configurable base URL — just a relative one from `MOCK_API_BASE_PATH`.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { describe, it, expect } from "vitest";
 import {
   assertMockServesVersion,
   injectServers,
   versionFromSpecFilename,
   MockServerInjector,
 } from "@/scripts/inject-mock-server";
-import { isMockApiEnabled, serverUrlFor } from "@/lib/mock/docs-wiring";
+import { MOCK_SPEC_DIR_NAME, serverUrlFor } from "@/lib/mock/docs-wiring";
 import { MOCK_API_BASE_PATH } from "@/lib/mock/router";
 import { SUPPORTED_VERSIONS } from "@/lib/mock/data/fixtures";
+import { Paths } from "@/lib/schema/paths";
 
 // Mimics the real spec's shape: no top-level `servers:` key, a top-level
 // `paths:` line, and a nested unrelated `servers:` key.
@@ -101,56 +103,6 @@ describe("injectServers", () => {
   });
 });
 
-describe("isMockApiEnabled", () => {
-  const originalMockApiEnabled = process.env.MOCK_API_ENABLED;
-
-  afterEach(() => {
-    if (originalMockApiEnabled === undefined) {
-      delete process.env.MOCK_API_ENABLED;
-    } else {
-      process.env.MOCK_API_ENABLED = originalMockApiEnabled;
-    }
-  });
-
-  it("is false when MOCK_API_ENABLED is unset", () => {
-    delete process.env.MOCK_API_ENABLED;
-
-    expect(isMockApiEnabled()).toBe(false);
-  });
-
-  it("is false when MOCK_API_ENABLED is blank or whitespace-only", () => {
-    process.env.MOCK_API_ENABLED = "   ";
-
-    expect(isMockApiEnabled()).toBe(false);
-  });
-
-  it("is true when MOCK_API_ENABLED is set to a non-blank value", () => {
-    process.env.MOCK_API_ENABLED = "true";
-
-    expect(isMockApiEnabled()).toBe(true);
-  });
-
-  // A gate keyed on mere presence would read "false" and "0" as ON, silently
-  // enabling Execute buttons on a build meant to be production-inert.
-  it.each(["false", "FALSE", "0", "off", "no"])(
-    "is false for the falsy value %s",
-    (value) => {
-      process.env.MOCK_API_ENABLED = value;
-
-      expect(isMockApiEnabled()).toBe(false);
-    },
-  );
-
-  it.each(["1", "true", "TRUE", "yes", "on"])(
-    "is true for the truthy value %s",
-    (value) => {
-      process.env.MOCK_API_ENABLED = value;
-
-      expect(isMockApiEnabled()).toBe(true);
-    },
-  );
-});
-
 describe("assertMockServesVersion", () => {
   it.each(SUPPORTED_VERSIONS)(
     "accepts v%s, which the router serves",
@@ -172,23 +124,30 @@ describe("assertMockServesVersion", () => {
 });
 
 describe("MockServerInjector", () => {
-  const originalMockApiEnabled = process.env.MOCK_API_ENABLED;
+  /** From disk, not `SUPPORTED_VERSIONS` — that's what the injector walks. */
+  const emittedSpecs = readdirSync(Paths.OPENAPI_DIR)
+    .sort()
+    .flatMap((filename) => {
+      const version = versionFromSpecFilename(filename);
+      return version === null ? [] : [{ filename, version }];
+    });
 
-  beforeEach(() => {
-    delete process.env.MOCK_API_ENABLED;
+  it("writes a mock-advertising copy of every emitted spec", () => {
+    const { written } = MockServerInjector.inject();
+
+    expect(written).toEqual(emittedSpecs.map(({ filename }) => filename));
   });
 
-  afterEach(() => {
-    if (originalMockApiEnabled === undefined) {
-      delete process.env.MOCK_API_ENABLED;
-    } else {
-      process.env.MOCK_API_ENABLED = originalMockApiEnabled;
+  it("points each copy's servers block at that spec's version of the mock", () => {
+    MockServerInjector.inject();
+
+    for (const { filename, version } of emittedSpecs) {
+      const copy = readFileSync(
+        join(Paths.PUBLIC_DIR, MOCK_SPEC_DIR_NAME, filename),
+        "utf-8",
+      );
+
+      expect(copy).toContain(`servers:\n  - url: ${serverUrlFor(version)}`);
     }
-  });
-
-  it("is a clean no-op when MOCK_API_ENABLED is unset, writing nothing", () => {
-    const result = MockServerInjector.inject();
-
-    expect(result).toEqual({ skipped: true, written: [] });
   });
 });

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -25,19 +25,6 @@ export default defineConfig({
   // Sessions are unused, but a non-KV driver stops the adapter injecting a
   // `SESSION` KV binding, whose auto-provisioning fails on repeat preview uploads.
   session: { driver: sessionDrivers.lruCache() },
-  vite: {
-    define: {
-      // Bakes the `MOCK_API_ENABLED` gate into the Worker bundle, so the
-      // `/api` route cannot outlive the docs that advertise it. It has to be
-      // inlined: `process.env` is empty inside the deployed Worker, so a
-      // runtime read would report the gate as off even on the previews that do
-      // enable it. Left as the raw value, which `isGateValueEnabled` reads —
-      // the same parse the injector and the api-docs page get.
-      "import.meta.env.MOCK_API_ENABLED": JSON.stringify(
-        process.env.MOCK_API_ENABLED ?? "",
-      ),
-    },
-  },
   security: {
     // Left ON deliberately (#1078). This CSRF guard answers a bare 403 to a
     // cross-origin non-GET that takes no body, where the 3A Worker returned a

--- a/website/src/lib/mock/docs-wiring.ts
+++ b/website/src/lib/mock/docs-wiring.ts
@@ -1,34 +1,10 @@
 /**
- * Shared wiring between `scripts/inject-mock-server.ts` and
- * `pages/protocol/api-docs.astro`, so the injected `servers:` URL and the
- * Execute-button gate cannot disagree. The URL is relative because the mock is
- * served same-origin by this site. The gate keeps Execute buttons off builds
- * (production GitHub Pages) that cannot serve the endpoint.
+ * Shared by `scripts/inject-mock-server.ts` and `pages/protocol/api-docs.astro`
+ * so the injected `servers:` URL and the directory the docs read specs from
+ * can't disagree. URLs are relative — the mock is same-origin.
  */
 
 import { MOCK_API_BASE_PATH } from "./router";
-
-/**
- * Matched explicitly rather than treating any non-blank string as truthy, so
- * `MOCK_API_ENABLED: "false"` reads as off.
- */
-const TRUTHY_VALUES = new Set(["1", "true", "yes", "on"]);
-
-/**
- * Reads one raw gate value. Split out from `isMockApiEnabled` for the `/api`
- * route, which cannot reach `process.env`: inside the deployed Worker it is
- * empty, so the route gets the value inlined at build time (see
- * `astro.config.mjs`) and parses it with this.
- */
-export function isGateValueEnabled(value: string | undefined): boolean {
-  const raw = value?.trim().toLowerCase();
-  return raw !== undefined && TRUTHY_VALUES.has(raw);
-}
-
-/** True when `MOCK_API_ENABLED` is set to a truthy value (case-insensitive). */
-export function isMockApiEnabled(): boolean {
-  return isGateValueEnabled(process.env.MOCK_API_ENABLED);
-}
 
 /**
  * Builds the root-relative server URL for one spec, e.g. `/api/v0.4.0`. The
@@ -39,15 +15,12 @@ export function serverUrlFor(version: string): string {
 }
 
 /**
- * Public directory holding the mock-advertising copies of the specs, written by
- * `scripts/inject-mock-server.ts` on gated builds only. A sibling of
- * `public/openapi/` rather than an edit of it: those specs are generated from
- * the TypeSpec source and tracked, and rewriting them in place left the
- * working tree dirty with artifacts that must never be committed.
+ * Public directory holding the mock-advertising spec copies, written each build
+ * by `scripts/inject-mock-server.ts`. A sibling of `public/openapi/` rather than
+ * an edit of it: those specs are tracked build output, so rewriting them in
+ * place left artifacts we must never commit.
  */
 export const MOCK_SPEC_DIR_NAME = "openapi-mock";
 
 /** Root-relative directory the docs page loads specs from. */
-export function specDirFor(mockEnabled: boolean): string {
-  return mockEnabled ? `/${MOCK_SPEC_DIR_NAME}` : "/openapi";
-}
+export const SPEC_DIR_URL = `/${MOCK_SPEC_DIR_NAME}`;

--- a/website/src/lib/mock/http/cors.ts
+++ b/website/src/lib/mock/http/cors.ts
@@ -4,14 +4,16 @@
  * fixture data and holds no credentials.
  */
 
+import { SUPPORTED_METHODS } from "./methods";
+
 /**
  * `X-API-Key` and `Authorization` are listed because the TS SDK sends them
  * when auth is configured; a preflight must name non-simple headers. The
- * method list must track the router's.
+ * methods come from `SUPPORTED_METHODS` so they cannot drift from the router.
  */
 const CORS_HEADERS: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, OPTIONS",
+  "Access-Control-Allow-Methods": [...SUPPORTED_METHODS, "OPTIONS"].join(", "),
   "Access-Control-Allow-Headers": "Content-Type, X-API-Key, Authorization",
   "Access-Control-Max-Age": "86400",
 };

--- a/website/src/lib/mock/http/methods.ts
+++ b/website/src/lib/mock/http/methods.ts
@@ -1,0 +1,12 @@
+/**
+ * The one list of verbs the mock implements. A leaf module so `cors.ts`, the
+ * router and the api-docs page can all read it without an import cycle —
+ * `router.ts` already imports `cors.ts`.
+ *
+ * `OPTIONS` is absent on purpose: `handleMockRequest` answers preflights before
+ * routing, so it is not a handler verb. `cors.ts` appends it to its own header.
+ *
+ * Adding a verb to a resource router means adding it here, or
+ * `router.spec.ts`'s allowlist test fails.
+ */
+export const SUPPORTED_METHODS = ["GET", "POST", "PUT", "PATCH"] as const;

--- a/website/src/pages/api/[...path].ts
+++ b/website/src/pages/api/[...path].ts
@@ -6,7 +6,6 @@
  */
 
 import type { APIRoute } from "astro";
-import { isGateValueEnabled } from "@/lib/mock/docs-wiring";
 import { handleMockRequest } from "@/lib/mock/router";
 
 export const prerender = false;
@@ -14,13 +13,5 @@ export const prerender = false;
 /**
  * `ALL` rather than named `GET`/`POST` exports, so unsupported methods get the
  * router's own protocol-shaped 404 instead of Astro's.
- *
- * The endpoint must not outlive the docs that advertise it: only gated builds
- * inject the `servers:` block and enable Execute, so an ungated build — every
- * production deploy — answers 404 here rather than serving fixtures. The gate
- * value is inlined at build time by `astro.config.mjs`.
  */
-export const ALL: APIRoute = ({ request }) =>
-  isGateValueEnabled(import.meta.env.MOCK_API_ENABLED)
-    ? handleMockRequest(request)
-    : new Response(null, { status: 404 });
+export const ALL: APIRoute = ({ request }) => handleMockRequest(request);

--- a/website/src/pages/protocol/api-docs.astro
+++ b/website/src/pages/protocol/api-docs.astro
@@ -2,6 +2,7 @@
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import "swagger-ui-dist/swagger-ui.css";
 import { SPEC_DIR_URL } from "@/lib/mock/docs-wiring";
+import { SUPPORTED_METHODS } from "@/lib/mock/http/methods";
 
 // Available OpenAPI versions (mirror of the emitted specs in public/openapi/)
 const availableVersions = [
@@ -26,7 +27,12 @@ const availableVersions = [
     </label>
   </div>
 
-  <div id="swagger-ui" data-spec-dir={SPEC_DIR_URL}></div>
+  <div
+    id="swagger-ui"
+    data-spec-dir={SPEC_DIR_URL}
+    data-submit-methods={SUPPORTED_METHODS.join(",").toLowerCase()}
+  >
+  </div>
 </StarlightPage>
 
 <style>
@@ -86,14 +92,19 @@ const availableVersions = [
   // and importing `docs-wiring` would drag the mock router into this bundle.
   const mount = document.querySelector<HTMLElement>("#swagger-ui");
   const specDir = mount?.dataset.specDir ?? "/openapi-mock";
+  // `filter(Boolean)` so a missing attribute yields [] rather than [""], which
+  // Swagger would read as a verb.
+  const submitMethods = (mount?.dataset.submitMethods ?? "")
+    .split(",")
+    .filter(Boolean);
 
   const render = (version: string): void => {
     SwaggerUIBundle({
       url: `${specDir}/openapi.${version}.yaml`,
       dom_id: "#swagger-ui",
-      // The verbs the mock implements. Listed explicitly because Swagger UI
-      // otherwise offers Execute on DELETE and friends, which it never serves.
-      supportedSubmitMethods: ["get", "post", "put", "patch"],
+      // From the router's own `SUPPORTED_METHODS`; Swagger UI would otherwise
+      // offer Execute on DELETE and friends, which the mock never serves.
+      supportedSubmitMethods: submitMethods,
       deepLinking: true,
     });
   };

--- a/website/src/pages/protocol/api-docs.astro
+++ b/website/src/pages/protocol/api-docs.astro
@@ -1,7 +1,7 @@
 ---
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
 import "swagger-ui-dist/swagger-ui.css";
-import { isMockApiEnabled, specDirFor } from "@/lib/mock/docs-wiring";
+import { SPEC_DIR_URL } from "@/lib/mock/docs-wiring";
 
 // Available OpenAPI versions (mirror of the emitted specs in public/openapi/)
 const availableVersions = [
@@ -10,15 +10,6 @@ const availableVersions = [
   { version: "0.2.0", label: "v0.2.0" },
   { version: "0.1.0", label: "v0.1.0" },
 ];
-
-// Same build-time gate as `scripts/inject-mock-server.ts`, shared via
-// `lib/mock/docs-wiring` so the two can't disagree. Keeps Execute buttons off
-// builds that cannot serve `/api/*`.
-const tryItOutEnabled = isMockApiEnabled();
-
-// Gated builds load the injector's copies, which carry the `servers:` block;
-// every other build loads the untouched generated specs.
-const specDir = specDirFor(tryItOutEnabled);
 ---
 
 <StarlightPage frontmatter={{ title: "OpenAPI docs", tableOfContents: false }}>
@@ -35,12 +26,7 @@ const specDir = specDirFor(tryItOutEnabled);
     </label>
   </div>
 
-  <div
-    id="swagger-ui"
-    data-try-it-out={String(tryItOutEnabled)}
-    data-spec-dir={specDir}
-  >
-  </div>
+  <div id="swagger-ui" data-spec-dir={SPEC_DIR_URL}></div>
 </StarlightPage>
 
 <style>
@@ -96,18 +82,18 @@ const specDir = specDirFor(tryItOutEnabled);
   import { SwaggerUIBundle } from "swagger-ui-dist";
   import { resolveVersion } from "@/lib/api-docs-version";
 
-  // Client scripts are bundled and can't close over frontmatter values, so the
-  // gate and the spec directory are read off the mount point.
+  // Via a data attribute, not an import: client scripts can't read frontmatter,
+  // and importing `docs-wiring` would drag the mock router into this bundle.
   const mount = document.querySelector<HTMLElement>("#swagger-ui");
-  const tryItOut = mount?.dataset.tryItOut === "true";
-  const specDir = mount?.dataset.specDir ?? "/openapi";
+  const specDir = mount?.dataset.specDir ?? "/openapi-mock";
 
   const render = (version: string): void => {
     SwaggerUIBundle({
       url: `${specDir}/openapi.${version}.yaml`,
       dom_id: "#swagger-ui",
-      // Empty disables Execute entirely; the mock serves GET and POST only.
-      supportedSubmitMethods: tryItOut ? ["get", "post"] : [],
+      // The verbs the mock implements. Listed explicitly because Swagger UI
+      // otherwise offers Execute on DELETE and friends, which it never serves.
+      supportedSubmitMethods: ["get", "post", "put", "patch"],
       deepLinking: true,
     });
   };

--- a/website/src/scripts/inject-mock-server.ts
+++ b/website/src/scripts/inject-mock-server.ts
@@ -7,11 +7,7 @@ import {
 } from "fs";
 import { join } from "path";
 import { Paths } from "../lib/schema/paths";
-import {
-  MOCK_SPEC_DIR_NAME,
-  isMockApiEnabled,
-  serverUrlFor,
-} from "../lib/mock/docs-wiring";
+import { MOCK_SPEC_DIR_NAME, serverUrlFor } from "../lib/mock/docs-wiring";
 import {
   SUPPORTED_VERSIONS,
   isSupportedVersion,
@@ -20,9 +16,8 @@ import {
 /**
  * Build-time script that copies each rendered OpenAPI spec into
  * `public/openapi-mock/` with a `servers:` block pointing at the mock, which is
- * how Swagger UI's "Try it out" finds it. No-op unless `MOCK_API_ENABLED` is
- * set (see `lib/mock/docs-wiring.ts`). Injection is targeted string insertion,
- * not a YAML parse/dump, which would rewrite the whole file.
+ * how Swagger UI's "Try it out" finds it. Injection is targeted string
+ * insertion, not a YAML parse/dump, which would rewrite the whole file.
  *
  * The copies live in a gitignored sibling directory rather than replacing
  * `public/openapi/` in place: those specs are generated from the TypeSpec
@@ -85,17 +80,15 @@ export function assertMockServesVersion(
   throw new Error(
     `${filename} would advertise ${serverUrlFor(version)}, which the mock router does not serve ` +
       `(it serves ${SUPPORTED_VERSIONS.join(", ")}). Teach src/lib/mock/data/fixtures.ts to shape ` +
-      `v${version} — SUPPORTED_VERSIONS and shapeOpportunityForVersion — before enabling the mock on it.`,
+      `v${version} — SUPPORTED_VERSIONS and shapeOpportunityForVersion — before emitting a spec for it.`,
   );
 }
 
 /** Where the mock-advertising copies go. Gitignored; regenerated per build. */
 const MOCK_SPEC_DIR = join(Paths.PUBLIC_DIR, MOCK_SPEC_DIR_NAME);
 
-/** Outcome of a run, so callers (and tests) can assert the no-op path. */
+/** Outcome of a run. */
 export interface InjectResult {
-  /** True when `MOCK_API_ENABLED` was unset and nothing was written. */
-  skipped: boolean;
   /** Filenames processed, in sorted order. */
   written: string[];
 }
@@ -103,19 +96,11 @@ export interface InjectResult {
 class MockServerInjector {
   /**
    * Copies every versioned spec in `Paths.OPENAPI_DIR` into `MOCK_SPEC_DIR`
-   * advertising the mock; skipped when the gate is off.
+   * advertising the mock.
    */
   static inject(): InjectResult {
-    // The copies belong to gated builds only, so an ungated one must not
-    // inherit a directory left behind by an earlier gated build.
+    // Cleared first so a dropped spec can't linger as a stale copy.
     rmSync(MOCK_SPEC_DIR, { recursive: true, force: true });
-
-    if (!isMockApiEnabled()) {
-      console.log(
-        "MOCK_API_ENABLED not set — leaving OpenAPI specs untouched (no mock server injected).",
-      );
-      return { skipped: true, written: [] };
-    }
 
     console.log("Injecting same-origin mock server into OpenAPI specs...");
 
@@ -158,7 +143,7 @@ class MockServerInjector {
       `\n✓ Wrote ${written.length} mock-advertising spec(s) to public/${MOCK_SPEC_DIR_NAME}/`,
     );
 
-    return { skipped: false, written };
+    return { written };
   }
 }
 


### PR DESCRIPTION
Removes the `MOCK_API_ENABLED` build-time gate so the mock API playground is always on.

## Why it existed

The site used to be hosted on GitHub Pages, which can only serve fixed files. It genuinely couldn't run code to answer `/api/...` requests. So the switch was left off in production to avoid advertising a button that didn't work.

## Why it's gone

The site moved to Cloudflare, which can run code and answer those requests-- i.e. it is now a switch that is never off. So it made sense to me to remove it altogether (dead code).

## What was broken

Only `ci-website-preview.yml` ever set the flag, so previews had the playground and commongrants.org didn't:

| Surface | Production |
|---|---|
| `/api/**` | `404`, empty body |
| Execute button | hidden |
| Injected `servers:` block | absent |

## Changes

- `docs-wiring.ts` — dropped `isGateValueEnabled`, `isMockApiEnabled`, `specDirFor`; last becomes a `SPEC_DIR_URL` constant
- `astro.config.mjs` — dropped the `vite.define` block that inlined the flag
- `api/[...path].ts` — delegates straight to `handleMockRequest`
- `inject-mock-server.ts` — dropped the gate branch and `skipped`
- `api-docs.astro` — dropped `data-try-it-out`; `supportedSubmitMethods` unconditional
- `ci-website-preview.yml` — dropped the env var
- tests — gate tests out; `MockServerInjector`'s no-op test replaced with two asserting it writes a `servers:`-carrying copy of every emitted spec

Net **−148 lines**. `cd-deploy-website.yml` is untouched.

## Second commit: the method allowlist

`supportedSubmitMethods` had drifted — it listed GET and POST, but #1137 taught the router PUT and PATCH. Three operations the mock serves rendered in the docs with Execute silently off:

| Operation | Handler |
|---|---|
| `PUT /applications/{appId}/forms/{formId}` | `writeFormResponse` |
| `PUT /applications/{appId}/submit` | `submitApplication` |
| `PATCH /orgs/{orgId}` | `updateOrganization` |

`cors.ts` was updated for that change; the docs list was the copy nobody touched. The method set lived in three places, with the invariant written down in one (`cors.ts`: *"the method list must track the router's"*) and enforced nowhere.

So: new `lib/mock/http/methods.ts` exports `SUPPORTED_METHODS`, and both consumers derive from it — `cors.ts` builds its `Access-Control-Allow-Methods` header, `api-docs.astro` passes the list to the client via `data-submit-methods`. A leaf module because `router.ts` already imports `cors.ts`; a data attribute because the client script can't import it without dragging the router into the browser bundle.

The test pairs each supported verb with a route that serves it, then asserts every constructible verb outside the constant answers 404 on all of them. Verified it fails in both directions:

- drop PUT/PATCH from the constant while the router still serves them → the 404 sweeps fail (the exact historical drift)
- add DELETE to the constant with no handler → the serves-it check fails

`TRACE`/`CONNECT`/`TRACK` are excluded — the Fetch spec forbids them in the `Request` constructor, so the router can never see one.

## Verification

serving the built Worker via `wrangler dev`:

- all four versions of `/api/v{version}/common-grants/opportunities` → `200` with fixture JSON
- `/openapi-mock/openapi.0.4.0.yaml` → `servers: - url: /api/v0.4.0`
- `/protocol/api-docs/` → `data-spec-dir="/openapi-mock"`
- no gate string left in `dist/`
- all four verbs answer through the Worker: `GET /opportunities`, `POST /opportunities/search`, `PUT /applications/{id}/forms/{formId}`, `PATCH /orgs/{id}` → 200; `PUT /applications/{id}/submit` → 400 validation (route reached); `DELETE` → 404, so the explicit method list still earns its keep

`checks` exit 0 (astro check + cspell clean), 542 tests pass.

## Note

commongrants.org now serves fixture data at `/api/**`.



